### PR TITLE
#146, #148, #150 Add user defined variables to controllers

### DIFF
--- a/common/python/powerpi_common/condition/parser.py
+++ b/common/python/powerpi_common/condition/parser.py
@@ -114,12 +114,15 @@ class ConditionParser:
         '''
         variable = self.__variable_manager.get_sensor(name, action)
 
-        if prop == 'value':
-            return variable.value.value
-        if prop == 'unit':
-            return variable.value.unit
-        if prop == 'state':
-            return variable.state
+        try:
+            if prop == 'value':
+                return variable.value.value
+            if prop == 'unit':
+                return variable.value.unit
+            if prop == 'state':
+                return variable.state
+        except AttributeError:
+            pass
 
         raise InvalidIdentifierException(identifier)
 

--- a/common/python/powerpi_common/condition/parser.py
+++ b/common/python/powerpi_common/condition/parser.py
@@ -47,7 +47,7 @@ class ConditionParser:
     def __init__(
         self,
         variable_manager: VariableManager,
-        message: MQTTMessage
+        message: Union[MQTTMessage, None] = None
     ):
         self.__variable_manager = variable_manager
         self.__message = message
@@ -123,11 +123,14 @@ class ConditionParser:
 
         raise InvalidIdentifierException(identifier)
 
-    def message_identifier(self, _: str, prop: str):
+    def message_identifier(self, identifier: str, prop: str):
         '''
         Return the value of the message identifier.
         e.g. var.message.state
         '''
+        if self.__message is None:
+            raise InvalidIdentifierException(identifier)
+
         try:
             return self.__message[prop]
         except KeyError:

--- a/common/python/powerpi_common/event/action.py
+++ b/common/python/powerpi_common/event/action.py
@@ -1,0 +1,23 @@
+from jsonpatch import JsonPatch
+
+from powerpi_common.device import Device
+
+
+async def device_on_action(device: Device):
+    await device.turn_on()
+
+
+async def device_off_action(device: Device):
+    await device.turn_off()
+
+
+def device_additional_state_action(patch: dict):
+    patch = JsonPatch(patch)
+
+    async def wrapper(device: Device):
+        current_state = device.additional_state
+
+        patched = patch.apply(current_state)
+        await device.change_power_and_additional_state(None, patched)
+
+    return wrapper

--- a/common/python/powerpi_common/event/action.py
+++ b/common/python/powerpi_common/event/action.py
@@ -1,6 +1,8 @@
 from jsonpatch import JsonPatch
 
+from powerpi_common.condition import ConditionParser
 from powerpi_common.device import Device
+from powerpi_common.variable import VariableManager
 
 
 async def device_on_action(device: Device):
@@ -11,11 +13,19 @@ async def device_off_action(device: Device):
     await device.turn_off()
 
 
-def device_additional_state_action(patch: dict):
+def device_additional_state_action(patch: dict, variable_manager: VariableManager):
     patch = JsonPatch(patch)
 
     async def wrapper(device: Device):
         current_state = device.additional_state
+
+        parser = ConditionParser(variable_manager)
+
+        # interpret any variables in the values to patch
+        for operation in patch:
+            operation['value'] = parser.conditional_expression(
+                operation['value']
+            )
 
         patched = patch.apply(current_state)
         await device.change_power_and_additional_state(None, patched)

--- a/common/python/powerpi_common/event/manager.py
+++ b/common/python/powerpi_common/event/manager.py
@@ -1,8 +1,9 @@
 from typing import List
-from jsonpatch import JsonPatch
 
 from powerpi_common.config import Config
-from powerpi_common.device import Device, DeviceManager, DeviceNotFoundException
+from powerpi_common.device import Device, DeviceManager, DeviceNotFoundException, DeviceStatus
+from powerpi_common.event.action import device_additional_state_action, device_off_action, \
+    device_on_action
 from powerpi_common.event.consumer import EventConsumer
 from powerpi_common.event.handler import EventHandler
 from powerpi_common.logger import Logger
@@ -98,36 +99,16 @@ class EventManager:
             state = action['state']
 
             # pylint: disable=no-else-return
-            if state == 'on':
+            if state == DeviceStatus.ON:
                 return device_on_action
-            elif state == 'off':
+            elif state == DeviceStatus.OFF:
                 return device_off_action
         except KeyError:
             pass
 
         try:
-            patch = JsonPatch(action['patch'])
-
-            return device_additional_state_action(patch)
+            return device_additional_state_action(action['patch'])
         except KeyError:
             pass
 
         return None
-
-
-async def device_on_action(device: Device):
-    await device.turn_on()
-
-
-async def device_off_action(device: Device):
-    await device.turn_off()
-
-
-def device_additional_state_action(patch: JsonPatch):
-    async def wrapper(device: Device):
-        current_state = device.additional_state
-
-        patched = patch.apply(current_state)
-        await device.change_power_and_additional_state(None, patched)
-
-    return wrapper

--- a/common/python/powerpi_common/event/manager.py
+++ b/common/python/powerpi_common/event/manager.py
@@ -93,21 +93,19 @@ class EventManager:
             f'Found {len(self.__consumers)} matching listener(s)'
         )
 
-    @classmethod
-    def __get_action(cls, action: object):
+    def __get_action(self, action: dict):
         try:
             state = action['state']
 
-            # pylint: disable=no-else-return
             if state == DeviceStatus.ON:
                 return device_on_action
-            elif state == DeviceStatus.OFF:
+            if state == DeviceStatus.OFF:
                 return device_off_action
         except KeyError:
             pass
 
         try:
-            return device_additional_state_action(action['patch'])
+            return device_additional_state_action(action['patch'], self.__variable_manager)
         except KeyError:
             pass
 

--- a/common/python/pyproject.toml
+++ b/common/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "powerpi-common"
-version = "0.2.3"
+version = "0.2.4"
 description = "PowerPi Common Python Library"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/common/python/tests/condition/test_parser.py
+++ b/common/python/tests/condition/test_parser.py
@@ -6,7 +6,6 @@ from pytest_mock import MockerFixture
 from powerpi_common.condition import ConditionParser, InvalidArgumentException, \
     InvalidIdentifierException, UnexpectedTokenException
 from powerpi_common.variable import SensorValue
-from powerpi_common_test.base import BaseTest
 
 
 class DeviceVariableImpl:
@@ -20,14 +19,12 @@ class SensorVariableImpl:
         self.value = SensorValue(f'{name}/{action}', f'{action}/{name}')
 
 
-class TestConditionParser(BaseTest):
-    def create_subject(self, mocker: MockerFixture):
+class TestConditionParser:
+    def create_subject(self, mocker: MockerFixture, message=None):
         variable_manager = mocker.Mock()
 
         variable_manager.get_device = DeviceVariableImpl
         variable_manager.get_sensor = SensorVariableImpl
-
-        message = {'timestamp': 1337}
 
         return ConditionParser(variable_manager, message)
 
@@ -60,7 +57,9 @@ class TestConditionParser(BaseTest):
         ('var.message.whatever', None),
     ])
     def test_identifier_success(self, mocker: MockerFixture, identifier: str, expected: str):
-        subject = self.create_subject(mocker)
+        message = {'timestamp': 1337}
+
+        subject = self.create_subject(mocker, message)
 
         result = subject.identifier(identifier)
 
@@ -79,7 +78,8 @@ class TestConditionParser(BaseTest):
         'var.sensor.office.temperature',
         'var.sensor.office.temperature.whatever',
         'message',
-        'var.message'
+        'var.message',
+        'var.message.timestamp'
     ])
     def test_identifier_invalid(self, mocker: MockerFixture, identifier: str):
         subject = self.create_subject(mocker)

--- a/common/python/tests/condition/test_parser.py
+++ b/common/python/tests/condition/test_parser.py
@@ -21,12 +21,13 @@ class SensorVariableImpl:
 
 class TestConditionParser:
     def create_subject(self, mocker: MockerFixture, message=None):
-        variable_manager = mocker.Mock()
+        # pylint: disable=attribute-defined-outside-init
+        self.variable_manager = mocker.Mock()
 
-        variable_manager.get_device = DeviceVariableImpl
-        variable_manager.get_sensor = SensorVariableImpl
+        self.variable_manager.get_device = DeviceVariableImpl
+        self.variable_manager.get_sensor = SensorVariableImpl
 
-        return ConditionParser(variable_manager, message)
+        return ConditionParser(self.variable_manager, message)
 
     @pytest.mark.parametrize('constant', [
         'strING',
@@ -83,6 +84,22 @@ class TestConditionParser:
     ])
     def test_identifier_invalid(self, mocker: MockerFixture, identifier: str):
         subject = self.create_subject(mocker)
+
+        with pytest.raises(InvalidIdentifierException):
+            subject.identifier(identifier)
+
+    @pytest.mark.parametrize('identifier', [
+        "var.sensor.office.temperature.state",
+        "var.sensor.office.temperature.value",
+        "var.sensor.office.temperature.unit"
+    ])
+    def test_sensor_identifier_invalid(self, mocker: MockerFixture, identifier: str):
+        subject = self.create_subject(mocker)
+
+        class NoValueSensor:
+            pass
+
+        self.variable_manager.get_sensor = lambda _, __: NoValueSensor
 
         with pytest.raises(InvalidIdentifierException):
             subject.identifier(identifier)

--- a/common/python/tests/event/test_action.py
+++ b/common/python/tests/event/test_action.py
@@ -1,0 +1,72 @@
+import pytest
+
+from powerpi_common.event.action import device_additional_state_action, device_off_action, \
+    device_on_action
+
+pytestmark = pytest.mark.asyncio
+
+
+class DeviceImpl:
+    def __init__(self):
+        self.state = None
+        self.additional_state = {
+            'brightness': None,
+            'other': True
+        }
+
+    async def turn_on(self):
+        self.state = 'on'
+
+    async def turn_off(self):
+        self.state = 'off'
+
+    async def change_power_and_additional_state(self, _, new_additional_state: dict):
+        self.additional_state = new_additional_state
+
+
+async def test_device_on_action():
+    device = DeviceImpl()
+
+    assert device.state is None
+
+    await device_on_action(device)
+
+    assert device.state == 'on'
+
+
+async def test_device_off_action():
+    device = DeviceImpl()
+
+    assert device.state is None
+
+    await device_off_action(device)
+
+    assert device.state == 'off'
+
+
+async def test_device_additional_state_action():
+    device = DeviceImpl()
+
+    patch = [
+        {
+            'op': 'replace',
+            'path': '/brightness',
+            'value': '+5000'
+        },
+        {
+            'op': 'add',
+            'path': '/something',
+            'value': 'boom'
+        }
+    ]
+
+    func = device_additional_state_action(patch)
+
+    assert device.additional_state['brightness'] is None
+    assert device.additional_state['other'] is True
+
+    await func(device)
+
+    assert device.additional_state['brightness'] == '+5000'
+    assert device.additional_state['something'] == 'boom'
+    assert device.additional_state['other'] is True

--- a/common/python/tests/event/test_manager.py
+++ b/common/python/tests/event/test_manager.py
@@ -1,6 +1,5 @@
 from unittest.mock import patch
 
-import pytest
 from pytest_mock import MockerFixture
 
 from powerpi_common.device import DeviceConfigType, DeviceNotFoundException

--- a/controllers/energenie/pyproject.toml
+++ b/controllers/energenie/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "energenie_controller"
-version = "0.1.6"
+version = "0.1.7"
 description = "PowerPi Engergenie Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/harmony/pyproject.toml
+++ b/controllers/harmony/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "harmony_controller"
-version = "0.1.4"
+version = "0.1.5"
 description = "PowerPi Logitech Harmony Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/lifx/pyproject.toml
+++ b/controllers/lifx/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lifx_controller"
-version = "0.1.4"
+version = "0.1.5"
 description = "PowerPi LIFX Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/macro/macro_controller/device/__init__.py
+++ b/controllers/macro/macro_controller/device/__init__.py
@@ -3,3 +3,4 @@ from .delay import DelayDevice
 from .log import LogDevice
 from .mutex import MutexDevice
 from .remote import RemoteDevice
+from .variable import VariableDevice

--- a/controllers/macro/macro_controller/device/container.py
+++ b/controllers/macro/macro_controller/device/container.py
@@ -1,11 +1,12 @@
 from dependency_injector import containers, providers
 
-from .composite import CompositeDevice
-from .delay import DelayDevice
-from .factory import RemoteDeviceFactory
-from .log import LogDevice
-from .mutex import MutexDevice
-from .remote import RemoteDevice
+from macro_controller.device.composite import CompositeDevice
+from macro_controller.device.delay import DelayDevice
+from macro_controller.device.factory import RemoteDeviceFactory
+from macro_controller.device.log import LogDevice
+from macro_controller.device.mutex import MutexDevice
+from macro_controller.device.remote import RemoteDevice
+from macro_controller.device.variable import VariableDevice
 
 
 class DeviceContainer(containers.DeclarativeContainer):
@@ -79,6 +80,17 @@ def add_devices(container):
         'remote_device',
         providers.Factory(
             RemoteDevice,
+            config=container.common.config,
+            logger=container.common.logger,
+            mqtt_client=container.common.mqtt_client
+        )
+    )
+
+    setattr(
+        device_container,
+        'variable_device',
+        providers.Factory(
+            VariableDevice,
             config=container.common.config,
             logger=container.common.logger,
             mqtt_client=container.common.mqtt_client

--- a/controllers/macro/macro_controller/device/variable.py
+++ b/controllers/macro/macro_controller/device/variable.py
@@ -1,0 +1,25 @@
+from powerpi_common.config import Config
+from powerpi_common.device import Device
+from powerpi_common.logger import Logger
+from powerpi_common.mqtt import MQTTClient
+
+
+class VariableDevice(Device):
+    def __init__(
+        self,
+        config: Config,
+        logger: Logger,
+        mqtt_client: MQTTClient,
+        **kwargs
+    ):
+        Device.__init__(
+            self, config, logger, mqtt_client, **kwargs
+        )
+
+    async def _turn_on(self):
+        # doesn't have to do anything special, just broadcast the status change
+        pass
+
+    async def _turn_off(self):
+        # doesn't have to do anything special, just broadcast the status change
+        pass

--- a/controllers/macro/pyproject.toml
+++ b/controllers/macro/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "macro_controller"
-version = "1.1.7"
+version = "1.1.8"
 description = "PowerPi Macro Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/macro/tests/device/test_variable.py
+++ b/controllers/macro/tests/device/test_variable.py
@@ -1,0 +1,14 @@
+from pytest_mock import MockerFixture
+
+from macro_controller.device import VariableDevice
+from powerpi_common_test.device import DeviceTestBase
+
+
+class TestVariableDevice(DeviceTestBase):
+    def get_subject(self, _: MockerFixture):
+        self.message = 'test message'
+
+        return VariableDevice(
+            self.config, self.logger, self.mqtt_client,
+            name='variable'
+        )

--- a/controllers/zigbee/pyproject.toml
+++ b/controllers/zigbee/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zigbee_controller"
-version = "0.1.5"
+version = "0.1.6"
 description = "PowerPi ZigBee Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -91,13 +91,13 @@ services:
         environment:
             - ENV=ENERGENIE_DEVICE=ENER314-RT:DEVICE_FATAL=true
             - CONTROLLER_NAME=energenie-controller
-            - IMAGE=${REGISTRY}/powerpi/energenie-controller:0.1.6
+            - IMAGE=${REGISTRY}/powerpi/energenie-controller:0.1.7
             - DEVICE=/dev/gpiomem
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock
 
     harmony-controller:
-        image: ${REGISTRY}/powerpi/harmony-controller:0.1.4
+        image: ${REGISTRY}/powerpi/harmony-controller:0.1.5
         networks:
             - powerpi
         deploy:
@@ -106,7 +106,7 @@ services:
             - mosquitto
 
     lifx-controller:
-        image: ${REGISTRY}/powerpi/lifx-controller:0.1.4
+        image: ${REGISTRY}/powerpi/lifx-controller:0.1.5
         networks:
             - powerpi
         deploy:
@@ -128,7 +128,7 @@ services:
         environment:
             - ENV=ZIGBEE_DEVICE=/dev/ttyACM0:DATABASE_PATH=/var/data/zigbee.db
             - CONTROLLER_NAME=zigbee-controller
-            - IMAGE=${REGISTRY}/powerpi/zigbee-controller:0.1.5
+            - IMAGE=${REGISTRY}/powerpi/zigbee-controller:0.1.6
             - DEVICE=/dev/ttyACM0
             - VOLUME=/srv/docker-volumes/powerpi/zigbee-controller
         volumes:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -69,7 +69,7 @@ services:
             - deep-thought
 
     macro-controller:
-        image: ${REGISTRY}/powerpi/macro-controller:1.1.7
+        image: ${REGISTRY}/powerpi/macro-controller:1.1.8
         networks:
             - powerpi
         deploy:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -156,7 +156,7 @@ services:
             - FREEDNS_PASSWORD=/var/run/secrets/powerpi_freedns
 
     nginx:
-        image: ${REGISTRY}/powerpi/nginx:1.2.10
+        image: ${REGISTRY}/powerpi/nginx:1.2.11
         networks:
             - powerpi
         ports:

--- a/services/nginx/ui/package.json
+++ b/services/nginx/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@powerpi/ui",
-    "version": "1.2.10",
+    "version": "1.2.11",
     "description": "PowerPi UI",
     "private": true,
     "license": "GPL-3.0-only",

--- a/services/nginx/ui/src/components/Components/DeviceIcon/DeviceIcon.tsx
+++ b/services/nginx/ui/src/components/Components/DeviceIcon/DeviceIcon.tsx
@@ -1,4 +1,5 @@
 import {
+    faEquals,
     faLayerGroup,
     faLightbulb,
     faLock,
@@ -53,6 +54,9 @@ function getDeviceTypeIcon(type: string) {
                 case "socket":
                 case "socket_group":
                     return faPlug;
+
+                case "variable":
+                    return faEquals;
 
                 default:
                     return faQuestion;


### PR DESCRIPTION
- Resolves #148 by adding new (state only) variable device to `macro-controller` and including an icon in the UI.
- Resolves #150 by evaluating the value in the patch command to replace with any variable type, or in fact conditional expression.
- Fixes #146 by handling the error if `state` or `value` is missing from the sensor returned by `VariableManager`. At the moment there are no sensors that produce value/unit pairs in a controller.