### PR TITLE
#130 Add Aqara door/window sensor

### DIFF
--- a/common/pytest/powerpi_common_test/device/mixin/pollable.py
+++ b/common/pytest/powerpi_common_test/device/mixin/pollable.py
@@ -12,3 +12,13 @@ class PollableMixinTestBase(ABC):
         subject = self.create_subject(mocker)
 
         await subject.poll()
+
+    def test_polling_enabled(self, mocker: MockerFixture):
+        subject = self.create_subject(mocker)
+
+        assert subject.polling_enabled is True
+
+    def test_poll_frequency(self, mocker: MockerFixture):
+        subject = self.create_subject(mocker)
+
+        assert subject.poll_frequency >= 10

--- a/common/pytest/powerpi_common_test/sensor/mixin/__init__.py
+++ b/common/pytest/powerpi_common_test/sensor/mixin/__init__.py
@@ -1,0 +1,1 @@
+from .battery import BatteryMixinTestBase

--- a/common/pytest/powerpi_common_test/sensor/mixin/battery.py
+++ b/common/pytest/powerpi_common_test/sensor/mixin/battery.py
@@ -1,0 +1,32 @@
+from abc import ABC
+from typing import Any, Dict
+
+from pytest_mock import MockerFixture
+
+
+class BatteryMixinTestBase(ABC):
+    def test_on_battery_message(self, mocker: MockerFixture):
+        # capture the published messages
+        self.messages = []
+
+        def mock_add_producer():
+            def add_producer():
+                def publish(_: str, message: Dict[str, Any]):
+                    self.messages.append(message)
+
+                return publish
+
+            self.mqtt_client.add_producer = add_producer
+
+        subject = self.create_subject(mocker, mock_add_producer)
+
+        levels = [13, 0, 100]
+        for level in levels:
+            subject.on_battery_change(level)
+
+        assert len(self.messages) == len(levels)
+
+        for level in levels:
+            assert any(
+                (message['value'] == level for message in self.messages)
+            )

--- a/common/pytest/powerpi_common_test/sensor/sensor.py
+++ b/common/pytest/powerpi_common_test/sensor/sensor.py
@@ -12,6 +12,7 @@ class SensorTestBase(BaseDeviceTestBase):
     pytestmark = pytest.mark.asyncio
 
     def create_subject(self, mocker: MockerFixture, func: Callable[[], None] = None):
+        self.config = mocker.Mock()
         self.logger = mocker.Mock()
         self.mqtt_client = mocker.Mock()
 

--- a/common/pytest/pyproject.toml
+++ b/common/pytest/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "powerpi-common-test"
-version = "0.2.0"
+version = "0.2.1"
 description = "PowerPi Common Python Test Library"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/common/python/powerpi_common/device/additional_state.py
+++ b/common/python/powerpi_common/device/additional_state.py
@@ -70,13 +70,13 @@ class AdditionalStateDevice(Device, AdditionalStateMixin):
         Update the state of this device to new_state, update the additional state
         to new_additional_state and broadcast the changes to the message queue.
         '''
-        if new_state is not None:
-            self.update_state_no_broadcast(new_state)
-
         new_additional_state = self._filter_keys(new_additional_state)
 
         if len(new_additional_state) > 0:
             self.__additional_state = new_additional_state
+
+        if new_state is not None:
+            self.update_state_no_broadcast(new_state)
 
         self._broadcast_state_change()
 

--- a/common/python/powerpi_common/device/base.py
+++ b/common/python/powerpi_common/device/base.py
@@ -1,7 +1,7 @@
-from abc import ABC
+from powerpi_common.logger import LogMixin
 
 
-class BaseDevice(ABC):
+class BaseDevice(LogMixin):
     '''
     Abstact base class for both "devices" and "sensors".
     '''
@@ -26,3 +26,22 @@ class BaseDevice(ABC):
 
     def __str__(self):
         return f'{type(self).__name__}({self._display_name})'
+
+    def log_debug(self, *args):
+        LogMixin.log_debug(self, *self.__update_log_message(*args))
+
+    def log_info(self, *args):
+        LogMixin.log_info(self, *self.__update_log_message(*args))
+
+    def log_warning(self, *args):
+        LogMixin.log_warning(self, *self.__update_log_message(*args))
+
+    def log_error(self, *args):
+        LogMixin.log_error(self, *self.__update_log_message(*args))
+
+    def log_exception(self, *args):
+        LogMixin.log_exception(self, *self.__update_log_message(*args))
+
+    def __update_log_message(self, *args):
+        message = f'[{self._name}]: {args[0]}'
+        return (message,) + args[1:]

--- a/common/python/powerpi_common/device/container.py
+++ b/common/python/powerpi_common/device/container.py
@@ -38,7 +38,6 @@ class DeviceContainer(containers.DeclarativeContainer):
 
     device_status_checker = providers.Singleton(
         DeviceStatusChecker,
-        config=config,
         logger=logger,
         device_manager=device_manager,
         scheduler=scheduler

--- a/common/python/powerpi_common/device/manager.py
+++ b/common/python/powerpi_common/device/manager.py
@@ -21,17 +21,24 @@ class DeviceManager(InitialisableMixin):
         self.__logger = logger
         self.__factory = factory
 
-        self.__devices: Dict[DeviceConfigType,
-                             Dict[str, Union[DeviceType, SensorType]]] = {}
+        self.__devices: Dict[
+            DeviceConfigType,
+            Dict[str, Union[DeviceType, SensorType]]
+        ] = {}
+
         for device_type in DeviceConfigType:
             self.__devices[device_type] = {}
 
     @property
-    def devices(self) -> DeviceType:
+    def devices_and_sensors(self):
+        return self.__devices
+
+    @property
+    def devices(self) -> Dict[str, DeviceType]:
         return self.__devices[DeviceConfigType.DEVICE]
 
     @property
-    def sensors(self) -> SensorType:
+    def sensors(self) -> Dict[str, SensorType]:
         return self.__devices[DeviceConfigType.SENSOR]
 
     def get_device(self, name: str) -> DeviceType:

--- a/common/python/powerpi_common/device/manager.py
+++ b/common/python/powerpi_common/device/manager.py
@@ -30,8 +30,8 @@ class DeviceManager(InitialisableMixin):
             self.__devices[device_type] = {}
 
     @property
-    def devices_and_sensors(self):
-        return self.__devices
+    def devices_and_sensors(self) -> List[Union[DeviceType, SensorType]]:
+        return list(self.devices.values()) + list(self.sensors.values())
 
     @property
     def devices(self) -> Dict[str, DeviceType]:

--- a/common/python/powerpi_common/device/mixin/pollable.py
+++ b/common/python/powerpi_common/device/mixin/pollable.py
@@ -1,4 +1,7 @@
 from abc import ABC
+from typing import Union
+
+from powerpi_common.config.config import Config
 
 
 class PollableMixin(ABC):
@@ -7,6 +10,31 @@ class PollableMixin(ABC):
     by the "DeviceStatusChecker" to update the state of a device that implements
     this mixin if the state of said device has been externally modified.
     '''
+
+    def __init__(self, config: Config, poll_frequency: Union[int, None] = None):
+        if poll_frequency is None:
+            self.__pollable = True
+            self.__poll_frequency = max(config.poll_frequency, 10)
+        elif poll_frequency <= 0:
+            self.__pollable = False
+        else:
+            self.__pollable = True
+            self.__poll_frequency = max(poll_frequency, 10)
+
+    @property
+    def polling_enabled(self):
+        '''
+        Return whether polling is enabled for this device.
+        '''
+        return self.__pollable
+
+    @property
+    def poll_frequency(self):
+        '''
+        Return the poll frequency for this device.
+        '''
+        return self.__poll_frequency
+
     async def poll(self):
         '''
         Implement this method to support polling in a concrete device implementation.

--- a/common/python/powerpi_common/device/mixin/pollable.py
+++ b/common/python/powerpi_common/device/mixin/pollable.py
@@ -11,7 +11,12 @@ class PollableMixin(ABC):
     this mixin if the state of said device has been externally modified.
     '''
 
-    def __init__(self, config: Config, poll_frequency: Union[int, None] = None):
+    def __init__(
+        self,
+        config: Config,
+        poll_frequency: Union[int, None] = None,
+        **_
+    ):
         if poll_frequency is None:
             self.__pollable = True
             self.__poll_frequency = max(config.poll_frequency, 10)

--- a/common/python/powerpi_common/device/status.py
+++ b/common/python/powerpi_common/device/status.py
@@ -1,8 +1,8 @@
-from typing import List
+from typing import Dict, List
+
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 
-from powerpi_common.config import Config
 from powerpi_common.logger import Logger
 from powerpi_common.util import ismixin
 from .manager import DeviceManager
@@ -12,36 +12,39 @@ from .mixin.pollable import PollableMixin
 class DeviceStatusChecker:
     def __init__(
         self,
-        config: Config,
         logger: Logger,
         device_manager: DeviceManager,
         scheduler: AsyncIOScheduler
     ):
         self.__logger = logger
         self.__device_manager = device_manager
-
         self.__scheduler = scheduler
 
