### PR TITLE
#197 Fix sensor temperature/humidity rounding

### DIFF
--- a/esp8266/configure.ac
+++ b/esp8266/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([powerpi-sensor], [0.2.2])
+AC_INIT([powerpi-sensor], [0.2.3])
 
 dnl The arguments the user can override
 AC_ARG_VAR([location], [The location of this sensor])

--- a/esp8266/src/dht22.h
+++ b/esp8266/src/dht22.h
@@ -24,6 +24,6 @@ unsigned short dhtCounter = USHRT_MAX - 1;
 void setupDHT22();
 void configureDHT22(ArduinoJson::JsonVariant config);
 void pollDHT22();
-double round(double value);
+double round2dp(double value);
 
 #endif

--- a/esp8266/src/dht22.ino
+++ b/esp8266/src/dht22.ino
@@ -29,12 +29,12 @@ void pollDHT22() {
         StaticJsonDocument<96> message;
 
         // generate and publish the temperature message
-        message["value"] = round(temperature);
+        message["value"] = round2dp(temperature);
         message["unit"] = "°C";
         publish("temperature", message);
 
         // generate and publish the humidity message
-        message["value"] = round(humidity);
+        message["value"] = round2dp(humidity);
         message["unit"] = "%";
         publish("humidity", message);
 
@@ -42,6 +42,6 @@ void pollDHT22() {
     }
 }
 
-double round(double value) {
+double round2dp(double value) {
    return (int)(value * 100 + 0.5) / 100.0;
 }


### PR DESCRIPTION
Resolves #197 by renaming the `round` to `round2dp` function as it was being overridden by the built-in `round` function.