### PR TITLE
#122 Add support for variables in controllers

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,6 @@
 [MESSAGES CONTROL]
 disable=
+    c-extension-no-member,
     missing-class-docstring,
     missing-function-docstring,
     missing-module-docstring,

--- a/common/pytest/powerpi_common_test/base.py
+++ b/common/pytest/powerpi_common_test/base.py
@@ -1,0 +1,9 @@
+from abc import ABC, abstractmethod
+
+from pytest_mock import MockerFixture
+
+
+class BaseTest(ABC):
+    @abstractmethod
+    def create_subject(self, _: MockerFixture) -> object:
+        raise NotImplementedError

--- a/common/pytest/powerpi_common_test/variable/__init__.py
+++ b/common/pytest/powerpi_common_test/variable/__init__.py
@@ -1,0 +1,1 @@
+from .variable import VariableTestBase

--- a/common/pytest/powerpi_common_test/variable/variable.py
+++ b/common/pytest/powerpi_common_test/variable/variable.py
@@ -1,3 +1,4 @@
+import re
 from abc import ABC, abstractmethod
 
 from pytest_mock import MockerFixture
@@ -23,3 +24,11 @@ class VariableTestBase(ABC):
 
         assert subject.json is not None
         assert isinstance(subject.json, dict)
+
+    def test_str(self, mocker: MockerFixture):
+        subject = self.create_subject(mocker)
+
+        assert bool(re.match(
+            r"^var\.(device|sensor)\..*=\{.*\}$",
+            str(subject))
+        ) is True

--- a/common/pytest/powerpi_common_test/variable/variable.py
+++ b/common/pytest/powerpi_common_test/variable/variable.py
@@ -1,14 +1,11 @@
 import re
-from abc import ABC, abstractmethod
 
 from pytest_mock import MockerFixture
 
+from powerpi_common_test.base import BaseTest
 
-class VariableTestBase(ABC):
-    @abstractmethod
-    def create_subject(self, _: MockerFixture):
-        raise NotImplementedError
 
+class VariableTestBase(BaseTest):
     def test_name(self, mocker: MockerFixture):
         subject = self.create_subject(mocker)
 

--- a/common/pytest/powerpi_common_test/variable/variable.py
+++ b/common/pytest/powerpi_common_test/variable/variable.py
@@ -1,0 +1,25 @@
+from abc import ABC, abstractmethod
+
+from pytest_mock import MockerFixture
+
+
+class VariableTestBase(ABC):
+    @abstractmethod
+    def create_subject(self, _: MockerFixture):
+        raise NotImplementedError
+
+    def test_name(self, mocker: MockerFixture):
+        subject = self.create_subject(mocker)
+
+        assert subject.name is not None
+
+    def test_variable_type(self, mocker: MockerFixture):
+        subject = self.create_subject(mocker)
+
+        assert subject.variable_type is not None
+
+    def test_json(self, mocker: MockerFixture):
+        subject = self.create_subject(mocker)
+
+        assert subject.json is not None
+        assert isinstance(subject.json, dict)

--- a/common/pytest/powerpi_common_test/variable/variable.py
+++ b/common/pytest/powerpi_common_test/variable/variable.py
@@ -26,6 +26,6 @@ class VariableTestBase(BaseTest):
         subject = self.create_subject(mocker)
 
         assert bool(re.match(
-            r"^var\.(device|sensor)\..*=\{.*\}$",
-            str(subject))
-        ) is True
+            r'^var\.(device|sensor)\..*=\{.*\}$',
+            str(subject)
+        )) is True

--- a/common/pytest/pyproject.toml
+++ b/common/pytest/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "powerpi-common-test"
-version = "0.2.1"
+version = "0.2.2"
 description = "PowerPi Common Python Test Library"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/common/python/powerpi_common/container.py
+++ b/common/python/powerpi_common/container.py
@@ -6,7 +6,8 @@ from powerpi_common.controller import Controller
 from powerpi_common.logger import Logger
 from powerpi_common.device import DeviceContainer
 from powerpi_common.event import EventManager
-from powerpi_common.mqtt.client import MQTTClient
+from powerpi_common.mqtt import MQTTClient
+from powerpi_common.variable import VariableContainer
 
 
 class Container(containers.DeclarativeContainer):
@@ -48,6 +49,14 @@ class Container(containers.DeclarativeContainer):
         config=config,
         logger=logger,
         mqtt_client=mqtt_client