-        # no more frequently than 10s
-        self.__poll_frequency = max(config.poll_frequency, 10)
-
-    @property
-    def devices(self) -> List[PollableMixin]:
-        return list(filter(
-            lambda device: ismixin(device, PollableMixin),
-            list(self.__device_manager.devices.values())
+    def start(self):
+        # create a list of pollable devices/sensors
+        devices: List[PollableMixin] = list(filter(
+            lambda device:
+                ismixin(device, PollableMixin)
+                and device.polling_enabled,
+            list(self.__device_manager.devices_and_sensors.values())
         ))
 
-    def start(self):
         # only schedule if there are pollable devices
-        if len(self.devices) > 0:
-            self.__logger.info(
-                f'Polling for device state changes every {self.__poll_frequency} seconds'
-                + f' for {len(self.devices)} device(s)'
-            )
+        if len(devices) > 0:
+            groups: Dict[int, List[PollableMixin]] = {}
 
-            interval = IntervalTrigger(seconds=self.__poll_frequency)
-            self.__scheduler.add_job(self._run, trigger=interval)
+            # group them by poll frequency
+            for device in devices:
+                if device.poll_frequency not in groups:
+                    groups[device.poll_frequency] = []
+
+                groups[device.poll_frequency].append(device)
+
+            for poll_frequency, devices in groups.items():
+                ScheduledDeviceGroup(
+                    self.__logger, self.__scheduler, poll_frequency, devices
+                )
+
             self.__scheduler.start()
 
     def stop(self):
@@ -49,11 +52,42 @@ class DeviceStatusChecker:
             self.__logger.info('Stopping device state change polling')
             self.__scheduler.shutdown()
 
-    async def _run(self):
-        # pylint: disable=broad-except
-        self.__logger.info('Checking devices state')
 
-        for device in self.devices:
+class ScheduledDeviceGroup:
+    def __init__(
+        self,
+        logger: Logger,
+        scheduler: AsyncIOScheduler,
+        poll_frequency: int,
+        devices: List[PollableMixin]
+    ):
+        self.__logger = logger
+        self.__scheduler = scheduler
+
+        self.__poll_frequency = poll_frequency
+        self.__devices = devices
+
+        self.__logger.info(
+            f'Polling {len(self.__devices)} device(s)/sensor(s)'
+            + f' every {poll_frequency} seconds'
+        )
+
+        interval = IntervalTrigger(seconds=poll_frequency)
+        self.__scheduler.add_job(self.run, trigger=interval)
+
+    @property
+    def poll_frequency(self):
+        return self.__poll_frequency
+
+    @property
+    def devices(self):
+        return self.__devices
+
+    async def run(self):
+        # pylint: disable=broad-except
+        self.__logger.info('Checking device(s)/sensor(s) state')
+
+        for device in self.__devices:
             try:
                 await device.poll()
             except Exception as ex:

--- a/common/python/powerpi_common/device/status.py
+++ b/common/python/powerpi_common/device/status.py
@@ -26,7 +26,7 @@ class DeviceStatusChecker:
             lambda device:
                 ismixin(device, PollableMixin)
                 and device.polling_enabled,
-            list(self.__device_manager.devices_and_sensors.values())
+            list(self.__device_manager.devices_and_sensors)
         ))
 
         # only schedule if there are pollable devices

--- a/common/python/powerpi_common/logger.py
+++ b/common/python/powerpi_common/logger.py
@@ -45,8 +45,32 @@ __________                         __________.__
     def warn(self, *args):
         self.__logger.warning(*args)
 
+    def warning(self, *args):
+        self.__logger.warning(*args)
+
     def error(self, *args):
         self.__logger.error(*args)
 
     def exception(self, *args):
         self.__logger.exception(*args)
+
+
+class LogMixin:
+    '''
+    Mixin to add methods for logging to a class.
+    '''
+
+    def log_debug(self, *args):
+        self._logger.debug(*args)
+
+    def log_info(self, *args):
+        self._logger.info(*args)
+
+    def log_warning(self, *args):
+        self._logger.warning(*args)
+
+    def log_error(self, *args):
+        self._logger.error(*args)
+
+    def log_exception(self, *args):
+        self._logger.exception(*args)

--- a/common/python/powerpi_common/sensor/mixin/__init__.py
+++ b/common/python/powerpi_common/sensor/mixin/__init__.py
@@ -1,0 +1,1 @@
+from .battery import BatteryMixin

--- a/common/python/powerpi_common/sensor/mixin/battery.py
+++ b/common/python/powerpi_common/sensor/mixin/battery.py
@@ -1,0 +1,18 @@
+from abc import ABC
+
+
+class BatteryMixin(ABC):
+    '''
+    Mixing to add battery message broadcast functionality to a sensor.
+    '''
+
+    def on_battery_change(self, level: int):
+        '''
+        Call this method to broadcast a new battery level for this sensor.
+        '''
+        message = {
+            'value': level,
+            'unit': '%'
+        }
+
+        self._broadcast('battery', message)

--- a/common/python/powerpi_common/sensor/sensor.py
+++ b/common/python/powerpi_common/sensor/sensor.py
@@ -14,26 +14,24 @@ class Sensor(BaseDevice):
     def __init__(
         self,
         mqtt_client: MQTTClient,
-        location: Union[str, None] = None,
         entity: Union[str, None] = None,
         action: Union[str, None] = None,
         **kwargs
     ):
         BaseDevice.__init__(self, **kwargs)
 
-        self.__location = location
         self.__entity = entity
         self.__action = action
 
         self._producer = mqtt_client.add_producer()
 
-    def _broadcast(self, action: str, message: dict):
-        entity = self.__entity if self.__entity is not None \
-            else self.__location if self.__location is not None \
-            else self._name
+    @property
+    def entity(self):
+        return self.__entity if self.__entity is not None else self._name
 
+    def _broadcast(self, action: str, message: dict):
         action = action if action is not None else self.__action
 
-        topic = f'event/{entity}/{action}'
+        topic = f'event/{self.entity}/{action}'
 
         self._producer(topic, message)

--- a/common/python/pyproject.toml
+++ b/common/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "powerpi-common"
-version = "0.2.0"
+version = "0.2.1"
 description = "PowerPi Common Python Library"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/common/python/tests/device/mixin/test_pollable.py
+++ b/common/python/tests/device/mixin/test_pollable.py
@@ -1,3 +1,5 @@
+import pytest
+
 from pytest_mock import MockerFixture
 
 from powerpi_common.device import Device
@@ -7,6 +9,11 @@ from powerpi_common_test.device.mixin import PollableMixinTestBase
 
 
 class DeviceImpl(Device, PollableMixin):
+    #pytest: disable=too-many-arguments
+    def __init__(self, config, logger, mqtt_client, name: str, poll_frequency=60):
+        Device.__init__(self, config, logger, mqtt_client, name=name)
+        PollableMixin.__init__(self, config, poll_frequency)
+
     async def poll(self):
         pass
 
@@ -23,3 +30,45 @@ class TestPollableMixin(DeviceTestBase, PollableMixinTestBase):
             self.config, self.logger, self.mqtt_client,
             name='pollable'
         )
+
+    def test_poll_frequency_default(self, mocker: MockerFixture):
+        self.config = mocker.Mock()
+        self.logger = mocker.Mock()
+        self.mqtt_client = mocker.Mock()
+
+        self.config.poll_frequency = 120
+
+        device = DeviceImpl(
+            self.config, self.logger, self.mqtt_client,
+            name='pollable', poll_frequency=120
+        )
+
+        assert device.polling_enabled is True
+        assert device.poll_frequency == 120
+
+    @pytest.mark.parametrize('value', [1, 9])
+    def test_poll_frequency_too_small(self, mocker: MockerFixture, value: int):
+        self.config = mocker.Mock()
+        self.logger = mocker.Mock()
+        self.mqtt_client = mocker.Mock()
+
+        device = DeviceImpl(
+            self.config, self.logger, self.mqtt_client,
+            name='pollable', poll_frequency=value
+        )
+
+        assert device.polling_enabled is True
+        assert device.poll_frequency == 10
+
+    @pytest.mark.parametrize('value', [-1, 0])
+    def test_poll_frequency_disable(self, mocker: MockerFixture, value: int):
+        self.config = mocker.Mock()
+        self.logger = mocker.Mock()
+        self.mqtt_client = mocker.Mock()
+
+        device = DeviceImpl(
+            self.config, self.logger, self.mqtt_client,
+            name='pollable', poll_frequency=value
+        )
+
+        assert device.polling_enabled is False

--- a/common/python/tests/device/test_manager.py
+++ b/common/python/tests/device/test_manager.py
@@ -49,6 +49,7 @@ class TestDeviceManager(InitialisableMixinTestBase):
 
         assert len(subject.devices) == 0
         assert len(subject.sensors) == 0
+        assert len(subject.devices_and_sensors) == 0
 
     async def test_load_unknown(self, mocker: MockerFixture):
         subject = self.create_subject(mocker)
@@ -70,6 +71,7 @@ class TestDeviceManager(InitialisableMixinTestBase):
 
         assert len(subject.devices) == 0
         assert len(subject.sensors) == 0
+        assert len(subject.devices_and_sensors) == 0
 
     async def test_load_content(self, mocker: MockerFixture):
         subject = self.create_subject(mocker)
@@ -92,6 +94,10 @@ class TestDeviceManager(InitialisableMixinTestBase):
         })
 
         await subject.load()
+
+        assert len(subject.devices) == 2
+        assert len(subject.sensors) == 2
+        assert len(subject.devices_and_sensors) == 4
 
         for device_name, instance_type, additional, initialised in \
                 [('a', 'test_device', True, False), ('b', 'another_device', False, True)]:

--- a/common/python/tests/device/test_status.py
+++ b/common/python/tests/device/test_status.py
@@ -181,9 +181,7 @@ class TestDeviceStatusChecker:
         all_devices.extend(pollable_3_devices)
         all_devices.extend(disabled_pollable_devices)
 
