### PR TITLE
#173 Support pressing powerpi-sensor button

### DIFF
--- a/esp8266/Makefile.in
+++ b/esp8266/Makefile.in
@@ -12,6 +12,7 @@ SERIAL_PORT?=/dev/ttyUSB0
 ADAFRUIT_SENSOR_VERSION=1.1.5
 ARDUINO_JSON_VERSION=v6.19.4
 DHT_SENSOR_VERSION=1.4.4
+EASY_BUTTON_VERSION=v2.0.1
 NTPCLIENT_VERSION=3.2.1
 PUBSUBCLIENT_VERSION=v2.8
 
@@ -32,11 +33,15 @@ endef
 
 all: compile flash monitor
 
-common_libraries: $(LIB_DIR)/ArduinoJson-$(ARDUINO_JSON_VERSION) $(LIB_DIR)/NTPClient-$(NTPCLIENT_VERSION) $(LIB_DIR)/pubsubclient-$(PUBSUBCLIENT_VERSION)
+common_libraries: $(LIB_DIR)/ArduinoJson-$(ARDUINO_JSON_VERSION) $(LIB_DIR)/EasyButton-$(EASY_BUTTON_VERSION) $(LIB_DIR)/NTPClient-$(NTPCLIENT_VERSION) $(LIB_DIR)/pubsubclient-$(PUBSUBCLIENT_VERSION)
 
 # Download Arduino JSON library
 $(LIB_DIR)/ArduinoJson-$(ARDUINO_JSON_VERSION):
 	$(call download_lib,ArduinoJson,$(ARDUINO_JSON_VERSION),bblanchon)
+
+# Download EasyButton library
+$(LIB_DIR)/EasyButton-$(EASY_BUTTON_VERSION):
+	$(call download_lib,EasyButton,$(EASY_BUTTON_VERSION),evert-arias)
 
 # Download NTPClient library
 $(LIB_DIR)/NTPClient-$(NTPCLIENT_VERSION):

--- a/esp8266/README.md
+++ b/esp8266/README.md
@@ -46,8 +46,11 @@ By default a sensor will retrieve configuration from [_clacks-config_](../servic
 # Configure a temperature/humidity sensor
 ./configure --enable-dht22 location=Bedroom
 
+# Configure a temperature/humidity sensor with button press support
+./configure --enable-dht22 --enable-button location=Bedroom
+
 # Configure a combined sensor
-./configure --enable-dht22 --enable-pir location=Office
+./configure --enable-dht22 --enable-pir --enable-button location=Office
 
 # Configure a sensor that doesn't get configuration from clacks-config
 ./configure --enable-dht22 --disable-clacks location=Lounge

--- a/esp8266/configure.ac
+++ b/esp8266/configure.ac
@@ -50,6 +50,15 @@ AC_ARG_ENABLE(
 )
 AC_SUBST([enable_pir])
 
+dnl Identify whether to include the button
+AC_ARG_ENABLE(
+    [button],
+    [AS_HELP_STRING([--enable-button], [Enable button press support])],
+    [enable_button=1],
+    [enable_button=0]
+)
+AC_SUBST([enable_button])
+
 dnl Find the arduino IDE
 AC_CHECK_PROG([ARDUINO], [arduino], $(whereis arduino -b | cut -d':' -f 2), [no])
 if test "$ARDUINO" == "no"

--- a/esp8266/configure.ac
+++ b/esp8266/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([powerpi-sensor], [0.2.1])
+AC_INIT([powerpi-sensor], [0.2.2])
 
 dnl The arguments the user can override
 AC_ARG_VAR([location], [The location of this sensor])

--- a/esp8266/src/button.h
+++ b/esp8266/src/button.h
@@ -1,0 +1,19 @@
+#ifndef __INCLUDED_BUTTON_H
+#define __INCLUDED_BUTTON_H
+
+#include <ArduinoJson.h>
+#include <EasyButton.h>
+
+#include "mqtt.h"
+
+// the data pin for the button (GPIO0/D3)
+#define BUTTON_PIN 0
+
+// the button instance to use
+EasyButton button(BUTTON_PIN);
+
+void setupButton();
+void pollButton();
+void handleButtonPress();
+
+#endif

--- a/esp8266/src/button.ino
+++ b/esp8266/src/button.ino
@@ -1,0 +1,23 @@
+#include "button.h"
+
+void setupButton() {
+    button.begin();
+    
+    button.onPressed(handleButtonPress);
+
+    button.enableInterrupt(pollButton);
+}
+
+void pollButton() {
+    button.read();
+}
+
+void handleButtonPress() {
+    StaticJsonDocument<96> message;
+
+    message["button"] = "default";
+    message["type"] = "single";
+    publish("press", message);
+
+    Serial.print("p");
+}

--- a/esp8266/src/config.h.in
+++ b/esp8266/src/config.h.in
@@ -41,4 +41,9 @@
     #define MOTION_SENSOR
 #endif
 
+// include the button functionality
+#if @enable_button@
+    #define BUTTON_SENSOR
+#endif
+
 #endif

--- a/esp8266/src/mqtt.h
+++ b/esp8266/src/mqtt.h
@@ -31,6 +31,6 @@ PubSubClient mqttClient(espClient);
 
 void setupMQTT();
 void connectMQTT(bool waitForNTP);
-void publish(char* action, ArduinoJson::JsonDocument& message);
+void publish(const char action[], ArduinoJson::JsonDocument& message);
 
 #endif

--- a/esp8266/src/mqtt.ino
+++ b/esp8266/src/mqtt.ino
@@ -30,7 +30,7 @@ void connectMQTT(bool waitForNTP) {
     }
 }
 
-void publish(char* action, ArduinoJson::JsonDocument& message) {
+void publish(const char action[], ArduinoJson::JsonDocument& message) {
     // retrieve the timestamp
     unsigned long long timestamp = timeClient.getEpochTime();
 

--- a/esp8266/src/sensors.h
+++ b/esp8266/src/sensors.h
@@ -4,6 +4,7 @@
 #include <ArduinoJson.h>
 
 #include "config.h"
+#include "button.h"
 #include "dht22.h"
 #include "pir.h"
 

--- a/esp8266/src/sensors.ino
+++ b/esp8266/src/sensors.ino
@@ -15,6 +15,11 @@ void setupSensors() {
         Serial.println("Humidity Sensor");
     #endif
 
+    #ifdef BUTTON_SENSOR
+        Serial.println("Button Sensor");
+        setupButton();
+    #endif
+
     Serial.println("Ready");
 }
 


### PR DESCRIPTION
- Resolves #173 by generating an event when the sensor built-in button is pressed.
- Can be disabled when compiling the firmware.
- Fix warnings with MQTT publish method and constant string conversion