+    )
+
+    variable = providers.Container(
+        VariableContainer,
+        config=config,
+        logger=logger,
+        mqtt_client=mqtt_client,
+        device_manager=device.device_manager
     )
 
     event_manager = providers.Singleton(

--- a/common/python/powerpi_common/sensor/consumers/__init__.py
+++ b/common/python/powerpi_common/sensor/consumers/__init__.py
@@ -1,0 +1,1 @@
+from .sensor_event_consumer import SensorEventConsumer

--- a/common/python/powerpi_common/sensor/consumers/sensor_event_consumer.py
+++ b/common/python/powerpi_common/sensor/consumers/sensor_event_consumer.py
@@ -1,0 +1,25 @@
+from powerpi_common.config import Config
+from powerpi_common.logger import Logger
+from powerpi_common.mqtt import MQTTConsumer, MQTTMessage
+from powerpi_common.typing import SensorType
+
+
+class SensorEventConsumer(MQTTConsumer):
+    def __init__(
+        self,
+        topic: str,
+        sensor: SensorType,
+        config: Config,
+        logger: Logger
+    ):
+        MQTTConsumer.__init__(self, topic, config, logger)
+
+        self._sensor = sensor
+
+    async def on_message(self, message: MQTTMessage, entity: str, action: str):
+        value = message.get('value')
+        unit = message.get('unit')
+
+        if value is not None and unit is not None:
+            value = float(value)
+            self._sensor.value = (value, unit)

--- a/common/python/powerpi_common/variable/__init__.py
+++ b/common/python/powerpi_common/variable/__init__.py
@@ -1,2 +1,4 @@
+from .container import VariableContainer
 from .device import DeviceVariable
+from .manager import VariableManager
 from .types import VariableType

--- a/common/python/powerpi_common/variable/__init__.py
+++ b/common/python/powerpi_common/variable/__init__.py
@@ -1,4 +1,5 @@
 from .container import VariableContainer
 from .device import DeviceVariable
 from .manager import VariableManager
+from .sensor import SensorVariable
 from .types import VariableType

--- a/common/python/powerpi_common/variable/__init__.py
+++ b/common/python/powerpi_common/variable/__init__.py
@@ -1,0 +1,2 @@
+from .device import DeviceVariable
+from .types import VariableType

--- a/common/python/powerpi_common/variable/container.py
+++ b/common/python/powerpi_common/variable/container.py
@@ -1,0 +1,34 @@
+from dependency_injector import containers, providers
+
+from powerpi_common.variable.device import DeviceVariable
+from powerpi_common.variable.manager import VariableManager
+
+
+class VariableContainer(containers.DeclarativeContainer):
+    __self__ = providers.Self()
+
+    service_provider = providers.Singleton(
+        __self__
+    )
+
+    config = providers.Dependency()
+
+    logger = providers.Dependency()
+
+    mqtt_client = providers.Dependency()
+
+    device_manager = providers.Dependency()
+
+    variable_manager = providers.Singleton(
+        VariableManager,
+        logger=logger,
+        device_manager=device_manager,
+        service_provider=service_provider
+    )
+
+    device_variable = providers.Factory(
+        DeviceVariable,
+        config=config,
+        logger=logger,
+        mqtt_client=mqtt_client
+    )

--- a/common/python/powerpi_common/variable/container.py
+++ b/common/python/powerpi_common/variable/container.py
@@ -2,6 +2,7 @@ from dependency_injector import containers, providers
 
 from powerpi_common.variable.device import DeviceVariable
 from powerpi_common.variable.manager import VariableManager
+from powerpi_common.variable.sensor import SensorVariable
 
 
 class VariableContainer(containers.DeclarativeContainer):
@@ -30,5 +31,10 @@ class VariableContainer(containers.DeclarativeContainer):
         DeviceVariable,
         config=config,
         logger=logger,
+        mqtt_client=mqtt_client
+    )
+
+    sensor_variable = providers.Factory(
+        SensorVariable,
         mqtt_client=mqtt_client
     )

--- a/common/python/powerpi_common/variable/container.py
+++ b/common/python/powerpi_common/variable/container.py
@@ -36,5 +36,7 @@ class VariableContainer(containers.DeclarativeContainer):
 
     sensor_variable = providers.Factory(
         SensorVariable,
+        config=config,
+        logger=logger,
         mqtt_client=mqtt_client
     )

--- a/common/python/powerpi_common/variable/device.py
+++ b/common/python/powerpi_common/variable/device.py
@@ -1,13 +1,16 @@
+from typing import List
+
 from powerpi_common.config import Config
 from powerpi_common.device import DeviceStatus
 from powerpi_common.device.consumers import DeviceStatusEventConsumer
+from powerpi_common.device.mixin import AdditionalState, AdditionalStateMixin
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
 from powerpi_common.variable.types import VariableType
 from powerpi_common.variable.variable import Variable
 
 