-        self.device_manager.devices_and_sensors = {
-            device.name: device for device in all_devices
-        }
+        self.device_manager.devices_and_sensors = all_devices
 
         return (
             pollable_none_devices + pollable_60_devices + pollable_3_devices,

--- a/common/python/tests/device/test_status.py
+++ b/common/python/tests/device/test_status.py
@@ -1,14 +1,20 @@
-import pytest
-
-from pytest_mock import MockerFixture
+from types import MethodType
+from typing import Union
 from unittest.mock import PropertyMock
 
+import pytest
+
+from apscheduler.triggers.interval import IntervalTrigger
+from pytest_mock import MockerFixture
+
+from powerpi_common.config import Config
 from powerpi_common.device.mixin.pollable import PollableMixin
 from powerpi_common.device.status import DeviceStatusChecker
 
 
 class PollableDeviceImpl(PollableMixin):
-    def __init__(self, name: str):
+    def __init__(self, config: Config, name: str, poll_frequency: Union[int, None]):
+        PollableMixin.__init__(self, config, poll_frequency)
         self.name = name
         self.count = 0
 
@@ -28,33 +34,63 @@ class TestDeviceStatusChecker:
         mocker.patch.object(self.config, 'poll_frequency', 1)
 
         return DeviceStatusChecker(
-            self.config, self.logger, self.device_manager, self.scheduler
+            self.logger, self.device_manager, self.scheduler
         )
 
-    @pytest.mark.parametrize('normal_devices', [0, 5])
-    @pytest.mark.parametrize('pollable_devices', [0, 3])
-    def test_devices(self, mocker: MockerFixture, normal_devices: int, pollable_devices: int):
+    @pytest.mark.parametrize('normal', [0, 3])
+    @pytest.mark.parametrize('pollable_none', [0, 2])
+    @pytest.mark.parametrize('pollable_60', [0, 4])
+    @pytest.mark.parametrize('pollable_3', [0, 6])
+    @pytest.mark.parametrize('disabled', [0, 5])
+    def test_start(
+        self,
+        mocker: MockerFixture,
+        normal: int,
+        pollable_none: int,
+        pollable_60: int,
+        pollable_3: int,
+        disabled: int
+    ):
         subject = self.get_subject(mocker)
 
-        self.__add_devices(mocker, normal_devices, pollable_devices)
+        self.config.poll_frequency = 120
 
-        devices = subject.devices
-        assert len(devices) == pollable_devices
+        groups = []
+        timers = []
 
-    @pytest.mark.parametrize('devices', [True, False])
-    def test_start(self, mocker: MockerFixture, devices: bool):
-        subject = self.get_subject(mocker)
+        def add_job(method: MethodType, trigger: IntervalTrigger):
+            groups.append(method.__self__)
+            timers.append(trigger.interval.seconds)
 
-        self.__add_devices(mocker, 1, 1 if devices else 0)
+        self.scheduler.add_job = add_job
+
+        self.__add_devices(
+            mocker, normal, pollable_none, pollable_60, pollable_3, disabled
+        )
 
         subject.start()
 
-        if devices:
-            self.scheduler.add_job.assert_called()
-            self.scheduler.start.assert_called()
-        else:
-            self.scheduler.add_job.assert_not_called()
+        if pollable_none + pollable_60 + pollable_3 == 0:
             self.scheduler.start.assert_not_called()
+        else:
+            count = sum([
+                1 if x > 0 else 0
+                for x in [pollable_none, pollable_60, pollable_3]
+            ])
+
+            assert len(timers) == count
+            assert len(groups) == count
+
+            self.scheduler.start.assert_called_once()
+
+        for count, interval in zip([pollable_none, pollable_60, pollable_3], [120, 60, 10]):
+            if count > 0:
+                assert interval in timers
+                assert any((
+                    group.poll_frequency == interval
+                    and len(group.devices) == count
+                    for group in groups
+                ))
 
     @pytest.mark.parametrize('running', [True, False])
     def test_stop(self, mocker: MockerFixture, running: bool):
@@ -72,36 +108,85 @@ class TestDeviceStatusChecker:
     async def test_run(self, mocker: MockerFixture):
         subject = self.get_subject(mocker)
 
-        pollable_devices = self.__add_devices(mocker, 1, 3)
+        groups = []
 
-        await subject._run()
+        def add_job(method: MethodType, **_):
+            groups.append(method.__self__)
 
-        for device in pollable_devices:
-            assert device.count == 1
+        self.scheduler.add_job = add_job
 
-        await subject._run()
+        (pollable_devices, normal_devices, disabled_devices) \
+            = self.__add_devices(mocker, 1, 3, 4, 2, 2)
 
-        for device in pollable_devices:
-            assert device.count == 2
+        subject.start()
 
-    def __add_devices(self, mocker: MockerFixture, normal: int, pollable: int):
+        async def check(count: int):
+            for group in groups:
+                await group.run()
+
+            for device in pollable_devices:
+                assert device.count == count
+
+            for device in normal_devices:
+                device.poll.assert_not_called()
+
+            for device in disabled_devices:
+                assert device.count == 0
+
+        await check(1)
+        await check(2)
+        await check(3)
+
+        # pylint: disable=too-many-arguments
+    def __add_devices(
+        self,
+        mocker: MockerFixture,
+        normal: int,
+        pollable_none: int,
+        pollable_60: int,
+        pollable_3: int,
+        disabled: int
+    ):
         normal_devices = []
+
         for i in range(0, normal):
             device = mocker.Mock()
-            type(device).name = PropertyMock(return_value=f'device{i}')
+            type(device).name = PropertyMock(return_value=f'device_{i}')
             normal_devices.append(device)
 
-        pollable_devices = [
-            PollableDeviceImpl(f'pollable{i}')
-            for i in range(0, pollable)
+        pollable_none_devices = [
+            PollableDeviceImpl(self.config, f'pollable_none_{i}', None)
+            for i in range(0, pollable_none)
+        ]
+
+        pollable_60_devices = [
+            PollableDeviceImpl(self.config, f'pollable_60_{i}', 60)
+            for i in range(0, pollable_60)
+        ]
+
+        pollable_3_devices = [
+            PollableDeviceImpl(self.config, f'pollable_3_{i}', 3)
+            for i in range(0, pollable_3)
+        ]
+
+        disabled_pollable_devices = [
+            PollableDeviceImpl(self.config, f'disabled_{i}', 0)
+            for i in range(0, disabled)
         ]
 
         all_devices = []
         all_devices.extend(normal_devices)
-        all_devices.extend(pollable_devices)
+        all_devices.extend(pollable_none_devices)
+        all_devices.extend(pollable_60_devices)
+        all_devices.extend(pollable_3_devices)
+        all_devices.extend(disabled_pollable_devices)
 
-        self.device_manager.devices = {
+        self.device_manager.devices_and_sensors = {
             device.name: device for device in all_devices
         }
 
-        return pollable_devices
+        return (
+            pollable_none_devices + pollable_60_devices + pollable_3_devices,
+            normal_devices,
+            disabled_pollable_devices
+        )

--- a/common/python/tests/sensor/mixin/test_battery.py
+++ b/common/python/tests/sensor/mixin/test_battery.py
@@ -1,0 +1,25 @@
+from pytest_mock import MockerFixture
+
+from powerpi_common.mqtt.client import MQTTClient
+from powerpi_common.sensor.mixin.battery import BatteryMixin
+from powerpi_common.sensor.sensor import Sensor
+from powerpi_common_test.sensor.sensor import SensorTestBase
+from powerpi_common_test.sensor.mixin.battery import BatteryMixinTestBase
+
+
+class SensorImpl(Sensor, BatteryMixin):
+    def __init__(
+        self,
+        mqtt_client: MQTTClient,
+        **kwargs
+    ):
+        Sensor.__init__(self, mqtt_client, **kwargs)
+
+
+class TestBatteryMixin(SensorTestBase, BatteryMixinTestBase):
+    def get_subject(self, _: MockerFixture):
+
+        return SensorImpl(
+            self.mqtt_client,
+            name='TestBattery'
+        )

--- a/common/python/tests/sensor/test_sensor.py
+++ b/common/python/tests/sensor/test_sensor.py
@@ -12,24 +12,22 @@ class SensorImpl(Sensor):
     def __init__(
         self,
         mqtt_client: MQTTClient,
-        location: Union[str, None],
         entity: Union[str, None],
         action: Union[str, None],
         **kwargs
     ):
-        Sensor.__init__(self, mqtt_client, location, entity, action, **kwargs)
+        Sensor.__init__(self, mqtt_client, entity, action, **kwargs)
 
 
 class TestSensor(SensorTestBase):
     def get_subject(self, mocker: MockerFixture):
         self.publish = mock_producer(mocker, self.mqtt_client)
 
-        self.location = getattr(self, 'location', None)
         self.entity = getattr(self, 'entity', None)
         self.action = getattr(self, 'action', None)
 
         return SensorImpl(
-            self.mqtt_client, self.location, self.entity, self.action,
+            self.mqtt_client, self.entity, self.action,
             name='TestSensor'
         )
 
@@ -37,13 +35,7 @@ class TestSensor(SensorTestBase):
         self.__broadcast(
             mocker,
             'event/Entity/Action',
-            entity='Entity', location='Location', action='Action'
-        )
-
-    def test_broadcast_location(self, mocker: MockerFixture):
-        self.__broadcast(
-            mocker, 'event/Location/Action',
-            location='Location', action='Action'
+            entity='Entity', action='Action'
         )
 
     def test_broadcast_name(self, mocker: MockerFixture):
@@ -59,12 +51,10 @@ class TestSensor(SensorTestBase):
         self,
         mocker: MockerFixture,
         topic: str,
-        location: Union[str, None] = None,
         entity: Union[str, None] = None,
         action: Union[str, None] = None,
         action_param: Union[str, None] = None
     ):
-        self.location = location
         self.entity = entity
         self.action = action
 

--- a/controllers/energenie/Dockerfile
+++ b/controllers/energenie/Dockerfile
@@ -35,7 +35,7 @@ LABEL description="PowerPi Energenie Controller"
 RUN apk add --no-cache libc6-compat
 
 ENV PATH="/usr/src/app/venv/bin:$PATH"
-ENV TZ="Europe/London"
+ENV TZ="UTC"
 
 RUN addgroup -g 997 -S gpio \
     && adduser --disabled-password powerpi \

--- a/controllers/energenie/README.md
+++ b/controllers/energenie/README.md
@@ -40,6 +40,14 @@ This service requires two configuration files, both of which are described on th
 -   [devices.json](../../clacks-config/README.md#devicesjson)
 -   [events.json](../../clacks-config/README.md#eventsjson)
 
+### Docker
+
+When running this service in Docker Swarm using the `docker-compose.yaml` file via [_device-mapper_](../../device-mapper/README.md), docker needs to know which node has the ENER314 or ENER314-RT device. The following command will add a label to the node `NODE_NAME` which should host this service.
+
+```bash
+docker node update --label-add energenie=true NODE_NAME
+```
+
 ## Testing
 
 This service can be tested by executing the following commands.

--- a/controllers/energenie/pyproject.toml
+++ b/controllers/energenie/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "energenie_controller"
-version = "0.1.4"
+version = "0.1.5"
 description = "PowerPi Engergenie Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/harmony/Dockerfile
+++ b/controllers/harmony/Dockerfile
@@ -29,7 +29,7 @@ LABEL description="PowerPi Logitech Harmony Controller"
 RUN apk add --no-cache libc6-compat
 
 ENV PATH="/usr/src/app/venv/bin:$PATH"
-ENV TZ="Europe/London"
+ENV TZ="UTC"
 
 RUN adduser --disabled-password powerpi
 USER powerpi

--- a/controllers/harmony/harmony_controller/device/harmony_hub.py
+++ b/controllers/harmony/harmony_controller/device/harmony_hub.py
@@ -38,6 +38,7 @@ class HarmonyHubDevice(Device, PollableMixin):
         Device.__init__(
             self, config, logger, mqtt_client, **kwargs
         )
+        PollableMixin.__init__(self, config, **kwargs)
 
         self.__device_manager = device_manager
 

--- a/controllers/harmony/pyproject.toml
+++ b/controllers/harmony/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "harmony_controller"
-version = "0.1.2"
+version = "0.1.3"
 description = "PowerPi Logitech Harmony Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/harmony/tests/device/test_harmony_hub.py
+++ b/controllers/harmony/tests/device/test_harmony_hub.py
@@ -60,7 +60,7 @@ class TestHarmonyHubDevice(DeviceTestBase, PollableMixinTestBase):
 
         hub = HarmonyHubDevice(
             self.config, self.logger, self.mqtt_client, self.device_manager, self.harmony_client,
-            name=self.__hub_name
+            name=self.__hub_name, poll_frequency=120
         )
 
         # device manager will include other activities and the hub

--- a/controllers/lifx/Dockerfile
+++ b/controllers/lifx/Dockerfile
@@ -29,7 +29,7 @@ LABEL description="PowerPi LIFX Controller"
 RUN apk add --no-cache libc6-compat
 
 ENV PATH="/usr/src/app/venv/bin:$PATH"
-ENV TZ="Europe/London"
+ENV TZ="UTC"
 
 RUN adduser --disabled-password powerpi
 USER powerpi

--- a/controllers/lifx/lifx_controller/device/lifx_light.py
+++ b/controllers/lifx/lifx_controller/device/lifx_light.py
@@ -36,6 +36,7 @@ class LIFXLightDevice(AdditionalStateDevice, PollableMixin):
         AdditionalStateDevice.__init__(
             self, config, logger, mqtt_client, **kwargs
         )
+        PollableMixin.__init__(self, config, **kwargs)
 
         self.__duration = duration
 

--- a/controllers/lifx/pyproject.toml
+++ b/controllers/lifx/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lifx_controller"
-version = "0.1.2"
+version = "0.1.3"
 description = "PowerPi LIFX Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/lifx/tests/device/test_lifx_light.py
+++ b/controllers/lifx/tests/device/test_lifx_light.py
@@ -26,7 +26,7 @@ class TestLIFXLightDevice(AdditionalStateDeviceTestBase, PollableMixinTestBase):
         return LIFXLightDevice(
             self.config, self.logger, self.mqtt_client, self.lifx_client,
             '00:00:00:00:00', 'mylight.home',
-            name='light'
+            name='light', poll_frequency=120
         )
 
     @pytest.mark.parametrize('status', ['on', 'off'])

--- a/controllers/macro/Dockerfile
+++ b/controllers/macro/Dockerfile
@@ -29,7 +29,7 @@ LABEL description="PowerPi Macro Controller"
 RUN apk add --no-cache libc6-compat
 
 ENV PATH="/usr/src/app/venv/bin:$PATH"
-ENV TZ="Europe/London"
+ENV TZ="UTC"
 
 RUN adduser --disabled-password powerpi
 USER powerpi

--- a/controllers/macro/macro_controller/device/composite.py
+++ b/controllers/macro/macro_controller/device/composite.py
@@ -27,6 +27,7 @@ class CompositeDevice(AdditionalStateDevice, DeviceOrchestratorMixin, PollableMi
         DeviceOrchestratorMixin.__init__(
             self, config, logger, mqtt_client, device_manager, devices
         )
+        PollableMixin.__init__(self, config, **kwargs)
 
     async def on_referenced_device_status(self, _: str, __: DeviceStatus):
         await self.poll()

--- a/controllers/macro/macro_controller/device/mutex.py
+++ b/controllers/macro/macro_controller/device/mutex.py
@@ -24,6 +24,7 @@ class MutexDevice(Device, DeviceOrchestratorMixin, PollableMixin):
         DeviceOrchestratorMixin.__init__(
             self, config, logger, mqtt_client, device_manager, on_devices + off_devices
         )
+        PollableMixin.__init__(self, config, **kwargs)
 
         self.__device_manager = device_manager
         self.__on_device_names = on_devices

--- a/controllers/macro/pyproject.toml
+++ b/controllers/macro/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "macro_controller"
-version = "1.1.4"
+version = "1.1.5"
 description = "PowerPi Macro Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/macro/tests/device/test_composite.py
+++ b/controllers/macro/tests/device/test_composite.py
@@ -32,7 +32,7 @@ class TestCompositeDevice(AdditionalStateDeviceTestBase, DeviceOrchestratorMixin
         return CompositeDevice(
             self.config, self.logger, self.mqtt_client, self.device_manager,
             ['device0', 'device1', 'device2', 'device3'],
-            name='composite'
+            name='composite', poll_frequency=60
         )
 
     async def test_all_on(self, mocker: MockerFixture):

--- a/controllers/macro/tests/device/test_mutex.py
+++ b/controllers/macro/tests/device/test_mutex.py
@@ -37,7 +37,8 @@ class TestMutexDevice(DeviceTestBase, DeviceOrchestratorMixinTestBase, PollableM
             self.config, self.logger, self.mqtt_client, self.device_manager,
             off_devices=[0, 1],
             on_devices=[2, 3],
-            name='mutex'
+            name='mutex',
+            poll_frequency=60
         )
 
     async def test_all_on(self, mocker: MockerFixture):

--- a/controllers/zigbee/Dockerfile
+++ b/controllers/zigbee/Dockerfile
@@ -32,7 +32,7 @@ RUN apk add --no-cache libc6-compat
 RUN apk add --no-cache sqlite-libs
 
 ENV PATH="/usr/src/app/venv/bin:$PATH"
-ENV TZ="Europe/London"
+ENV TZ="UTC"
 
 RUN adduser --disabled-password powerpi \
     && addgroup powerpi dialout

--- a/controllers/zigbee/README.md
+++ b/controllers/zigbee/README.md
@@ -8,6 +8,7 @@ The service is built using python, with dependencies using [poetry](https://pyth
 
 This controller service currently supports the following ZigBee devices:
 
+-   [Aqara Door and Window Sensor](https://www.aqara.com/en/door_and_window_sensor.html) - Magnetic door and window sensor supporting open and close events as well as battery life.
 -   Osram Smart+ Switch Mini - ZigBee remote with 3 buttons (centre, up and down) supporting single and long press.
 
 ## Building
@@ -33,6 +34,14 @@ This service requires two configuration files, both of which are described on th
 
 -   [devices.json](../../clacks-config/README.md#devicesjson)
 -   [events.json](../../clacks-config/README.md#eventsjson)
+
+### Docker
+
+When running this service in Docker Swarm using the `docker-compose.yaml` file via [_device-mapper_](../../device-mapper/README.md), docker needs to know which node has the ZigBee device. The following command will add a label to the node `NODE_NAME` which should host this service.
+
+```bash
+docker node update --label-add zigbee=true NODE_NAME
+```
 
 ## Testing
 

--- a/controllers/zigbee/pyproject.toml
+++ b/controllers/zigbee/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zigbee_controller"
-version = "0.1.3"
+version = "0.1.4"
 description = "PowerPi ZigBee Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/zigbee/tests/sensor/aqara/test_door_window_sensor.py
+++ b/controllers/zigbee/tests/sensor/aqara/test_door_window_sensor.py
@@ -56,6 +56,51 @@ class TestAqaraDoorWindowSensor(
 
         self.publish.assert_not_called()
 
+    @pytest.mark.parametrize('values', [
+        (3100, 100),
+        (3101, 100),
+        (2820, 0),
+        (2819, 0),
+        (2819, 0),
+        (3075, 91)
+    ])
+    def test_on_attribute_updated(self, mocker: MockerFixture, values: Tuple[int, int]):
+        (data, percent) = values
+
+        def mock():
+            self.publish = mock_producer(mocker, self.mqtt_client)
+
+        subject = self.create_subject(mocker, mock)
+
+        # data is attribute id (0x01), type value (0x21), data in little endian
+        value = bytearray(b'\x01\x21')
+        value += data.to_bytes(2, 'little')
+        value = value.decode('utf8')
+
+        subject.on_attribute_updated(0xFF01, value)
+
+        topic = 'event/test/battery'
+        message = {'value': percent, 'unit': '%'}
+        self.publish.assert_called_once_with(topic, message)
+
+    @pytest.mark.parametrize('values', [(0xFF00, 0x01), (0xFF01, 0xBD)])
+    def test_on_attribute_updated_other_data(self, mocker: MockerFixture, values: Tuple[int, int]):
+        (attribute_id, data_id) = values
+
+        def mock():
+            self.publish = mock_producer(mocker, self.mqtt_client)
+
+        subject = self.create_subject(mocker, mock)
+
+        # data is attribute id (0x02), type value (0x21), data in little endian
+        value = bytearray(data_id)
+        value += b'\x21\x00\x00'
+        value = value.decode('utf8')
+
+        subject.on_attribute_updated(attribute_id, value)
+
+        self.publish.assert_not_called()
+
     def __verify_publish(self, state: str):
         topic = 'event/test/change'
 

--- a/controllers/zigbee/tests/sensor/aqara/test_door_window_sensor.py
+++ b/controllers/zigbee/tests/sensor/aqara/test_door_window_sensor.py
@@ -4,14 +4,16 @@ import pytest
 
 from pytest_mock import MockerFixture
 
-from powerpi_common_test.device.mixin import PollableMixinTestBase
+from powerpi_common_test.device.mixin import InitialisableMixinTestBase, PollableMixinTestBase
 from powerpi_common_test.mqtt import mock_producer
 from powerpi_common_test.sensor import SensorTestBase
 from powerpi_common_test.sensor.mixin import BatteryMixinTestBase
 from zigbee_controller.sensor.aqara.door_window_sensor import AqaraDoorWindowSensor
 
 
-class TestAqaraDoorWindowSensor(SensorTestBase, PollableMixinTestBase, BatteryMixinTestBase):
+class TestAqaraDoorWindowSensor(
+    SensorTestBase, PollableMixinTestBase, BatteryMixinTestBase, InitialisableMixinTestBase
+):
     def get_subject(self, mocker: MockerFixture):
         self.controller = mocker.MagicMock()
 

--- a/controllers/zigbee/tests/sensor/aqara/test_door_window_sensor.py
+++ b/controllers/zigbee/tests/sensor/aqara/test_door_window_sensor.py
@@ -26,7 +26,7 @@ class TestAqaraDoorWindowSensor(SensorTestBase, PollableMixinTestBase, BatteryMi
 
         return AqaraDoorWindowSensor(
             self.config, self.logger, self.controller, self.mqtt_client,
-            '00:00:00:00:00:00:00:00', '0xAAAA',
+            ieee='00:00:00:00:00:00:00:00', nwk='0xAAAA',
             name='test', poll_frequency=60
         )
 

--- a/controllers/zigbee/tests/sensor/aqara/test_door_window_sensor.py
+++ b/controllers/zigbee/tests/sensor/aqara/test_door_window_sensor.py
@@ -1,0 +1,55 @@
+from typing import Tuple, Union
+
+import pytest
+
+from pytest_mock import MockerFixture
+
+from powerpi_common_test.mqtt.mqtt import mock_producer
+from powerpi_common_test.sensor.sensor import SensorTestBase
+from zigbee_controller.sensor.aqara.door_window_sensor import AqaraDoorWindowSensor
+
+
+class TestAqaraDoorWindowSensor(SensorTestBase):
+    def get_subject(self, mocker: MockerFixture):
+        self.controller = mocker.MagicMock()
+
+        self.endpoints = {
+            1: mocker.Mock()
+        }
+
+        def getitem(key: str):
+            return self.endpoints[key]
+
+        self.controller.__getitem__.side_effect = getitem
+
+        self.publish = mock_producer(mocker, self.mqtt_client)
+
+        return AqaraDoorWindowSensor(
+            self.logger, self.controller, self.mqtt_client,
+            '00:00:00:00:00:00:00:00', '0xAAAA', name='test'
+        )
+
+    @pytest.mark.parametrize('values', [(0, 'close'), (1, 'open'), (False, 'close'), (True, 'open')])
+    def test_open_close_handler(self, mocker: MockerFixture, values: Tuple[Union[int, bool], str]):
+        (arg, state) = values
+
+        subject = self.create_subject(mocker)
+
+        subject.open_close_handler(arg)
+
+        self.__verify_publish(state)
+
+    @pytest.mark.parametrize('arg', [2, -1, None])
+    def test_open_close_handler_bad_args(self, mocker: MockerFixture, arg: Union[int, None]):
+        subject = self.create_subject(mocker)
+
+        subject.open_close_handler(arg)
+
+        self.publish.assert_not_called()
+
+    def __verify_publish(self, state: str):
+        topic = 'event/test/change'
+
+        message = {'state': state}
+
+        self.publish.assert_called_once_with(topic, message)

--- a/controllers/zigbee/tests/sensor/aqara/test_door_window_sensor.py
+++ b/controllers/zigbee/tests/sensor/aqara/test_door_window_sensor.py
@@ -4,7 +4,7 @@ import pytest
 
 from pytest_mock import MockerFixture
 
-from powerpi_common_test.device.mixin import InitialisableMixinTestBase, PollableMixinTestBase
+from powerpi_common_test.device.mixin import InitialisableMixinTestBase
 from powerpi_common_test.mqtt import mock_producer
 from powerpi_common_test.sensor import SensorTestBase
 from powerpi_common_test.sensor.mixin import BatteryMixinTestBase
@@ -12,7 +12,7 @@ from zigbee_controller.sensor.aqara.door_window_sensor import AqaraDoorWindowSen
 
 
 class TestAqaraDoorWindowSensor(
-    SensorTestBase, PollableMixinTestBase, BatteryMixinTestBase, InitialisableMixinTestBase
+    SensorTestBase, BatteryMixinTestBase, InitialisableMixinTestBase
 ):
     def get_subject(self, mocker: MockerFixture):
         self.controller = mocker.MagicMock()
@@ -27,9 +27,9 @@ class TestAqaraDoorWindowSensor(
         self.controller.__getitem__.side_effect = getitem
 
         return AqaraDoorWindowSensor(
-            self.config, self.logger, self.controller, self.mqtt_client,
+            self.logger, self.controller, self.mqtt_client,
             ieee='00:00:00:00:00:00:00:00', nwk='0xAAAA',
-            name='test', poll_frequency=60
+            name='test'
         )
 
     @pytest.mark.parametrize('values', [(0, 'close'), (1, 'open'), (False, 'close'), (True, 'open')])

--- a/controllers/zigbee/tests/sensor/osram/test_switch_mini.py
+++ b/controllers/zigbee/tests/sensor/osram/test_switch_mini.py
@@ -4,12 +4,13 @@ import pytest
 
 from pytest_mock import MockerFixture
 
+from powerpi_common_test.device.mixin import InitialisableMixinTestBase
 from powerpi_common_test.mqtt import mock_producer
 from powerpi_common_test.sensor import SensorTestBase
 from zigbee_controller.sensor.osram.switch_mini import Button, PressType, OsramSwitchMiniSensor
 
 
-class TestOsramSwitchMiniSensor(SensorTestBase):
+class TestOsramSwitchMiniSensor(SensorTestBase, InitialisableMixinTestBase):
     def get_subject(self, mocker: MockerFixture):
         self.controller = mocker.MagicMock()
 

--- a/controllers/zigbee/tests/sensor/osram/test_switch_mini.py
+++ b/controllers/zigbee/tests/sensor/osram/test_switch_mini.py
@@ -28,7 +28,7 @@ class TestOsramSwitchMiniSensor(SensorTestBase):
 
         return OsramSwitchMiniSensor(
             self.logger, self.controller, self.mqtt_client,
-            '00:00:00:00:00:00:00:00', '0xAAAA', name='test'
+            ieee='00:00:00:00:00:00:00:00', nwk='0xAAAA', name='test'
         )
 
     @pytest.mark.parametrize('button', [Button.UP, Button.MIDDLE, Button.DOWN])

--- a/controllers/zigbee/zigbee_controller/sensor/__init__.py
+++ b/controllers/zigbee/zigbee_controller/sensor/__init__.py
@@ -1,5 +1,7 @@
+from .aqara import add_aqara_sensors
 from .osram import add_osram_sensors
 
 
 def add_sensors(container):
+    add_aqara_sensors(container)
     add_osram_sensors(container)

--- a/controllers/zigbee/zigbee_controller/sensor/aqara/__init__.py
+++ b/controllers/zigbee/zigbee_controller/sensor/aqara/__init__.py
@@ -12,7 +12,6 @@ def add_aqara_sensors(container):
             f'aqara_{sensor_type}_sensor',
             providers.Factory(
                 AqaraDoorWindowSensor,
-                config=container.common.config,
                 logger=container.common.logger,
                 controller=container.device.zigbee_controller,
                 mqtt_client=container.common.mqtt_client

--- a/controllers/zigbee/zigbee_controller/sensor/aqara/__init__.py
+++ b/controllers/zigbee/zigbee_controller/sensor/aqara/__init__.py
@@ -12,6 +12,7 @@ def add_aqara_sensors(container):
             f'aqara_{sensor_type}_sensor',
             providers.Factory(
                 AqaraDoorWindowSensor,
+                config=container.common.config,
                 logger=container.common.logger,
                 controller=container.device.zigbee_controller,
                 mqtt_client=container.common.mqtt_client

--- a/controllers/zigbee/zigbee_controller/sensor/aqara/__init__.py
+++ b/controllers/zigbee/zigbee_controller/sensor/aqara/__init__.py
@@ -1,0 +1,19 @@
+from dependency_injector import providers
+
+from .door_window_sensor import AqaraDoorWindowSensor
+
+
+def add_aqara_sensors(container):
+    device_container = container.common().device()
+
+    for sensor_type in ['door', 'window']:
+        setattr(
+            device_container,
+            f'aqara_{sensor_type}_sensor',
+            providers.Factory(
+                AqaraDoorWindowSensor,
+                logger=container.common.logger,
+                controller=container.device.zigbee_controller,
+                mqtt_client=container.common.mqtt_client
+            )
+        )

--- a/controllers/zigbee/zigbee_controller/sensor/aqara/door_window_sensor.py
+++ b/controllers/zigbee/zigbee_controller/sensor/aqara/door_window_sensor.py
@@ -1,19 +1,18 @@
-from typing import List
+from typing import Any, Dict, List
 
-from zigpy.zcl.clusters.general import OnOff as OnOffCluster
-from zigpy.zcl.foundation import Attribute
+from zigpy.zcl.clusters.general import Basic, OnOff as OnOffCluster
+from zigpy.zcl.foundation import Attribute, TypeValue
 
-from powerpi_common.config import Config
-from powerpi_common.device.mixin import PollableMixin
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
 from powerpi_common.sensor import Sensor
 from powerpi_common.sensor.mixin.battery import BatteryMixin
 from zigbee_controller.device import ZigbeeController
-from zigbee_controller.zigbee import ClusterGeneralCommandListener, OnOff, OpenClose, ZigbeeMixin
+from zigbee_controller.zigbee import ClusterAttributeListener, ClusterGeneralCommandListener, \
+    OnOff, OpenClose, ZigbeeMixin
 
 
-class AqaraDoorWindowSensor(Sensor, ZigbeeMixin, PollableMixin, BatteryMixin):
+class AqaraDoorWindowSensor(Sensor, ZigbeeMixin, BatteryMixin):
     '''
     Adds support for Aqara Door/Window Sensor.
     Generates the following events on open/close.
@@ -25,10 +24,21 @@ class AqaraDoorWindowSensor(Sensor, ZigbeeMixin, PollableMixin, BatteryMixin):
     /event/NAME/change:{"state": "close"}
     '''
 
+    # the additional attribute id returned by this device
+    AQARA_ATTRIBUTE = 0xFF01
+
+    # the attribute id in AQARA_ATTRIBUTE for the battery mV level
+    BATTERY_VOLTAGE_ATTRIBUTE = 1
+
+    # the minimum expected voltage in mV
+    MIN_VOLTAGE = 2820
+
+    # the maximum expected voltage in mV
+    MAX_VOLTAGE = 3100
+
     # pylint: disable=too-many-arguments
     def __init__(
         self,
-        config: Config,
         logger: Logger,
         controller: ZigbeeController,
         mqtt_client: MQTTClient,
@@ -36,12 +46,8 @@ class AqaraDoorWindowSensor(Sensor, ZigbeeMixin, PollableMixin, BatteryMixin):
     ):
         Sensor.__init__(self, mqtt_client, **kwargs)
         ZigbeeMixin.__init__(self, controller, **kwargs)
-        PollableMixin.__init__(self, config, **kwargs)
 
         self.__logger = logger
-
-    async def poll(self):
-        pass
 
     def open_close_handler(self, on_off: OnOff):
         self.__logger.info(f'Received {on_off} from door/window sensor')
@@ -53,9 +59,39 @@ class AqaraDoorWindowSensor(Sensor, ZigbeeMixin, PollableMixin, BatteryMixin):
             state = OpenClose.CLOSE
 
         if state:
-            message = {"state": state}
+            message = {'state': state}
 
             self._broadcast('change', message)
+
+    def on_attribute_updated(self, attribute_id: int, value: Any):
+        if attribute_id == self.AQARA_ATTRIBUTE:
+            additional_attributes: Dict[int, TypeValue] = {}
+
+            # read the additional attributes from the binary response
+            data = bytes(value, 'utf-8')
+            while data not in (b'', b'\x00'):
+                key = int(data[0])
+                data_value, data = TypeValue.deserialize(data[1:])
+
+                additional_attributes[key] = data_value
+
+                # we only care about the battery voltage
+                if key == self.BATTERY_VOLTAGE_ATTRIBUTE:
+                    break
+
+            # if the battery voltage attribute is included
+            if self.BATTERY_VOLTAGE_ATTRIBUTE in additional_attributes:
+                voltage = additional_attributes[self.BATTERY_VOLTAGE_ATTRIBUTE].value
+
+                # ensure voltage is in the expected range
+                voltage = max(voltage, self.MIN_VOLTAGE)
+                voltage = min(voltage, self.MAX_VOLTAGE)
+
+                # convert to a percentage
+                multiplier = 100 / (self.MAX_VOLTAGE - self.MIN_VOLTAGE)
+                percentage = round((voltage - self.MIN_VOLTAGE) * multiplier)
+
+                self.on_battery_change(percentage)
 
     async def initialise(self):
         device = self._zigbee_device
@@ -77,6 +113,11 @@ class AqaraDoorWindowSensor(Sensor, ZigbeeMixin, PollableMixin, BatteryMixin):
             ClusterGeneralCommandListener(
                 lambda _, args: self.open_close_handler(parse(args))
             )
+        )
+
+        # battery status
+        device[1].in_clusters[Basic.cluster_id].add_listener(
+            ClusterAttributeListener(self.on_attribute_updated)
         )
 
     def __str__(self):

--- a/controllers/zigbee/zigbee_controller/sensor/aqara/door_window_sensor.py
+++ b/controllers/zigbee/zigbee_controller/sensor/aqara/door_window_sensor.py
@@ -11,6 +11,17 @@ from zigbee_controller.zigbee import ClusterGeneralCommandListener, OnOff, Zigbe
 
 
 class AqaraDoorWindowSensor(Sensor, ZigbeeMixin):
+    '''
+    Adds support for Aqara Door/Window Sensor.
+    Generates the following events on open/close.
+
+    Open:
+    /event/NAME/change:{"state": "open"}
+
+    Close:
+    /event/NAME/change:{"state": "close"}
+    '''
+
     # pylint: disable=too-many-arguments
     def __init__(
         self,
@@ -57,6 +68,8 @@ class AqaraDoorWindowSensor(Sensor, ZigbeeMixin):
                 except KeyError:
                     # this is probably the wrong report
                     pass
+
+            return None
 
         # open/close
         device[1].in_clusters[OnOffCluster.cluster_id].add_listener(

--- a/controllers/zigbee/zigbee_controller/sensor/aqara/door_window_sensor.py
+++ b/controllers/zigbee/zigbee_controller/sensor/aqara/door_window_sensor.py
@@ -32,12 +32,10 @@ class AqaraDoorWindowSensor(Sensor, ZigbeeMixin, PollableMixin, BatteryMixin):
         logger: Logger,
         controller: ZigbeeController,
         mqtt_client: MQTTClient,
-        ieee: str,
-        nwk: str,
         **kwargs
     ):
         Sensor.__init__(self, mqtt_client, **kwargs)
-        ZigbeeMixin.__init__(self, controller, ieee, nwk)
+        ZigbeeMixin.__init__(self, controller, **kwargs)
         PollableMixin.__init__(self, config, **kwargs)
 
         self.__logger = logger

--- a/controllers/zigbee/zigbee_controller/sensor/aqara/door_window_sensor.py
+++ b/controllers/zigbee/zigbee_controller/sensor/aqara/door_window_sensor.py
@@ -1,0 +1,58 @@
+from enum import Enum
+
+from powerpi_common.logger import Logger
+from powerpi_common.mqtt.client import MQTTClient
+from powerpi_common.sensor.sensor import Sensor
+from zigbee_controller.device import ZigbeeController
+from zigbee_controller.zigbee import ClusterGeneralCommandListener, ZigbeeMixin
+
+
+class OnOff(int, Enum):
+    OFF = 0
+    ON = 1
+
+
+class AqaraDoorWindowSensor(Sensor, ZigbeeMixin):
+    # pylint: disable=too-many-arguments
+    def __init__(
+        self,
+        logger: Logger,
+        controller: ZigbeeController,
+        mqtt_client: MQTTClient,
+        ieee: str,
+        nwk: str,
+        **kwargs
+    ):
+        Sensor.__init__(self, mqtt_client, **kwargs)
+        ZigbeeMixin.__init__(self, controller, ieee, nwk)
+
+        self.__logger = logger
+
+        self.__register()
+
+    def __str__(self):
+        return ZigbeeMixin.__str__(self)
+
+    def open_close_handler(self, on_off: OnOff):
+        self.__logger.info(f'Received {on_off} from door/window sensor')
+
+        state = None
+        if on_off == OnOff.ON:
+            state = 'open'
+        elif on_off == OnOff.OFF:
+            state = 'closed'
+
+        if state:
+            message = {"state": state}
+
+            self._broadcast('change', message)
+
+    def __register(self):
+        device = self._zigbee_device
+
+        # open/close
+        device[1].in_clusters[6].add_listener(
+            ClusterGeneralCommandListener(
+                lambda _, args: self.open_close_handler(args[0][0].value.value)
+            )
+        )

--- a/controllers/zigbee/zigbee_controller/sensor/aqara/door_window_sensor.py
+++ b/controllers/zigbee/zigbee_controller/sensor/aqara/door_window_sensor.py
@@ -47,10 +47,10 @@ class AqaraDoorWindowSensor(Sensor, ZigbeeMixin, BatteryMixin):
         Sensor.__init__(self, mqtt_client, **kwargs)
         ZigbeeMixin.__init__(self, controller, **kwargs)
 
-        self.__logger = logger
+        self._logger = logger
 
     def open_close_handler(self, on_off: OnOff):
-        self.__logger.info(f'Received {on_off} from door/window sensor')
+        self.log_info(f'Received {on_off} from door/window sensor')
 
         state = None
         if on_off == OnOff.ON:
@@ -73,7 +73,9 @@ class AqaraDoorWindowSensor(Sensor, ZigbeeMixin, BatteryMixin):
                 key = int(data[0])
                 data_value, data = TypeValue.deserialize(data[1:])
 
-                additional_attributes[key] = data_value
+                additional_attributes[key] = data_value.value
+
+                self.log_debug(f'{key}: {additional_attributes[key]}')
 
                 # we only care about the battery voltage
                 if key == self.BATTERY_VOLTAGE_ATTRIBUTE:
@@ -81,7 +83,8 @@ class AqaraDoorWindowSensor(Sensor, ZigbeeMixin, BatteryMixin):
 
             # if the battery voltage attribute is included
             if self.BATTERY_VOLTAGE_ATTRIBUTE in additional_attributes:
-                voltage = additional_attributes[self.BATTERY_VOLTAGE_ATTRIBUTE].value
+                voltage = additional_attributes[self.BATTERY_VOLTAGE_ATTRIBUTE]
+                self.log_info(f'Received battery value of {voltage}mV')
 
                 # ensure voltage is in the expected range
                 voltage = max(voltage, self.MIN_VOLTAGE)

--- a/controllers/zigbee/zigbee_controller/sensor/aqara/door_window_sensor.py
+++ b/controllers/zigbee/zigbee_controller/sensor/aqara/door_window_sensor.py
@@ -1,15 +1,10 @@
-from enum import Enum
+from zigpy.zcl.clusters.general import OnOff as OnOffCluster
 
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt.client import MQTTClient
 from powerpi_common.sensor.sensor import Sensor
 from zigbee_controller.device import ZigbeeController
-from zigbee_controller.zigbee import ClusterGeneralCommandListener, ZigbeeMixin
-
-
-class OnOff(int, Enum):
-    OFF = 0
-    ON = 1
+from zigbee_controller.zigbee import ClusterGeneralCommandListener, OnOff, ZigbeeMixin
 
 
 class AqaraDoorWindowSensor(Sensor, ZigbeeMixin):
@@ -40,7 +35,7 @@ class AqaraDoorWindowSensor(Sensor, ZigbeeMixin):
         if on_off == OnOff.ON:
             state = 'open'
         elif on_off == OnOff.OFF:
-            state = 'closed'
+            state = 'close'
 
         if state:
             message = {"state": state}
@@ -51,7 +46,7 @@ class AqaraDoorWindowSensor(Sensor, ZigbeeMixin):
         device = self._zigbee_device
 
         # open/close
-        device[1].in_clusters[6].add_listener(
+        device[1].in_clusters[OnOffCluster.cluster_id].add_listener(
             ClusterGeneralCommandListener(
                 lambda _, args: self.open_close_handler(args[0][0].value.value)
             )

--- a/controllers/zigbee/zigbee_controller/sensor/aqara/door_window_sensor.py
+++ b/controllers/zigbee/zigbee_controller/sensor/aqara/door_window_sensor.py
@@ -10,7 +10,7 @@ from powerpi_common.mqtt import MQTTClient
 from powerpi_common.sensor import Sensor
 from powerpi_common.sensor.mixin.battery import BatteryMixin
 from zigbee_controller.device import ZigbeeController
-from zigbee_controller.zigbee import ClusterGeneralCommandListener, OnOff, ZigbeeMixin
+from zigbee_controller.zigbee import ClusterGeneralCommandListener, OnOff, OpenClose, ZigbeeMixin
 
 
 class AqaraDoorWindowSensor(Sensor, ZigbeeMixin, PollableMixin, BatteryMixin):
@@ -40,8 +40,6 @@ class AqaraDoorWindowSensor(Sensor, ZigbeeMixin, PollableMixin, BatteryMixin):
 
         self.__logger = logger
 
-        self.__register()
-
     async def poll(self):
         pass
 
@@ -50,16 +48,16 @@ class AqaraDoorWindowSensor(Sensor, ZigbeeMixin, PollableMixin, BatteryMixin):
 
         state = None
         if on_off == OnOff.ON:
-            state = 'open'
+            state = OpenClose.OPEN
         elif on_off == OnOff.OFF:
-            state = 'close'
+            state = OpenClose.CLOSE
 
         if state:
             message = {"state": state}
 
             self._broadcast('change', message)
 
-    def __register(self):
+    async def initialise(self):
         device = self._zigbee_device
 
         def parse(args: List[List[Attribute]]):

--- a/controllers/zigbee/zigbee_controller/sensor/osram/switch_mini.py
+++ b/controllers/zigbee/zigbee_controller/sensor/osram/switch_mini.py
@@ -5,7 +5,7 @@ from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
 from powerpi_common.sensor import Sensor
 from zigbee_controller.device import ZigbeeController
-from zigbee_controller.zigbee import ClusterListener, ZigbeeMixin
+from zigbee_controller.zigbee import ClusterCommandListener, ZigbeeMixin
 
 
 class Button(str, Enum):
@@ -96,30 +96,30 @@ class OsramSwitchMiniSensor(Sensor, ZigbeeMixin):
 
         # single press
         device[1].out_clusters[6].add_listener(
-            ClusterListener(lambda _, __, ___: self.button_press_handler(
+            ClusterCommandListener(lambda _, __, ___: self.button_press_handler(
                 Button.UP, PressType.SINGLE)
             )
         )
         device[2].out_clusters[6].add_listener(
-            ClusterListener(lambda _, __, ___: self.button_press_handler(
+            ClusterCommandListener(lambda _, __, ___: self.button_press_handler(
                 Button.DOWN, PressType.SINGLE))
         )
         device[3].out_clusters[8].add_listener(
-            ClusterListener(lambda _, __, ___: self.button_press_handler(
+            ClusterCommandListener(lambda _, __, ___: self.button_press_handler(
                 Button.MIDDLE, PressType.SINGLE))
         )
 
         # long press
         device[1].out_clusters[8].add_listener(
-            ClusterListener(
+            ClusterCommandListener(
                 lambda _, __, args: self.long_button_press_handler(Button.UP, args))
         )
         device[2].out_clusters[8].add_listener(
-            ClusterListener(
+            ClusterCommandListener(
                 lambda _, __, args: self.long_button_press_handler(Button.DOWN, args))
         )
         device[3].out_clusters[768].add_listener(
-            ClusterListener(
+            ClusterCommandListener(
                 lambda _, __, args: self.long_middle_button_press_handler(args))
         )
 

--- a/controllers/zigbee/zigbee_controller/sensor/osram/switch_mini.py
+++ b/controllers/zigbee/zigbee_controller/sensor/osram/switch_mini.py
@@ -65,8 +65,6 @@ class OsramSwitchMiniSensor(Sensor, ZigbeeMixin):
 
         self.__logger = logger
 
-        self.__register()
-
     def button_press_handler(self, button: Button, press_type: PressType):
         self.__logger.info(f'Received {press_type} press of {button}')
 
@@ -99,7 +97,7 @@ class OsramSwitchMiniSensor(Sensor, ZigbeeMixin):
 
             self.button_press_handler(Button.MIDDLE, press_type)
 
-    def __register(self):
+    async def initialise(self):
         device = self._zigbee_device
 
         # single press

--- a/controllers/zigbee/zigbee_controller/sensor/osram/switch_mini.py
+++ b/controllers/zigbee/zigbee_controller/sensor/osram/switch_mini.py
@@ -58,12 +58,10 @@ class OsramSwitchMiniSensor(Sensor, ZigbeeMixin):
         logger: Logger,
         controller: ZigbeeController,
         mqtt_client: MQTTClient,
-        ieee: str,
-        nwk: str,
         **kwargs
     ):
         Sensor.__init__(self, mqtt_client, **kwargs)
-        ZigbeeMixin.__init__(self, controller, ieee, nwk)
+        ZigbeeMixin.__init__(self, controller, **kwargs)
 
         self.__logger = logger
 

--- a/controllers/zigbee/zigbee_controller/sensor/osram/switch_mini.py
+++ b/controllers/zigbee/zigbee_controller/sensor/osram/switch_mini.py
@@ -5,7 +5,7 @@ from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
 from powerpi_common.sensor import Sensor
 from zigbee_controller.device import ZigbeeController
-from zigbee_controller.zigbee import ClusterListener, ZigbeeDevice
+from zigbee_controller.zigbee import ClusterListener, ZigbeeMixin
 
 
 class Button(str, Enum):
@@ -20,7 +20,7 @@ class PressType(str, Enum):
     RELEASE = 'release'
 
 
-class OsramSwitchMiniSensor(Sensor, ZigbeeDevice):
+class OsramSwitchMiniSensor(Sensor, ZigbeeMixin):
     ''' Adds support for Osram Smart+ Switch Mini
         Generates the following events on button clicks where NAME is the
         configured name of the device.
@@ -53,7 +53,7 @@ class OsramSwitchMiniSensor(Sensor, ZigbeeDevice):
         **kwargs
     ):
         Sensor.__init__(self, mqtt_client, **kwargs)
-        ZigbeeDevice.__init__(self, controller, ieee, nwk)
+        ZigbeeMixin.__init__(self, controller, ieee, nwk)
 
         self.__logger = logger
 
@@ -124,4 +124,4 @@ class OsramSwitchMiniSensor(Sensor, ZigbeeDevice):
         )
 
     def __str__(self):
-        return ZigbeeDevice.__str__(self)
+        return ZigbeeMixin.__str__(self)

--- a/controllers/zigbee/zigbee_controller/sensor/osram/switch_mini.py
+++ b/controllers/zigbee/zigbee_controller/sensor/osram/switch_mini.py
@@ -30,25 +30,26 @@ class PressType(str, Enum):
 
 
 class OsramSwitchMiniSensor(Sensor, ZigbeeMixin):
-    ''' Adds support for Osram Smart+ Switch Mini
-        Generates the following events on button clicks where NAME is the
-        configured name of the device.
+    ''' 
+    Adds support for Osram Smart+ Switch Mini
+    Generates the following events on button clicks where NAME is the
+    configured name of the device.
 
-        Single press:
-        /event/NAME/press:{"button": "up", "type": "single"}
-        /event/NAME/press:{"button": "middle", "type": "single"}
-        /event/NAME/press:{"button": "down", "type": "single"}
+    Single press:
+    /event/NAME/press:{"button": "up", "type": "single"}
+    /event/NAME/press:{"button": "middle", "type": "single"}
+    /event/NAME/press:{"button": "down", "type": "single"}
 
-        Long press generates an event pair, one when the button is pressed and
-        the other when it's released:
-        /event/NAME/press:{"button": "up", "type": "hold"}
-        /event/NAME/press:{"button": "up", "type": "release"}
+    Long press generates an event pair, one when the button is pressed and
+    the other when it's released:
+    /event/NAME/press:{"button": "up", "type": "hold"}
+    /event/NAME/press:{"button": "up", "type": "release"}
 
-        /event/NAME/press:{"button": "middle", "type": "hold"}
-        /event/NAME/press:{"button": "middle", "type": "release"}
+    /event/NAME/press:{"button": "middle", "type": "hold"}
+    /event/NAME/press:{"button": "middle", "type": "release"}
 
-        /event/NAME/press:{"button": "down", "type": "hold"}
-        /event/NAME/press:{"button": "down", "type": "release"}
+    /event/NAME/press:{"button": "down", "type": "hold"}
+    /event/NAME/press:{"button": "down", "type": "release"}
     '''
 
     #pylint: disable=too-many-arguments

--- a/controllers/zigbee/zigbee_controller/sensor/osram/switch_mini.py
+++ b/controllers/zigbee/zigbee_controller/sensor/osram/switch_mini.py
@@ -63,10 +63,10 @@ class OsramSwitchMiniSensor(Sensor, ZigbeeMixin):
         Sensor.__init__(self, mqtt_client, **kwargs)
         ZigbeeMixin.__init__(self, controller, **kwargs)
 
-        self.__logger = logger
+        self._logger = logger
 
     def button_press_handler(self, button: Button, press_type: PressType):
-        self.__logger.info(f'Received {press_type} press of {button}')
+        self.log_info(f'Received {press_type} press of {button}')
 
         message = {
             'button': button,

--- a/controllers/zigbee/zigbee_controller/sensor/osram/switch_mini.py
+++ b/controllers/zigbee/zigbee_controller/sensor/osram/switch_mini.py
@@ -1,11 +1,20 @@
 from enum import Enum
 from typing import List
 
+from zigpy.zcl.clusters.general import LevelControl, OnOff
+from zigpy.zcl.clusters.lighting import Color
+
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
 from powerpi_common.sensor import Sensor
 from zigbee_controller.device import ZigbeeController
 from zigbee_controller.zigbee import ClusterCommandListener, ZigbeeMixin
+
+
+class ButtonEndpoint(int, Enum):
+    UP = 1
+    MIDDLE = 3
+    DOWN = 2
 
 
 class Button(str, Enum):
@@ -95,32 +104,41 @@ class OsramSwitchMiniSensor(Sensor, ZigbeeMixin):
         device = self._zigbee_device
 
         # single press
-        device[1].out_clusters[6].add_listener(
+        device[ButtonEndpoint.UP].out_clusters[OnOff.cluster_id].add_listener(
             ClusterCommandListener(lambda _, __, ___: self.button_press_handler(
-                Button.UP, PressType.SINGLE)
-            )
+                Button.UP, PressType.SINGLE
+            ))
         )
-        device[2].out_clusters[6].add_listener(
+        device[ButtonEndpoint.DOWN].out_clusters[OnOff.cluster_id].add_listener(
             ClusterCommandListener(lambda _, __, ___: self.button_press_handler(
-                Button.DOWN, PressType.SINGLE))
+                Button.DOWN, PressType.SINGLE
+            ))
         )
-        device[3].out_clusters[8].add_listener(
+        device[ButtonEndpoint.MIDDLE].out_clusters[LevelControl.cluster_id].add_listener(
             ClusterCommandListener(lambda _, __, ___: self.button_press_handler(
-                Button.MIDDLE, PressType.SINGLE))
+                Button.MIDDLE, PressType.SINGLE
+            ))
         )
 
         # long press
-        device[1].out_clusters[8].add_listener(
+        device[ButtonEndpoint.UP].out_clusters[LevelControl.cluster_id].add_listener(
             ClusterCommandListener(
-                lambda _, __, args: self.long_button_press_handler(Button.UP, args))
+                lambda _, __, args: self.long_button_press_handler(
+                    Button.UP, args
+                )
+            )
         )
-        device[2].out_clusters[8].add_listener(
+        device[ButtonEndpoint.DOWN].out_clusters[LevelControl.cluster_id].add_listener(
             ClusterCommandListener(
-                lambda _, __, args: self.long_button_press_handler(Button.DOWN, args))
+                lambda _, __, args: self.long_button_press_handler(
+                    Button.DOWN, args
+                )
+            )
         )
-        device[3].out_clusters[768].add_listener(
+        device[ButtonEndpoint.MIDDLE].out_clusters[Color.cluster_id].add_listener(
             ClusterCommandListener(
-                lambda _, __, args: self.long_middle_button_press_handler(args))
+                lambda _, __, args: self.long_middle_button_press_handler(args)
+            )
         )
 
     def __str__(self):

--- a/controllers/zigbee/zigbee_controller/zigbee/__init__.py
+++ b/controllers/zigbee/zigbee_controller/zigbee/__init__.py
@@ -1,2 +1,3 @@
 from .cluster_listener import ClusterCommandListener, ClusterGeneralCommandListener
+from .constants import OnOff
 from .device import ZigbeeMixin

--- a/controllers/zigbee/zigbee_controller/zigbee/__init__.py
+++ b/controllers/zigbee/zigbee_controller/zigbee/__init__.py
@@ -1,2 +1,2 @@
-from .cluster_listener import ClusterListener
+from .cluster_listener import ClusterCommandListener, ClusterGeneralCommandListener
 from .device import ZigbeeMixin

--- a/controllers/zigbee/zigbee_controller/zigbee/__init__.py
+++ b/controllers/zigbee/zigbee_controller/zigbee/__init__.py
@@ -1,3 +1,4 @@
-from .cluster_listener import ClusterCommandListener, ClusterGeneralCommandListener
+from .cluster_listener import ClusterAttributeListener, ClusterCommandListener, \
+    ClusterGeneralCommandListener
 from .constants import OnOff, OpenClose
 from .device import ZigbeeMixin

--- a/controllers/zigbee/zigbee_controller/zigbee/__init__.py
+++ b/controllers/zigbee/zigbee_controller/zigbee/__init__.py
@@ -1,3 +1,3 @@
 from .cluster_listener import ClusterCommandListener, ClusterGeneralCommandListener
-from .constants import OnOff
+from .constants import OnOff, OpenClose
 from .device import ZigbeeMixin

--- a/controllers/zigbee/zigbee_controller/zigbee/__init__.py
+++ b/controllers/zigbee/zigbee_controller/zigbee/__init__.py
@@ -1,2 +1,2 @@
 from .cluster_listener import ClusterListener
-from .device import ZigbeeDevice
+from .device import ZigbeeMixin

--- a/controllers/zigbee/zigbee_controller/zigbee/cluster_listener.py
+++ b/controllers/zigbee/zigbee_controller/zigbee/cluster_listener.py
@@ -1,6 +1,8 @@
 from abc import ABC
 from typing import Any, Callable, List
 
+from zigpy.zcl.foundation import Attribute, ZCLHeader
+
 
 class ClusterListener(ABC):
     def __init__(self, method: Callable):
@@ -16,9 +18,9 @@ class ClusterCommandListener(ClusterListener):
 
 
 class ClusterGeneralCommandListener(ClusterListener):
-    def __init__(self, method: Callable[[Any, List[Any]], None]):
+    def __init__(self, method: Callable[[ZCLHeader, List[List[Attribute]]], None]):
         ClusterListener.__init__(self, method)
 
-    def general_command(self, hdr, args: List[Any]):
+    def general_command(self, hdr: ZCLHeader, args: List[List[Attribute]]):
         print(args)
         self._listener(hdr, args)

--- a/controllers/zigbee/zigbee_controller/zigbee/cluster_listener.py
+++ b/controllers/zigbee/zigbee_controller/zigbee/cluster_listener.py
@@ -22,5 +22,4 @@ class ClusterGeneralCommandListener(ClusterListener):
         ClusterListener.__init__(self, method)
 
     def general_command(self, hdr: ZCLHeader, args: List[List[Attribute]]):
-        print(args)
         self._listener(hdr, args)

--- a/controllers/zigbee/zigbee_controller/zigbee/cluster_listener.py
+++ b/controllers/zigbee/zigbee_controller/zigbee/cluster_listener.py
@@ -1,9 +1,24 @@
+from abc import ABC
 from typing import Any, Callable, List
 
 
-class ClusterListener:
+class ClusterListener(ABC):
+    def __init__(self, method: Callable):
+        self._listener = method
+
+
+class ClusterCommandListener(ClusterListener):
     def __init__(self, method: Callable[[int, int, List[Any]], None]):
-        self.__listener = method
+        ClusterListener.__init__(self, method)
 
     def cluster_command(self, tsn: int, command_id: int, *args):
-        self.__listener(tsn, command_id, args)
+        self._listener(tsn, command_id, args)
+
+
+class ClusterGeneralCommandListener(ClusterListener):
+    def __init__(self, method: Callable[[Any, List[Any]], None]):
+        ClusterListener.__init__(self, method)
+
+    def general_command(self, hdr, args: List[Any]):
+        print(args)
+        self._listener(hdr, args)

--- a/controllers/zigbee/zigbee_controller/zigbee/cluster_listener.py
+++ b/controllers/zigbee/zigbee_controller/zigbee/cluster_listener.py
@@ -9,6 +9,14 @@ class ClusterListener(ABC):
         self._listener = method
 
 
+class ClusterAttributeListener(ClusterListener):
+    def __init__(self, method: Callable[[int, Any], None]):
+        ClusterListener.__init__(self, method)
+
+    def attribute_updated(self, attribute_id: int, value: Any):
+        self._listener(attribute_id, value)
+
+
 class ClusterCommandListener(ClusterListener):
     def __init__(self, method: Callable[[int, int, List[Any]], None]):
         ClusterListener.__init__(self, method)

--- a/controllers/zigbee/zigbee_controller/zigbee/constants.py
+++ b/controllers/zigbee/zigbee_controller/zigbee/constants.py
@@ -4,3 +4,8 @@ from enum import Enum
 class OnOff(int, Enum):
     OFF = 0
     ON = 1
+
+
+class OpenClose(str, Enum):
+    CLOSE = 'close',
+    OPEN = 'open'

--- a/controllers/zigbee/zigbee_controller/zigbee/constants.py
+++ b/controllers/zigbee/zigbee_controller/zigbee/constants.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class OnOff(int, Enum):
+    OFF = 0
+    ON = 1

--- a/controllers/zigbee/zigbee_controller/zigbee/device.py
+++ b/controllers/zigbee/zigbee_controller/zigbee/device.py
@@ -11,7 +11,8 @@ class ZigbeeMixin(ABC):
         self,
         controller: ZigbeeController,
         ieee: str,
-        nwk: str
+        nwk: str,
+        **_
     ):
         self.__controller = controller
         self.__ieee = EUI64.convert(ieee)

--- a/controllers/zigbee/zigbee_controller/zigbee/device.py
+++ b/controllers/zigbee/zigbee_controller/zigbee/device.py
@@ -1,12 +1,11 @@
-from abc import ABC
-
 from zigpy.types import EUI64
 from zigpy.typing import DeviceType
 
+from powerpi_common.device.mixin import InitialisableMixin
 from zigbee_controller.device import ZigbeeController
 
 
-class ZigbeeMixin(ABC):
+class ZigbeeMixin(InitialisableMixin):
     def __init__(
         self,
         controller: ZigbeeController,

--- a/controllers/zigbee/zigbee_controller/zigbee/device.py
+++ b/controllers/zigbee/zigbee_controller/zigbee/device.py
@@ -6,7 +6,7 @@ from zigpy.typing import DeviceType
 from zigbee_controller.device import ZigbeeController
 
 
-class ZigbeeDevice(ABC):
+class ZigbeeMixin(ABC):
     def __init__(
         self,
         controller: ZigbeeController,

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -69,7 +69,7 @@ services:
             - deep-thought
 
     macro-controller:
-        image: ${REGISTRY}/powerpi/controllers/macro:1.1.4
+        image: ${REGISTRY}/powerpi/controllers/macro:1.1.5
         networks:
             - powerpi
         deploy:
@@ -97,7 +97,7 @@ services:
             - /var/run/docker.sock:/var/run/docker.sock
 
     harmony-controller:
-        image: ${REGISTRY}/powerpi/controllers/harmony:0.1.2
+        image: ${REGISTRY}/powerpi/controllers/harmony:0.1.3
         networks:
             - powerpi
         deploy:
@@ -106,7 +106,7 @@ services:
             - mosquitto
 
     lifx-controller:
-        image: ${REGISTRY}/powerpi/controllers/lifx:0.1.2
+        image: ${REGISTRY}/powerpi/controllers/lifx:0.1.3
         networks:
             - powerpi
         deploy:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -128,7 +128,7 @@ services:
         environment:
             - ENV=ZIGBEE_DEVICE=/dev/ttyACM0:DATABASE_PATH=/var/data/zigbee.db
             - CONTROLLER_NAME=zigbee-controller
-            - IMAGE=${REGISTRY}/powerpi/controllers/zigbee:0.1.3
+            - IMAGE=${REGISTRY}/powerpi/controllers/zigbee:0.1.4
             - DEVICE=/dev/ttyACM0
             - VOLUME=/srv/docker-volumes/powerpi/zigbee-controller
         volumes:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -91,7 +91,7 @@ services:
         environment:
             - ENV=ENERGENIE_DEVICE=ENER314-RT:DEVICE_FATAL=true
             - CONTROLLER_NAME=energenie-controller
-            - IMAGE=${REGISTRY}/powerpi/controllers/energenie:0.1.4
+            - IMAGE=${REGISTRY}/powerpi/controllers/energenie:0.1.5
             - DEVICE=/dev/gpiomem
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
- Resolve #130 to support Aqara door/window sensor in `zigbee_controller`.
  - Use some of the constants from `zigpy` for both supported sensors.
  - Add `BatteryMixin` to support broadcasting battery level.
  - Use `IntiailisableMixin` in ZigBee devices instead of the old `register` method call in their constructors.
  - Make `ZigbeeDevice` a mixin as `ZigbeeMixin`.
  - Update documentation.
- Resolve #134 by extending `PollableMixin` to support passing in the `poll_frequency` (not actually required for the sensor it seems).
  - Requires update to all controllers except `energenie_controller`.
  - Refactor `DeviceStatusChecker` to group devices by `poll_frequency` to schedule their polling together and to support polling sensors.
- Fix #127 in `lifx_controller` by switching the order of power state and additional state change.
- Fix #136 timezone bug in controllers by setting timezone to UTC in Dockerfile.
  - Requires update to all controllers.