### PR TITLE
#158 Add maximum threshold value to energy-monitor

### DIFF
--- a/common/node/common/package.json
+++ b/common/node/common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@powerpi/common",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "description": "PowerPi Common Typescript library",
     "private": true,
     "license": "GPL-3.0-only",

--- a/common/node/common/src/services/mqtt.ts
+++ b/common/node/common/src/services/mqtt.ts
@@ -25,7 +25,11 @@ export class MqttService {
     }
 
     private get clientId() {
-        return `${this.config.service}-${os.hostname}`;
+        const prefix = this.config.service.indexOf("/")
+            ? this.config.service.split("/").slice(-1)[0]
+            : this.config.service;
+
+        return `${prefix}-${os.hostname}`;
     }
 
     public async connect() {

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -221,7 +221,7 @@ services:
             - DB_SECRET_FILE=/var/run/secrets/powerpi_db
 
     energy-monitor:
-        image: ${REGISTRY}/powerpi/energy-monitor:0.0.3
+        image: ${REGISTRY}/powerpi/energy-monitor:0.0.4
         networks:
             - powerpi
         deploy:

--- a/services/babel-fish/package.json
+++ b/services/babel-fish/package.json
@@ -18,7 +18,7 @@
     },
     "dependencies": {
         "@powerpi/api": "^0.0.10",
-        "@powerpi/common": "^0.0.7",
+        "@powerpi/common": "^0.0.8",
         "@types/express": "^4.17.12",
         "@types/node": "^16.11.12",
         "@types/socket.io-client": "^3.0.0",

--- a/services/clacks-config/package.json
+++ b/services/clacks-config/package.json
@@ -16,7 +16,7 @@
     },
     "dependencies": {
         "@octokit/rest": "^18.12.0",
-        "@powerpi/common": "^0.0.7",
+        "@powerpi/common": "^0.0.8",
         "@types/node": "^16.11.4",
         "ts-node": "^10.4.0",
         "typedi": "^0.10.0",

--- a/services/deep-thought/package.json
+++ b/services/deep-thought/package.json
@@ -16,7 +16,7 @@
     },
     "dependencies": {
         "@powerpi/api": "^0.0.10",
-        "@powerpi/common": "^0.0.7",
+        "@powerpi/common": "^0.0.8",
         "@tsed/common": "^6.115.0",
         "@tsed/core": "^6.115.0",
         "@tsed/di": "^6.115.0",

--- a/services/energy-monitor/Dockerfile
+++ b/services/energy-monitor/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /home/node/app
 RUN mkdir -p /home/node/app/common/node/common
 COPY package.json yarn.lock tsconfig.json ./
 COPY common/node/common/package.json ./common/node/common/
-RUN yarn workspace @powerpi/common install
+RUN yarn workspace @powerpi/common install --frozen-lockfile
 COPY common/node/common ./common/node/common/
 RUN yarn workspace @powerpi/common build
 
@@ -26,7 +26,7 @@ COPY --from=build-image --chown=node:node /home/node/app/common/node/common/dist
 
 # install the dependencies
 COPY --chown=node:node services/energy-monitor/package.json ./services/energy-monitor
-RUN yarn workspace @powerpi/energy-monitor install --production
+RUN yarn workspace @powerpi/energy-monitor install --production --frozen-lockfile
 
 # copy the application
 COPY --chown=node:node services/energy-monitor ./services/energy-monitor

--- a/services/energy-monitor/README.md
+++ b/services/energy-monitor/README.md
@@ -20,6 +20,8 @@ This service expects the following environment variables to be set before it wil
 
 -   **MQTT_ADDRESS** - The URI to the MQTT instance to use, e.g. _mqtt://POWERPI_URL:1883_
 -   **IHD_SECRET_FILE** - The path to a file which contains the IHD (In Home Device) MAC address, which is used to authenticate against N3rgy. In the form _00-00-00-00-00-00-00-00_.
+-   **MAXIUM_THRESHOLD** - The maximum value to publish in a message, used to prevent large erroneous valeus from upsetting charts (default _undefined_).
+-   **MESSAGE_WRITE_DELAY** - The number of milliseconds to wait between publishing each message, to ensure we don't overwhelm the message queue (default _100_).
 
 ## Testing
 

--- a/services/energy-monitor/package.json
+++ b/services/energy-monitor/package.json
@@ -15,7 +15,7 @@
         "start": "ts-node src/index.ts"
     },
     "dependencies": {
-        "@powerpi/common": "^0.0.7",
+        "@powerpi/common": "^0.0.8",
         "@types/dateformat": "^5.0.0",
         "@types/node": "^18.0.0",
         "axios": "^0.27.2",

--- a/services/energy-monitor/package.json
+++ b/services/energy-monitor/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@powerpi/energy-monitor",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "description": "PowerPi n3rgy energy usage retrieval service",
     "private": true,
     "license": "GPL-3.0-only",
@@ -16,12 +16,12 @@
     },
     "dependencies": {
         "@powerpi/common": "^0.0.7",
-        "@types/dateformat": "^3.0.1",
-        "@types/node": "^16.0.0",
-        "axios": "^0.21.4",
-        "dateformat": "^4.5.1",
-        "ts-node": "^10.0.0",
+        "@types/dateformat": "^5.0.0",
+        "@types/node": "^18.0.0",
+        "axios": "^0.27.2",
+        "dateformat": "^4.6.3",
+        "ts-node": "^10.8.1",
         "typedi": "^0.10.0",
-        "typescript": "^4.3.5"
+        "typescript": "^4.7.4"
     }
 }