-class DeviceVariable(Variable, DeviceStatusEventConsumer):
+class DeviceVariable(Variable, DeviceStatusEventConsumer, AdditionalStateMixin):
     def __init__(
         self,
         config: Config,
@@ -19,6 +22,7 @@ class DeviceVariable(Variable, DeviceStatusEventConsumer):
         DeviceStatusEventConsumer.__init__(self, self, config, logger)
 
         self.__state = DeviceStatus.UNKNOWN
+        self.__additional_state = {}
 
         mqtt_client.add_consumer(self)
 
@@ -35,5 +39,25 @@ class DeviceVariable(Variable, DeviceStatusEventConsumer):
         self.__state = new_state
 
     @property
+    def additional_state(self):
+        return self.__additional_state
+
+    @additional_state.setter
+    def additional_state(self, new_additional_state: AdditionalState):
+        self.__additional_state = new_additional_state
+
+    def set_state_and_additional(
+        self,
+        new_state: DeviceStatus,
+        new_additional_state: AdditionalState
+    ):
+        self.__state = new_state
+        self.__additional_state = new_additional_state
+
+    @property
     def json(self):
-        return {'state': self.__state}
+        return {'state': self.__state, **self.__additional_state}
+
+    def _additional_state_keys(self) -> List[str]:
+        # we don't know what the actual implementation supports, so we're not setting keys
+        return []

--- a/common/python/powerpi_common/variable/device.py
+++ b/common/python/powerpi_common/variable/device.py
@@ -1,0 +1,39 @@
+from powerpi_common.config import Config
+from powerpi_common.device import DeviceStatus
+from powerpi_common.device.consumers import DeviceStatusEventConsumer
+from powerpi_common.logger import Logger
+from powerpi_common.mqtt import MQTTClient
+from powerpi_common.variable.types import VariableType
+from powerpi_common.variable.variable import Variable
+
+
+class DeviceVariable(Variable, DeviceStatusEventConsumer):
+    def __init__(
+        self,
+        config: Config,
+        logger: Logger,
+        mqtt_client: MQTTClient,
+        **kwargs
+    ):
+        Variable.__init__(self, **kwargs)
+        DeviceStatusEventConsumer.__init__(self, self, config, logger)
+
+        self.__state = DeviceStatus.UNKNOWN
+
+        mqtt_client.add_consumer(self)
+
+    @property
+    def variable_type(self):
+        return VariableType.DEVICE
+
+    @property
+    def state(self):
+        return self.__state
+
+    @state.setter
+    def state(self, new_state: str):
+        self.__state = new_state
+
+    @property
+    def json(self):
+        return {'state': self.__state}

--- a/common/python/powerpi_common/variable/manager.py
+++ b/common/python/powerpi_common/variable/manager.py
@@ -53,10 +53,13 @@ class VariableManager:
             kwargs['action'] = variable.action
 
         key = self.__key(variable_type, variable.name, **kwargs)
+        if key in self.__variables[variable_type]:
+            return False
 
         self.__variables[variable_type][key] = variable
 
         self.__logger.info(f'Adding variable {variable}')
+        return True
 
     def __create(self, variable_type: VariableType, name: str, action: Union[str, None]):
         variable_attribute = f'{variable_type}_variable'

--- a/common/python/powerpi_common/variable/manager.py
+++ b/common/python/powerpi_common/variable/manager.py
@@ -25,7 +25,10 @@ class VariableManager:
         self.__device_manager = device_manager
         self.__service_provider = service_provider
 
-        self.__variables: Dict[VariableType, Dict[str, DeviceVariable]] = {}
+        self.__variables: Dict[
+            VariableType,
+            Dict[str, Union[DeviceVariable, SensorVariable]]
+        ] = {}
 
         for variable_type in VariableType:
             self.__variables[variable_type] = {}

--- a/common/python/powerpi_common/variable/manager.py
+++ b/common/python/powerpi_common/variable/manager.py
@@ -1,0 +1,64 @@
+from typing import Dict, Union
+
+from powerpi_common.device import DeviceManager
+from powerpi_common.device.manager import DeviceNotFoundException
+from powerpi_common.logger import Logger
+from powerpi_common.typing import DeviceType
+from powerpi_common.variable.device import DeviceVariable
+from powerpi_common.variable.types import VariableType
+
+
+class VariableManager:
+    '''
+    Class to retrieve a variable, or if it's a local device/sensor, the actual device 
+    from DeviceManager, which has the live state.
+    '''
+
+    def __init__(
+        self,
+        logger: Logger,
+        device_manager: DeviceManager,
+        service_provider
+    ):
+        self.__logger = logger
+        self.__device_manager = device_manager
+        self.__service_provider = service_provider
+
+        self.__variables: Dict[VariableType, Dict[str, DeviceVariable]] = {}
+
+        for variable_type in VariableType:
+            self.__variables[variable_type] = {}
+
+    def get_device(self, name: str) -> Union[DeviceVariable, DeviceType]:
+        '''
+        Returns the device variable if it exists, or the actual device if that exists.
+        '''
+        return self.__get(VariableType.DEVICE, name)
+
+    def __add(self, variable_type: VariableType, name: str):
+        variable_attribute = f'{variable_type}_variable'
+
+        factory = getattr(self.__service_provider, variable_attribute, None)
+
+        if factory is None:
+            self.__logger.debug(
+                f'Could not find variable type "{variable_type}')
+            return None
+
+        instance = factory(name)
+
+        self.__variables[variable_type][name] = instance
+
+        return instance
+
+    def __get(self, variable_type: VariableType, name: str):
+        try:
+            return self.__variables[variable_type][name]
+        except KeyError:
+            # no variable yet, so try getting it from DeviceManager
+            try:
+                if variable_type == VariableType.DEVICE:
+                    return self.__device_manager.get_device(name)
+            except DeviceNotFoundException:
+                # no local device, so let's create a variable
+                return self.__add(variable_type, name)

--- a/common/python/powerpi_common/variable/manager.py
+++ b/common/python/powerpi_common/variable/manager.py
@@ -3,8 +3,9 @@ from typing import Dict, Union
 from powerpi_common.device import DeviceManager
 from powerpi_common.device.manager import DeviceNotFoundException
 from powerpi_common.logger import Logger
-from powerpi_common.typing import DeviceType
+from powerpi_common.typing import DeviceType, SensorType
 from powerpi_common.variable.device import DeviceVariable
+from powerpi_common.variable.sensor import SensorVariable
 from powerpi_common.variable.types import VariableType
 
 
@@ -35,6 +36,12 @@ class VariableManager:
         '''
         return self.__get(VariableType.DEVICE, name)
 
+    def get_sensor(self, name: str) -> Union[SensorVariable, SensorType]:
+        '''
+        Returns the sensor variable if it exists, or the actual sensor if that exists.
+        '''
+        return self.__get(VariableType.SENSOR, name)
+
     def __add(self, variable_type: VariableType, name: str):
         variable_attribute = f'{variable_type}_variable'
 
@@ -60,8 +67,11 @@ class VariableManager:
             try:
                 if variable_type == VariableType.DEVICE:
                     return self.__device_manager.get_device(name)
-            except DeviceNotFoundException:
-                # no local device, so let's create a variable
-                return self.__add(variable_type, name)
 
-        return None
+                if variable_type == VariableType.SENSOR:
+                    return self.__device_manager.get_sensor(name)
+            except DeviceNotFoundException:
+                pass
+
+            # no local device, so let's create a variable
+            return self.__add(variable_type, name)

--- a/common/python/powerpi_common/variable/manager.py
+++ b/common/python/powerpi_common/variable/manager.py
@@ -10,7 +10,7 @@ from powerpi_common.variable.types import VariableType
 
 class VariableManager:
     '''
-    Class to retrieve a variable, or if it's a local device/sensor, the actual device 
+    Class to retrieve a variable, or if it's a local device/sensor, the actual device
     from DeviceManager, which has the live state.
     '''
 
@@ -42,7 +42,8 @@ class VariableManager:
 
         if factory is None:
             self.__logger.debug(
-                f'Could not find variable type "{variable_type}')
+                f'Could not find variable type "{variable_type}'
+            )
             return None
 
         instance = factory(name)
@@ -62,3 +63,5 @@ class VariableManager:
             except DeviceNotFoundException:
                 # no local device, so let's create a variable
                 return self.__add(variable_type, name)
+
+        return None

--- a/common/python/powerpi_common/variable/sensor.py
+++ b/common/python/powerpi_common/variable/sensor.py
@@ -27,6 +27,7 @@ class SensorVariable(Variable, SensorEventConsumer):
             self, f'sensor/{name}/{action}', self, config, logger
         )
 
+        self.__action = action
         self.__value = SensorValue(None, None)
 
         mqtt_client.add_consumer(self)
@@ -34,6 +35,10 @@ class SensorVariable(Variable, SensorEventConsumer):
     @property
     def variable_type(self):
         return VariableType.SENSOR
+
+    @property
+    def action(self):
+        return self.__action
 
     @property
     def value(self):

--- a/common/python/powerpi_common/variable/sensor.py
+++ b/common/python/powerpi_common/variable/sensor.py
@@ -24,7 +24,7 @@ class SensorVariable(Variable, SensorEventConsumer):
     ):
         Variable.__init__(self, name, **kwargs)
         SensorEventConsumer.__init__(
-            self, f'sensor/{name}/{action}', self, config, logger
+            self, f'event/{name}/{action}', self, config, logger
         )
 
         self.__action = action

--- a/common/python/powerpi_common/variable/sensor.py
+++ b/common/python/powerpi_common/variable/sensor.py
@@ -1,6 +1,10 @@
 from collections import namedtuple
+from typing import Tuple
 
+from powerpi_common.config import Config
+from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
+from powerpi_common.sensor.consumers import SensorEventConsumer
 from powerpi_common.variable.types import VariableType
 from powerpi_common.variable.variable import Variable
 
@@ -8,15 +12,24 @@ from powerpi_common.variable.variable import Variable
 SensorValue = namedtuple('SensorValue', 'value unit')
 
 
-class SensorVariable(Variable):
+class SensorVariable(Variable, SensorEventConsumer):
     def __init__(
         self,
-        _: MQTTClient,
+        config: Config,
+        logger: Logger,
+        mqtt_client: MQTTClient,
+        name: str,
+        action: str,
         **kwargs
     ):
-        Variable.__init__(self, **kwargs)
+        Variable.__init__(self, name, **kwargs)
+        SensorEventConsumer.__init__(
+            self, f'sensor/{name}/{action}', self, config, logger
+        )
 
         self.__value = SensorValue(None, None)
+
+        mqtt_client.add_consumer(self)
 
     @property
     def variable_type(self):
@@ -27,7 +40,8 @@ class SensorVariable(Variable):
         return self.__value
 
     @value.setter
-    def value(self, new_value: float, new_unit: str):
+    def value(self, new_tuple: Tuple[float, str]):
+        new_value, new_unit = new_tuple
         self.__value = SensorValue(new_value, new_unit)
 
     @property

--- a/common/python/powerpi_common/variable/sensor.py
+++ b/common/python/powerpi_common/variable/sensor.py
@@ -1,0 +1,35 @@
+from collections import namedtuple
+
+from powerpi_common.mqtt import MQTTClient
+from powerpi_common.variable.types import VariableType
+from powerpi_common.variable.variable import Variable
+
+
+SensorValue = namedtuple('SensorValue', 'value unit')
+
+
+class SensorVariable(Variable):
+    def __init__(
+        self,
+        _: MQTTClient,
+        **kwargs
+    ):
+        Variable.__init__(self, **kwargs)
+
+        self.__value = SensorValue(None, None)
+
+    @property
+    def variable_type(self):
+        return VariableType.SENSOR
+
+    @property
+    def value(self):
+        return self.__value
+
+    @value.setter
+    def value(self, new_value: float, new_unit: str):
+        self.__value = SensorValue(new_value, new_unit)
+
+    @property
+    def json(self):
+        return {'value': self.__value.value, 'unit': self.__value.unit}

--- a/common/python/powerpi_common/variable/types.py
+++ b/common/python/powerpi_common/variable/types.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class VariableType(str, Enum):
+    DEVICE = 'device'
+    SENSOR = 'sensor'

--- a/common/python/powerpi_common/variable/variable.py
+++ b/common/python/powerpi_common/variable/variable.py
@@ -1,8 +1,34 @@
-from abc import ABC
+from abc import ABC, abstractmethod
+from typing import Any, Dict
+
+from powerpi_common.variable.types import VariableType
 
 
 class Variable(ABC):
     '''
     Abstract base class for a variable, which can monitor a remote device or sensor to allow its
-    state to be used when activating other devices.
+    state to be used when choosing to activate other devices.
     '''
+
+    def __init__(self, name: str, **_):
+        self._name = name
+
+    @property
+    def name(self):
+        '''
+        Returns the unique name identifier for this device/sensor.
+        '''
+        return self._name
+
+    @property
+    @abstractmethod
+    def variable_type(self) -> VariableType:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def json(self) -> Dict[str, Any]:
+        raise NotImplementedError
+
+    def __str__(self):
+        return f'var.{self.variable_type}.{self._name}={self.json}'

--- a/common/python/powerpi_common/variable/variable.py
+++ b/common/python/powerpi_common/variable/variable.py
@@ -1,0 +1,8 @@
+from abc import ABC
+
+
+class Variable(ABC):
+    '''
+    Abstract base class for a variable, which can monitor a remote device or sensor to allow its
+    state to be used when activating other devices.
+    '''

--- a/common/python/pyproject.toml
+++ b/common/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "powerpi-common"
-version = "0.2.1"
+version = "0.2.2"
 description = "PowerPi Common Python Library"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/common/python/tests/variable/test_device.py
+++ b/common/python/tests/variable/test_device.py
@@ -1,0 +1,13 @@
+from pytest_mock import MockerFixture
+
+from powerpi_common.variable.device import DeviceVariable
+from powerpi_common_test.variable.variable import VariableTestBase
+
+
+class TestDeviceVariable(VariableTestBase):
+    def create_subject(self, mocker: MockerFixture):
+        self.config = mocker.Mock()
+        self.logger = mocker.Mock()
+        self.mqtt_client = mocker.Mock()
+
+        return DeviceVariable(self.config, self.logger, self.mqtt_client, name='TestVariable')

--- a/common/python/tests/variable/test_manager.py
+++ b/common/python/tests/variable/test_manager.py
@@ -1,0 +1,70 @@
+from pytest_mock import MockerFixture
+
+from powerpi_common.device import DeviceConfigType, DeviceNotFoundException
+from powerpi_common.variable import VariableManager
+from powerpi_common_test.base import BaseTest
+
+
+class TestVariableManager(BaseTest):
+    def create_subject(self, mocker: MockerFixture):
+        self.logger = mocker.Mock()
+        self.device_manager = mocker.Mock()
+        self.service_provider = mocker.Mock()
+
+        return VariableManager(self.logger, self.device_manager, self.service_provider)
+
+    def test_get_device_adds(self, mocker: MockerFixture):
+        subject = self.create_subject(mocker)
+
+        def not_found(name: str):
+            raise DeviceNotFoundException(DeviceConfigType.DEVICE, name)
+        self.device_manager.get_device = not_found
+
+        self.service_provider.device_variable = lambda name: f'device: {name}'
+
+        name = 'new_variable'
+
+        result = subject.get_device(name)
+
+        assert result is not None
+        assert result == 'device: new_variable'
+
+    def test_get_device_from_manager(self, mocker: MockerFixture):
+        subject = self.create_subject(mocker)
+
+        self.device_manager.get_device = lambda name: f'device: {name}'
+
+        name = 'found_device'
+
+        result = subject.get_device(name)
+
+        assert result is not None
+        assert result == 'device: found_device'
+
+        self.service_provider.device_variable.assert_not_called()
+
+    def test_get_device_exists(self, mocker: MockerFixture):
+        subject = self.create_subject(mocker)
+
+        def not_found(name: str):
+            raise DeviceNotFoundException(DeviceConfigType.DEVICE, name)
+        self.device_manager.get_device = not_found
+
+        self.service_provider.device_variable = lambda name: f'device: {name}'
+
+        name = 'found_variable'
+
+        # ensure it's already there
+        subject.get_device(name)
+
+        # then reset
+        self.device_manager.get_device = mocker.Mock()
+        self.service_provider.device_variable = mocker.Mock()
+
+        result = subject.get_device(name)
+
+        assert result is not None
+        assert result == 'device: found_variable'
+
+        self.device_manager.get_device.assert_not_called()
+        self.service_provider.device_variable.assert_not_called()

--- a/common/python/tests/variable/test_manager.py
+++ b/common/python/tests/variable/test_manager.py
@@ -24,12 +24,12 @@ class TestVariableManager(BaseTest):
         self.device_manager.get_sensor = not_found
 
         self.service_provider.device_variable = lambda name: f'device: {name}'
-        self.service_provider.sensor_variable = lambda name: f'sensor: {name}'
+        self.service_provider.sensor_variable = lambda name, action: f'sensor: {name}'
 
         name = 'new_variable'
 
         result = subject.get_device(name) if variable_type == VariableType.DEVICE \
-            else subject.get_sensor(name)
+            else subject.get_sensor(name, 'action')
 
         assert result is not None
         assert result == f'{variable_type}: new_variable'
@@ -44,7 +44,7 @@ class TestVariableManager(BaseTest):
         name = 'found_device'
 
         result = subject.get_device(name) if variable_type == VariableType.DEVICE \
-            else subject.get_sensor(name)
+            else subject.get_sensor(name, 'action')
 
         assert result is not None
         assert result == f'{variable_type}: found_device'
@@ -62,7 +62,7 @@ class TestVariableManager(BaseTest):
         self.device_manager.get_sensor = not_found
 
         self.service_provider.device_variable = lambda name: f'device: {name}'
-        self.service_provider.sensor_variable = lambda name: f'sensor: {name}'
+        self.service_provider.sensor_variable = lambda name, action: f'sensor: {name}'
 
         name = 'found_variable'
 
@@ -70,7 +70,7 @@ class TestVariableManager(BaseTest):
         if variable_type == VariableType.DEVICE:
             subject.get_device(name)
         else:
-            subject.get_sensor(name)
+            subject.get_sensor(name, 'action')
 
         # then reset
         self.device_manager.get_device = mocker.Mock()
@@ -79,7 +79,7 @@ class TestVariableManager(BaseTest):
         self.service_provider.sensor_variable = mocker.Mock()
 
         result = subject.get_device(name) if variable_type == VariableType.DEVICE \
-            else subject.get_sensor(name)
+            else subject.get_sensor(name, 'action')
 
         assert result is not None
         assert result == f'{variable_type}: found_variable'

--- a/common/python/tests/variable/test_manager.py
+++ b/common/python/tests/variable/test_manager.py
@@ -86,5 +86,6 @@ class TestVariableManager(BaseTest):
 
         self.device_manager.get_device.assert_not_called()
         self.device_manager.get_sensor.assert_not_called()
+
         self.service_provider.device_variable.assert_not_called()
         self.service_provider.sensor_variable.assert_not_called()

--- a/common/python/tests/variable/test_manager.py
+++ b/common/python/tests/variable/test_manager.py
@@ -1,7 +1,8 @@
+import pytest
 from pytest_mock import MockerFixture
 
 from powerpi_common.device import DeviceConfigType, DeviceNotFoundException
-from powerpi_common.variable import VariableManager
+from powerpi_common.variable import VariableManager, VariableType
 from powerpi_common_test.base import BaseTest
 
 
@@ -13,58 +14,77 @@ class TestVariableManager(BaseTest):
 
         return VariableManager(self.logger, self.device_manager, self.service_provider)
 
-    def test_get_device_adds(self, mocker: MockerFixture):
+    @pytest.mark.parametrize('variable_type', [VariableType.DEVICE, VariableType.SENSOR])
+    def test_get_x_adds(self, mocker: MockerFixture, variable_type: VariableType):
         subject = self.create_subject(mocker)
 
         def not_found(name: str):
             raise DeviceNotFoundException(DeviceConfigType.DEVICE, name)
         self.device_manager.get_device = not_found
+        self.device_manager.get_sensor = not_found
 
         self.service_provider.device_variable = lambda name: f'device: {name}'
+        self.service_provider.sensor_variable = lambda name: f'sensor: {name}'
 
         name = 'new_variable'
 
-        result = subject.get_device(name)
+        result = subject.get_device(name) if variable_type == VariableType.DEVICE \
+            else subject.get_sensor(name)
 
         assert result is not None
-        assert result == 'device: new_variable'
+        assert result == f'{variable_type}: new_variable'
 
-    def test_get_device_from_manager(self, mocker: MockerFixture):
+    @pytest.mark.parametrize('variable_type', [VariableType.DEVICE, VariableType.SENSOR])
+    def test_get_x_from_manager(self, mocker: MockerFixture, variable_type: VariableType):
         subject = self.create_subject(mocker)
 
         self.device_manager.get_device = lambda name: f'device: {name}'
+        self.device_manager.get_sensor = lambda name: f'sensor: {name}'
 
         name = 'found_device'
 
-        result = subject.get_device(name)
+        result = subject.get_device(name) if variable_type == VariableType.DEVICE \
+            else subject.get_sensor(name)
 
         assert result is not None
-        assert result == 'device: found_device'
+        assert result == f'{variable_type}: found_device'
 
         self.service_provider.device_variable.assert_not_called()
+        self.service_provider.sensor_variable.assert_not_called()
 
-    def test_get_device_exists(self, mocker: MockerFixture):
+    @pytest.mark.parametrize('variable_type', [VariableType.DEVICE, VariableType.SENSOR])
+    def test_get_x_exists(self, mocker: MockerFixture, variable_type: VariableType):
         subject = self.create_subject(mocker)
 
         def not_found(name: str):
             raise DeviceNotFoundException(DeviceConfigType.DEVICE, name)
         self.device_manager.get_device = not_found
+        self.device_manager.get_sensor = not_found
 
         self.service_provider.device_variable = lambda name: f'device: {name}'
+        self.service_provider.sensor_variable = lambda name: f'sensor: {name}'
 
         name = 'found_variable'
 
         # ensure it's already there
-        subject.get_device(name)
+        if variable_type == VariableType.DEVICE:
+            subject.get_device(name)
+        else:
+            subject.get_sensor(name)
 
         # then reset
         self.device_manager.get_device = mocker.Mock()
+        self.device_manager.get_sensor = mocker.Mock()
         self.service_provider.device_variable = mocker.Mock()
+        self.service_provider.sensor_variable = mocker.Mock()
 
-        result = subject.get_device(name)
+        result = subject.get_device(name) if variable_type == VariableType.DEVICE \
+            else subject.get_sensor(name)
 
         assert result is not None
-        assert result == 'device: found_variable'
+        assert result == f'{variable_type}: found_variable'
 
         self.device_manager.get_device.assert_not_called()
+        self.device_manager.get_sensor.assert_not_called()
         self.service_provider.device_variable.assert_not_called()
+        self.service_provider.sensor_variable.assert_not_called()

--- a/common/python/tests/variable/test_sensor.py
+++ b/common/python/tests/variable/test_sensor.py
@@ -1,3 +1,4 @@
+import pytest
 from pytest_mock import MockerFixture
 
 from powerpi_common.variable.sensor import SensorVariable
@@ -5,7 +6,44 @@ from powerpi_common_test.variable.variable import VariableTestBase
 
 
 class TestSensorVariable(VariableTestBase):
+    pytestmark = pytest.mark.asyncio
+
     def create_subject(self, mocker: MockerFixture):
+        self.config = mocker.Mock()
+        self.logger = mocker.Mock()
         self.mqtt_client = mocker.Mock()
 
-        return SensorVariable(self.mqtt_client, name='TestVariable')
+        return SensorVariable(
+            self.config, self.logger, self.mqtt_client,
+            name='TestSensor',
+            action='detect'
+        )
+
+    def test_topic(self, mocker: MockerFixture):
+        subject = self.create_subject(mocker)
+
+        assert subject.topic == 'sensor/TestSensor/detect'
+
+    async def test_on_message_updates(self, mocker: MockerFixture):
+        subject = self.create_subject(mocker)
+
+        message = {'value': 12.34, 'unit': 'doughnuts'}
+
+        assert subject.value == (None, None)
+
+        await subject.on_message(message, 'TestSensor', 'detect')
+
+        assert subject.value == (12.34, 'doughnuts')
+
+    @pytest.mark.parametrize('which', ['value', 'unit'])
+    async def test_on_message_ignores(self, mocker: MockerFixture, which: str):
+        subject = self.create_subject(mocker)
+
+        message = {'value': 12.34, 'unit': 'doughnuts'}
+        message[which] = None
+
+        assert subject.value == (None, None)
+
+        await subject.on_message(message, 'TestSensor', 'detect')
+
+        assert subject.value == (None, None)

--- a/common/python/tests/variable/test_sensor.py
+++ b/common/python/tests/variable/test_sensor.py
@@ -1,0 +1,11 @@
+from pytest_mock import MockerFixture
+
+from powerpi_common.variable.sensor import SensorVariable
+from powerpi_common_test.variable.variable import VariableTestBase
+
+
+class TestSensorVariable(VariableTestBase):
+    def create_subject(self, mocker: MockerFixture):
+        self.mqtt_client = mocker.Mock()
+
+        return SensorVariable(self.mqtt_client, name='TestVariable')

--- a/common/python/tests/variable/test_sensor.py
+++ b/common/python/tests/variable/test_sensor.py
@@ -22,7 +22,7 @@ class TestSensorVariable(VariableTestBase):
     def test_topic(self, mocker: MockerFixture):
         subject = self.create_subject(mocker)
 
-        assert subject.topic == 'sensor/TestSensor/detect'
+        assert subject.topic == 'event/TestSensor/detect'
 
     async def test_on_message_updates(self, mocker: MockerFixture):
         subject = self.create_subject(mocker)

--- a/common/python/tests/variable/test_variable.py
+++ b/common/python/tests/variable/test_variable.py
@@ -1,6 +1,6 @@
-from powerpi_common.variable.types import VariableType
 from pytest_mock import MockerFixture
 
+from powerpi_common.variable.types import VariableType
 from powerpi_common.variable.variable import Variable
 from powerpi_common_test.variable import VariableTestBase
 

--- a/common/python/tests/variable/test_variable.py
+++ b/common/python/tests/variable/test_variable.py
@@ -1,0 +1,20 @@
+from powerpi_common.variable.types import VariableType
+from pytest_mock import MockerFixture
+
+from powerpi_common.variable.variable import Variable
+from powerpi_common_test.variable import VariableTestBase
+
+
+class VariableImpl(Variable):
+    @property
+    def variable_type(self):
+        return VariableType.DEVICE
+
+    @property
+    def json(self):
+        return {}
+
+
+class TestVariable(VariableTestBase):
+    def create_subject(self, _: MockerFixture):
+        return VariableImpl('TestVariable')

--- a/controllers/macro/macro_controller/device/container.py
+++ b/controllers/macro/macro_controller/device/container.py
@@ -25,8 +25,7 @@ def add_devices(container):
     device_container.device_factory.override(providers.Factory(
         RemoteDeviceFactory,
         logger=container.common.logger,
-        device_service_provider=container.common.device.service_provider,
-        variable_service_provider=container.common.variable.service_provider
+        service_provider=container.common.device.service_provider
     ))
 
     setattr(

--- a/controllers/macro/macro_controller/device/container.py
+++ b/controllers/macro/macro_controller/device/container.py
@@ -25,7 +25,8 @@ def add_devices(container):
     device_container.device_factory.override(providers.Factory(
         RemoteDeviceFactory,
         logger=container.common.logger,
-        service_provider=container.common.device.service_provider
+        device_service_provider=container.common.device.service_provider,
+        variable_service_provider=container.common.variable.service_provider
     ))
 
     setattr(

--- a/controllers/macro/macro_controller/device/factory.py
+++ b/controllers/macro/macro_controller/device/factory.py
@@ -1,12 +1,22 @@
 from powerpi_common.device import DeviceFactory, DeviceConfigType
 from powerpi_common.logger import Logger
+from powerpi_common.variable import VariableManager
 
 
 class RemoteDeviceFactory(DeviceFactory):
-    def __init__(self, logger: Logger, service_provider):
-        DeviceFactory.__init__(self, logger, service_provider)
+    def __init__(
+        self,
+        logger: Logger,
+        device_service_provider,
+        variable_service_provider
+    ):
+        DeviceFactory.__init__(self, logger, device_service_provider)
 
-        self.__service_provider = service_provider
+        self.__device_service_provider = device_service_provider
+
+        # have to get VariableManager this way to prevent cyclic instantiation
+        self.__variable_service_provider = variable_service_provider
+        self.__variable_manager: VariableManager = None
 
     def build(self, device_type: DeviceConfigType, instance_type: str, **kwargs):
         device = DeviceFactory.build(
@@ -14,8 +24,11 @@ class RemoteDeviceFactory(DeviceFactory):
         )
 
         if device is None and device_type == DeviceConfigType.DEVICE:
-            factory = getattr(self.__service_provider, 'remote_device')
+            device = self.__device_service_provider.remote_device(**kwargs)
 
-            device = factory(**kwargs)
+            if self.__variable_manager is None:
+                self.__variable_manager = self.__variable_service_provider.variable_manager()
+
+            self.__variable_manager.add(device)
 
         return device

--- a/controllers/macro/macro_controller/device/factory.py
+++ b/controllers/macro/macro_controller/device/factory.py
@@ -1,17 +1,17 @@
-from dependency_injector.containers import Container
-
 from powerpi_common.device import DeviceFactory, DeviceConfigType
 from powerpi_common.logger import Logger
 
 
 class RemoteDeviceFactory(DeviceFactory):
-    def __init__(self, logger: Logger, service_provider: Container):
+    def __init__(self, logger: Logger, service_provider):
         DeviceFactory.__init__(self, logger, service_provider)
 
         self.__service_provider = service_provider
 
     def build(self, device_type: DeviceConfigType, instance_type: str, **kwargs):
-        device = super().build(device_type, instance_type, **kwargs)
+        device = DeviceFactory.build(
+            self, device_type, instance_type, **kwargs
+        )
 
         if device is None and device_type == DeviceConfigType.DEVICE:
             factory = getattr(self.__service_provider, 'remote_device')

--- a/controllers/macro/macro_controller/device/factory.py
+++ b/controllers/macro/macro_controller/device/factory.py
@@ -1,22 +1,16 @@
 from powerpi_common.device import DeviceFactory, DeviceConfigType
 from powerpi_common.logger import Logger
-from powerpi_common.variable import VariableManager
 
 
 class RemoteDeviceFactory(DeviceFactory):
     def __init__(
         self,
         logger: Logger,
-        device_service_provider,
-        variable_service_provider
+        service_provider
     ):
-        DeviceFactory.__init__(self, logger, device_service_provider)
+        DeviceFactory.__init__(self, logger, service_provider)
 
-        self.__device_service_provider = device_service_provider
-
-        # have to get VariableManager this way to prevent cyclic instantiation
-        self.__variable_service_provider = variable_service_provider
-        self.__variable_manager: VariableManager = None
+        self.__service_provider = service_provider
 
     def build(self, device_type: DeviceConfigType, instance_type: str, **kwargs):
         device = DeviceFactory.build(
@@ -24,11 +18,6 @@ class RemoteDeviceFactory(DeviceFactory):
         )
 
         if device is None and device_type == DeviceConfigType.DEVICE:
-            device = self.__device_service_provider.remote_device(**kwargs)
-
-            if self.__variable_manager is None:
-                self.__variable_manager = self.__variable_service_provider.variable_manager()
-
-            self.__variable_manager.add(device)
+            device = self.__service_provider.remote_device(**kwargs)
 
         return device

--- a/controllers/macro/macro_controller/device/remote.py
+++ b/controllers/macro/macro_controller/device/remote.py
@@ -103,7 +103,9 @@ class RemoteDevice(DeviceVariable):
         try:
             await wait_for(self.__waiting.wait(), timeout)
         except AsyncTimeoutError:
-            self.__logger.info(f'Timed out waiting for device "{self.name}"')
+            self.__logger.warning(
+                f'Timed out waiting for device "{self.name}"'
+            )
 
     def __str__(self):
         return f'{type(self).__name__}({self.name}, {self.json})'

--- a/controllers/macro/macro_controller/device/remote.py
+++ b/controllers/macro/macro_controller/device/remote.py
@@ -1,62 +1,41 @@
-import contextlib
-
 from asyncio import Event, wait_for
 from asyncio.exceptions import TimeoutError as AsyncTimeoutError
-from typing import List, Union
+from typing import Union
 
 from powerpi_common.config import Config
 from powerpi_common.device import DeviceStatus
-from powerpi_common.device.consumers import DeviceStatusEventConsumer
-from powerpi_common.device.mixin import AdditionalState, AdditionalStateMixin
+from powerpi_common.device.mixin import AdditionalState
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
+from powerpi_common.variable import DeviceVariable
 
 
-class RemoteDevice(DeviceStatusEventConsumer, AdditionalStateMixin):
+class RemoteDevice(DeviceVariable):
     #pylint: disable=too-many-arguments
     def __init__(
         self,
         config: Config,
         logger: Logger,
         mqtt_client: MQTTClient,
-        name: str,
         timeout: float = 12.5,
-        **_
+        **kwargs
     ):
         self.__logger = logger
-        self.__name = name
         self.__timeout = timeout
-
-        DeviceStatusEventConsumer.__init__(self, self, config, logger)
-
-        self.__state = DeviceStatus.UNKNOWN
-        self.__additional_state = {}
 
         self.__producer = mqtt_client.add_producer()
         self.__waiting = Event()
 
-        mqtt_client.add_consumer(self)
+        DeviceVariable.__init__(self, config, logger, mqtt_client, **kwargs)
 
-    @property
-    def name(self):
-        return self.__name
-
-    @property
-    def state(self):
-        return self.__state
-
-    @state.setter
+    @DeviceVariable.state.setter
     def state(self, new_state: str):
-        self.__state = new_state
+        DeviceVariable.state.fset(self, new_state)
         self.__waiting.set()
 
-    @property
-    def additional_state(self):
-        return self.__additional_state
-
-    @additional_state.setter
+    @DeviceVariable.additional_state.setter
     def additional_state(self, new_additional_state: AdditionalState):
-        self.__additional_state = new_additional_state
+        DeviceVariable.additional_state.fset(self, new_additional_state)
         self.__waiting.set()
 
     async def change_power_and_additional_state(
@@ -71,21 +50,20 @@ class RemoteDevice(DeviceStatusEventConsumer, AdditionalStateMixin):
         new_state: DeviceStatus,
         new_additional_state: AdditionalState
     ):
-        self.__state = new_state
-        self.__additional_state = new_additional_state
+        DeviceVariable.set_state_and_additional(
+            self, new_state, new_additional_state
+        )
         self.__waiting.set()
 
-    async def on_additional_state_change(self, new_additional_state: AdditionalState) -> AdditionalState:
+    async def on_additional_state_change(
+        self, new_additional_state: AdditionalState
+    ) -> AdditionalState:
         # we are doing everything in change_power_and_additional_state
         return new_additional_state
 
     def _filter_keys(self, new_additional_state: AdditionalState):
         # we don't know what the actual implementation supports, so keep it as it is
         return new_additional_state
-
-    def _additional_state_keys(self) -> List[str]:
-        # we don't know what the actual implementation supports, so we're not setting keys
-        return []
 
     async def turn_on(self):
         await self.__send_message(DeviceStatus.ON)
@@ -98,7 +76,7 @@ class RemoteDevice(DeviceStatusEventConsumer, AdditionalStateMixin):
         state: Union[DeviceStatus, None],
         additional_state: Union[AdditionalState, None] = None
     ):
-        topic = f'device/{self.__name}/change'
+        topic = f'device/{self.name}/change'
         message = {}
 
         if additional_state is not None:
@@ -112,18 +90,20 @@ class RemoteDevice(DeviceStatusEventConsumer, AdditionalStateMixin):
         self.__producer(topic, message)
 
         self.__logger.info(
-            f'Waiting for state update for device "{self.__name}"'
+            f'Waiting for state update for device "{self.name}"'
         )
 
         await self.__wait(self.__timeout)
 
         self.__logger.info(
-            f'Continuing after device "{self.__name}"'
+            f'Continuing after device "{self.name}"'
         )
 
     async def __wait(self, timeout: float):
-        with contextlib.suppress(AsyncTimeoutError):
+        try:
             await wait_for(self.__waiting.wait(), timeout)
+        except AsyncTimeoutError:
+            self.__logger.info(f'Timed out waiting for device "{self.name}"')
 
     def __str__(self):
-        return f'{type(self).__name__}({self.__name}, {self.__state})'
+        return f'{type(self).__name__}({self.name}, {self.json})'

--- a/controllers/macro/pyproject.toml
+++ b/controllers/macro/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "macro_controller"
-version = "1.1.5"
+version = "1.1.6"
 description = "PowerPi Macro Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/macro/tests/device/test_remote.py
+++ b/controllers/macro/tests/device/test_remote.py
@@ -10,7 +10,7 @@ from macro_controller.device.remote import RemoteDevice
 from powerpi_common_test.mqtt import mock_producer
 
 
-class TestRemoteDevice(object):
+class TestRemoteDevice:
     pytestmark = pytest.mark.asyncio
 
     def get_subject(self, mocker: MockerFixture, timeout: float):
@@ -21,7 +21,8 @@ class TestRemoteDevice(object):
         self.publish = mock_producer(mocker, self.mqtt_client)
 
         return RemoteDevice(
-            self.config, self.logger, self.mqtt_client, 'remote', timeout
+            self.config, self.logger, self.mqtt_client, timeout,
+            name='remote'
         )
 
     @pytest.mark.parametrize('state', ['on', 'off'])

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -69,7 +69,7 @@ services:
             - deep-thought
 
     macro-controller:
-        image: ${REGISTRY}/powerpi/controllers/macro:1.1.5
+        image: ${REGISTRY}/powerpi/controllers/macro:1.1.6
         networks:
             - powerpi
         deploy:


### PR DESCRIPTION
Resolves #122 
- Add support for `DeviceVariable` and `SensorVariable` which capture the events from the message queue to allow the states of those remote devices/sensors to be used in other services, i.e. for a complex condition.
- Add a `VariableManager` which will allow these variables to be kept and maintained.
- Update `RemoteDevice` in `macro-controller` to use `DeviceVariable` as it's essentially a special case.