### PR TITLE
#124 Add sensor battery value to API response

### DIFF
--- a/babel-fish/package.json
+++ b/babel-fish/package.json
@@ -17,7 +17,7 @@
         "build-platform": "./node_modules/jovo-cli/bin/run build"
     },
     "dependencies": {
-        "@powerpi/api": "^0.0.8",
+        "@powerpi/api": "^0.0.9",
         "@powerpi/common": "^0.0.6",
         "@types/express": "^4.17.12",
         "@types/node": "^16.11.12",

--- a/common/node/api/package.json
+++ b/common/node/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@powerpi/api",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "description": "PowerPi API Common Typescript library",
     "private": true,
     "license": "GPL-3.0-only",

--- a/common/node/api/src/SensorStatus.ts
+++ b/common/node/api/src/SensorStatus.ts
@@ -4,6 +4,8 @@ export interface SensorStatusMessage {
     value?: number;
     unit?: string;
     timestamp: number;
+    battery?: number;
+    batteryTimestamp?: number;
 }
 
 export type SensorStatusCallback = (message: SensorStatusMessage) => void;

--- a/deep-thought/package.json
+++ b/deep-thought/package.json
@@ -1,6 +1,6 @@
 {
     "name": "deep-thought",
-    "version": "0.5.11",
+    "version": "0.5.12",
     "description": "PowerPi API",
     "private": true,
     "license": "GPL-3.0-only",

--- a/deep-thought/src/models/sensor.ts
+++ b/deep-thought/src/models/sensor.ts
@@ -7,4 +7,6 @@ export interface Sensor extends ISensor {
     value: number | undefined;
     unit: string | undefined;
     since: number;
+    battery: number | undefined;
+    batterySince: number | undefined;
 }

--- a/deep-thought/src/services/sensorState.ts
+++ b/deep-thought/src/services/sensorState.ts
@@ -41,4 +41,8 @@ class SensorConsumer extends SensorStateListener {
     protected onSensorDataMessage(_: string, __: number, ___: string, ____?: number): void {
         return;
     }
+
+    protected onSensorBatteryMessage(_: string, __: number, ___?: number): void {
+        return;
+    }
 }

--- a/deep-thought/src/services/socketService.ts
+++ b/deep-thought/src/services/socketService.ts
@@ -50,7 +50,9 @@ export default class ApiSocketService {
         state?: string,
         value?: number,
         unit?: string,
-        timestamp?: number
+        timestamp?: number,
+        battery?: number,
+        batteryTimestamp?: number
     ) {
         this.namespace?.emit("sensor", {
             sensor: sensorName,
@@ -58,6 +60,8 @@ export default class ApiSocketService {
             value,
             unit,
             timestamp,
+            battery,
+            batteryTimestamp,
         });
     }
 
@@ -104,5 +108,17 @@ class SensorListener extends SensorStateListener {
         timestamp?: number
     ): void {
         this.socketService.onEventMessage(sensorName, undefined, value, unit, timestamp);
+    }
+
+    protected onSensorBatteryMessage(sensorName: string, value: number, timestamp?: number): void {
+        this.socketService.onEventMessage(
+            sensorName,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            value,
+            timestamp
+        );
     }
 }

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -156,7 +156,7 @@ services:
             - FREEDNS_PASSWORD=/var/run/secrets/powerpi_freedns
 
     nginx:
-        image: ${REGISTRY}/powerpi/nginx:1.2.9
+        image: ${REGISTRY}/powerpi/nginx:1.2.10
         networks:
             - powerpi
         ports:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -31,7 +31,7 @@ services:
             - FILE_PATH=docker/config
 
     deep-thought:
-        image: ${REGISTRY}/powerpi/deep-thought:0.5.11
+        image: ${REGISTRY}/powerpi/deep-thought:0.5.12
         networks:
             - powerpi
         deploy:

--- a/nginx/ui/package.json
+++ b/nginx/ui/package.json
@@ -22,7 +22,7 @@
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/free-solid-svg-icons": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.1.18",
-        "@powerpi/api": "^0.0.8",
+        "@powerpi/api": "^0.0.9",
         "chart.js": "^3.7.0",
         "chartjs-adapter-luxon": "^1.1.0",
         "classnames": "^2.3.1",

--- a/nginx/ui/package.json
+++ b/nginx/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@powerpi/ui",
-    "version": "1.2.9",
+    "version": "1.2.10",
     "description": "PowerPi UI",
     "private": true,
     "license": "GPL-3.0-only",

--- a/nginx/ui/src/hooks/sensors.ts
+++ b/nginx/ui/src/hooks/sensors.ts
@@ -22,11 +22,24 @@ export default function useGetSensors() {
             if (index !== -1) {
                 const newSensors = [...sensors];
 
-                newSensors[index] = { ...newSensors[index] };
-                newSensors[index].state = message.state;
-                newSensors[index].value = message.value;
-                newSensors[index].unit = message.unit;
-                newSensors[index].since = message.timestamp;
+                const newSensor = { ...newSensors[index] };
+                newSensors[index] = newSensor;
+
+                if (message.state !== undefined) {
+                    newSensor.state = message.state;
+                    newSensor.since = message.timestamp;
+                }
+
+                if (message.value !== undefined) {
+                    newSensor.value = message.value;
+                    newSensor.unit = message.unit;
+                    newSensor.since = message.timestamp;
+                }
+
+                if (message.battery !== undefined) {
+                    newSensor.battery = message.battery;
+                    newSensor.batterySince = message.batteryTimestamp;
+                }
 
                 setSensors(newSensors);
             }


### PR DESCRIPTION
- Add sensor's battery level and when it was last updated to the response from the API.
- Update the UI to also expect the sensor's battery level from socket.io.