### PR TITLE
#157 Use variable expressions for conditions

### DIFF
--- a/common/python/powerpi_common/condition/lexeme.py
+++ b/common/python/powerpi_common/condition/lexeme.py
@@ -11,6 +11,7 @@ class Lexeme(str, Enum):
     LESS_THAN_EQUAL = 'less than equal'
     NOT = 'not'
     OR = 'or'
+    VAR = 'var'
     WHEN = 'when'
 
     # symbol aliases

--- a/common/python/pyproject.toml
+++ b/common/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "powerpi-common"
-version = "0.2.4"
+version = "0.2.5"
 description = "PowerPi Common Python Library"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/common/python/tests/event/test_action.py
+++ b/common/python/tests/event/test_action.py
@@ -86,7 +86,7 @@ async def test_device_additional_state_action_with_variable(mocker: MockerFixtur
         {
             'op': 'replace',
             'path': '/brightness',
-            'value': 'var.device.Light.other'
+            'value': {'var': 'device.Light.other'}
         },
     ]
 

--- a/controllers/energenie/pyproject.toml
+++ b/controllers/energenie/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "energenie_controller"
-version = "0.1.7"
+version = "0.1.8"
 description = "PowerPi Engergenie Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/harmony/pyproject.toml
+++ b/controllers/harmony/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "harmony_controller"
-version = "0.1.5"
+version = "0.1.6"
 description = "PowerPi Logitech Harmony Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/lifx/pyproject.toml
+++ b/controllers/lifx/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lifx_controller"
-version = "0.1.5"
+version = "0.1.6"
 description = "PowerPi LIFX Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/macro/pyproject.toml
+++ b/controllers/macro/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "macro_controller"
-version = "1.1.8"
+version = "1.1.9"
 description = "PowerPi Macro Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/zigbee/pyproject.toml
+++ b/controllers/zigbee/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zigbee_controller"
-version = "0.1.6"
+version = "0.1.7"
 description = "PowerPi ZigBee Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -69,7 +69,7 @@ services:
             - deep-thought
 
     macro-controller:
-        image: ${REGISTRY}/powerpi/macro-controller:1.1.8
+        image: ${REGISTRY}/powerpi/macro-controller:1.1.9
         networks:
             - powerpi
         deploy:
@@ -91,13 +91,13 @@ services:
         environment:
             - ENV=ENERGENIE_DEVICE=ENER314-RT:DEVICE_FATAL=true
             - CONTROLLER_NAME=energenie-controller
-            - IMAGE=${REGISTRY}/powerpi/energenie-controller:0.1.7
+            - IMAGE=${REGISTRY}/powerpi/energenie-controller:0.1.8
             - DEVICE=/dev/gpiomem
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock
 
     harmony-controller:
-        image: ${REGISTRY}/powerpi/harmony-controller:0.1.5
+        image: ${REGISTRY}/powerpi/harmony-controller:0.1.6
         networks:
             - powerpi
         deploy:
@@ -106,7 +106,7 @@ services:
             - mosquitto
 
     lifx-controller:
-        image: ${REGISTRY}/powerpi/lifx-controller:0.1.5
+        image: ${REGISTRY}/powerpi/lifx-controller:0.1.6
         networks:
             - powerpi
         deploy:
@@ -128,7 +128,7 @@ services:
         environment:
             - ENV=ZIGBEE_DEVICE=/dev/ttyACM0:DATABASE_PATH=/var/data/zigbee.db
             - CONTROLLER_NAME=zigbee-controller
-            - IMAGE=${REGISTRY}/powerpi/zigbee-controller:0.1.6
+            - IMAGE=${REGISTRY}/powerpi/zigbee-controller:0.1.7
             - DEVICE=/dev/ttyACM0
             - VOLUME=/srv/docker-volumes/powerpi/zigbee-controller
         volumes:


### PR DESCRIPTION
Resolves #157, instead of `"var.device.DeviceName.property"` for a variable condition, which looks weird and means certain strings aren't allowable use `{"var": "device.DeviceName.property"}`.