### PR TITLE
#170 Fix interval issue in esp8266 sensors

### DIFF
--- a/esp8266/configure.ac
+++ b/esp8266/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([powerpi-sensor], [0.2.0])
+AC_INIT([powerpi-sensor], [0.2.1])
 
 dnl The arguments the user can override
 AC_ARG_VAR([location], [The location of this sensor])

--- a/esp8266/src/clacks.ino
+++ b/esp8266/src/clacks.ino
@@ -24,7 +24,7 @@ void setupClacksConfig() {
             mqttClient.loop();
 
             // terminate if we can't get the configuration after 60s
-            if(counter++ >= CONFIG_WAIT) {
+            if(++counter >= CONFIG_WAIT) {
                 Serial.println("No configuration received, giving up...");
                 useDefaultConfig();
                 return;

--- a/esp8266/src/dht22.ino
+++ b/esp8266/src/dht22.ino
@@ -15,7 +15,7 @@ void configureDHT22(ArduinoJson::JsonVariant config) {
 
 void pollDHT22() {
     // check if we've skipped enough counts
-    if(dhtCounter++ >= clacksConfig.dht22Skip) {
+    if(++dhtCounter >= clacksConfig.dht22Skip) {
         dhtCounter = 0;
 
         float humidity = dht.readHumidity();

--- a/esp8266/src/pir.ino
+++ b/esp8266/src/pir.ino
@@ -29,7 +29,7 @@ void configurePIR(ArduinoJson::JsonVariant config) {
 void pollPIR() {
     // check if we're skipping
     if(pirCounterMax > 0) {
-        if(pirCounter++ >= pirCounterMax) {
+        if(++pirCounter >= pirCounterMax) {
             pirCounter = 0;
             pirCounterMax = 0;
         } else {


### PR DESCRIPTION
Fixes #170 by using `++counter >= skip`.