--- a/services/energy-monitor/src/services/config.ts
+++ b/services/energy-monitor/src/services/config.ts
@@ -38,6 +38,15 @@ export default class ConfigService extends CommonConfigService {
         const str = process.env["TIMEOUT_OFFSET"] ?? "30 minutes";
         return this.interval.parse(str);
     }
+
+    get maximumThreshold() {
+        const threshold = process.env["MAXIMUM_THRESHOLD"];
+        if (threshold) {
+            return parseInt(threshold);
+        }
+
+        return undefined;
+    }
 }
 
 Container.override(CommonConfigService, ConfigService);

--- a/services/energy-monitor/src/services/config.ts
+++ b/services/energy-monitor/src/services/config.ts
@@ -47,6 +47,16 @@ export default class ConfigService extends CommonConfigService {
 
         return undefined;
     }
+
+    get messageWriteDelay() {
+        const delay = process.env["MESSAGE_WRITE_DELAY"] ?? 100;
+
+        if (typeof delay === "string") {
+            return parseInt(delay);
+        }
+
+        return delay;
+    }
 }
 
 Container.override(CommonConfigService, ConfigService);

--- a/services/energy-monitor/src/services/monitor.ts
+++ b/services/energy-monitor/src/services/monitor.ts
@@ -22,8 +22,8 @@ export default class EnergyMonitorService {
     }
 
     public start() {
-        this.update("electricity");
-        this.update("gas");
+        this.update(EnergyType.Electricity);
+        this.update(EnergyType.Gas);
     }
 
     private async update(energyType: EnergyType) {
@@ -33,7 +33,7 @@ export default class EnergyMonitorService {
         this.logger.info("Retrieving", energyType, "usage between", start, "and", end);
 
         const generator = getData(
-            energyType === "electricity" ? this.n3rgy.getElecticity : this.n3rgy.getGas,
+            energyType === EnergyType.Electricity ? this.n3rgy.getElecticity : this.n3rgy.getGas,
             energyType,
             start,
             end,

--- a/services/energy-monitor/src/services/n3rgy.ts
+++ b/services/energy-monitor/src/services/n3rgy.ts
@@ -4,7 +4,10 @@ import { Service } from "typedi";
 import N3rgyData from "../models/n3rgy";
 import ConfigService from "./config";
 
-export type EnergyType = "electricity" | "gas";
+export enum EnergyType {
+    Electricity = "electricity",
+    Gas = "gas",
+}
 
 @Service()
 export default class N3rgyService {
@@ -12,30 +15,29 @@ export default class N3rgyService {
 
     constructor(private config: ConfigService) {}
 
-    public getElecticity = (start: Date, end: Date) => this.get("electricity", start, end);
+    public getElecticity = (start: Date, end: Date) => this.get(EnergyType.Electricity, start, end);
 
-    public getGas = (start: Date, end: Date) => this.get("gas", start, end);
+    public getGas = (start: Date, end: Date) => this.get(EnergyType.Gas, start, end);
 
     private async get(energyType: EnergyType, start: Date, end: Date) {
         const url = `${this.config.n3rgyApiBase}/${energyType}/consumption/1`;
+
         const params = {
             start: dateFormat(start, N3rgyService.dateFormatString),
             end: dateFormat(end, N3rgyService.dateFormatString),
         };
 
-        const result = await axios.get(url, {
+        const { data, status } = await axios.get<N3rgyData>(url, {
             params,
             headers: {
                 Authorization: await this.config.ihdId,
-                "User-Agent": `powerpi-${this.config.service} ${this.config.version}`,
+                "User-Agent": `${this.config.service}/${this.config.version}`,
             },
         });
 
-        if (!(result?.status >= 200 && result?.status < 300)) {
-            throw `API call returned ${result.status}`;
+        if (!(status >= 200 && status < 300)) {
+            throw `API call returned ${status}`;
         }
-
-        const data = result?.data as N3rgyData;
 
         if (data.message) {
             throw data.message;

--- a/services/light-fantastic/package.json
+++ b/services/light-fantastic/package.json
@@ -15,7 +15,7 @@
         "start": "ts-node src/index.ts"
     },
     "dependencies": {
-        "@powerpi/common": "^0.0.7",
+        "@powerpi/common": "^0.0.8",
         "@types/luxon": "^2.0.5",
         "@types/node": "^16.11.2",
         "luxon": "^2.0.2",

--- a/services/persistence/package.json
+++ b/services/persistence/package.json
@@ -15,7 +15,7 @@
         "start": "ts-node src/app.ts"
     },
     "dependencies": {
-        "@powerpi/common": "^0.0.7",
+        "@powerpi/common": "^0.0.8",
         "@types/bluebird": "^3.5.32",
         "@types/node": "^16.11.12",
         "@types/validator": "^13.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1133,11 +1133,6 @@
   resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.12.tgz#6b2c510a7ad7039e98e7b8d3d6598f4359e5c080"
   integrity sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==
 
-"@types/dateformat@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@types/dateformat/-/dateformat-3.0.1.tgz#98d747a2e5e9a56070c6bf14e27bff56204e34cc"
-  integrity sha512-KlPPdikagvL6ELjWsljbyDIPzNCeliYkqRpI+zea99vBBbCIA5JNshZAwQKTON139c87y9qvTFVgkFd14rtS4g==
-
 "@types/dateformat@^5.0.0":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@types/dateformat/-/dateformat-5.0.0.tgz#17ce64b0318f3f36d1c830c58a7a915445f1f93d"
@@ -1297,7 +1292,7 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.52.tgz#03c13be70b9031baaed79481c0c0cfb0045e53f7"
   integrity sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==
 
-"@types/node@^16.0.0", "@types/node@^16.11.12", "@types/node@^16.11.2", "@types/node@^16.11.4":
+"@types/node@^16.11.12", "@types/node@^16.11.2", "@types/node@^16.11.4":
   version "16.11.41"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.41.tgz#88eb485b1bfdb4c224d878b7832239536aa2f813"
   integrity sha512-mqoYK2TnVjdkGk8qXAVGc/x9nSaTpSrFaGFm43BUH3IdoBV0nta6hYaGmdOvIMlbHJbUEVen3gvwpwovAZKNdQ==
@@ -2024,7 +2019,7 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-axios@^0.21.1, axios@^0.21.2, axios@^0.21.4:
+axios@^0.21.1, axios@^0.21.2:
   version "0.21.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
@@ -2758,7 +2753,7 @@ date-format@^4.0.6:
   resolved "https://registry.yarnpkg.com/date-format/-/date-format-4.0.11.tgz#ae0d1e069d7f0687938fd06f98c12f3a6276e526"
   integrity sha512-VS20KRyorrbMCQmpdl2hg5KaOUsda1RbnsJg461FfrcyCUg+pkd0b40BSW4niQyTheww4DBXQnS7HwSrKkipLw==
 
-dateformat@^4.5.1, dateformat@^4.6.2:
+dateformat@^4.6.2, dateformat@^4.6.3:
   version "4.6.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.6.3.tgz#556fa6497e5217fedb78821424f8a1c22fa3f4b5"
   integrity sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==


### PR DESCRIPTION
- Fixes #158 by adding a maximum threshold value to `energy-monitor`, if a value in the data response exceeds this it won't be published to the queue. Unfortunately the bad data is coming from the service.
- Upgraded packages in `energy-monitor`.
- Added a delay when writing the energy values to the message queue, to ensure the queue (and the `persistence` service) isn't overwhelmed by the number of messages all at once.
- Fixed the MQTT client id from `@powerpi/common` as it contained "@powerpi" as all the services now have that in their name.