### PR TITLE
#202 Use aiolifx library in lifx-controller

### DIFF
--- a/controllers/lifx/lifx_controller/container.py
+++ b/controllers/lifx/lifx_controller/container.py
@@ -1,8 +1,8 @@
 from dependency_injector import containers, providers
+from powerpi_common.container import Container as CommonContainer
 
 from lifx_controller.__version__ import __app_name__, __version__
 from lifx_controller.device.container import DeviceContainer
-from powerpi_common.container import Container as CommonContainer
 
 
 class ApplicationContainer(containers.DeclarativeContainer):
@@ -20,5 +20,6 @@ class ApplicationContainer(containers.DeclarativeContainer):
     )
 
     device = providers.Container(
-        DeviceContainer
+        DeviceContainer,
+        logger=common.logger
     )

--- a/controllers/lifx/lifx_controller/device/container.py
+++ b/controllers/lifx/lifx_controller/device/container.py
@@ -11,8 +11,11 @@ class DeviceContainer(containers.DeclarativeContainer):
         __self__
     )
 
+    logger = providers.Dependency()
+
     lifx_client = providers.Factory(
-        LIFXClient
+        LIFXClient,
+        logger=logger
     )
 
 

--- a/controllers/lifx/lifx_controller/device/lifx_client.py
+++ b/controllers/lifx/lifx_controller/device/lifx_client.py
@@ -1,4 +1,3 @@
-import re
 from asyncio import get_running_loop
 from socket import AF_INET, SOCK_STREAM, gethostbyname, socket
 from typing import Callable, Tuple, Union
@@ -30,10 +29,6 @@ class LIFXClient:
 
     @address.setter
     def address(self, new_address: str):
-        if re.search('[a-zA-Z]', new_address):
-            # if it's not an IP address, get the IP address
-            new_address = gethostbyname(new_address)
-
         self.__address = new_address
 
     @property
@@ -146,6 +141,7 @@ class LIFXClient:
 
         # a callback that will set the results in the future
         def callback(*args):
+            print(args[0].__dict__)
             loop.call_soon_threadsafe(future.set_result, args)
 
         # call the method using the callback

--- a/controllers/lifx/lifx_controller/device/lifx_client.py
+++ b/controllers/lifx/lifx_controller/device/lifx_client.py
@@ -95,7 +95,7 @@ class LIFXClient:
         await self.connect()
 
         # ensure the values are in the allowable range
-        if colour.temperature < self.__kelvin_range[0] or colour.temperature > self.__kelvin_range[1]:
+        if self.supports_temperature and (colour.temperature < self.__kelvin_range[0] or colour.temperature > self.__kelvin_range[1]):
             original = colour.temperature
 
             colour.temperature = max(
@@ -115,10 +115,10 @@ class LIFXClient:
 
         features = features_map[version.product]
 
-        self.__supports_colour = getattr(features, 'color', False)
+        self.__supports_colour = features.get('color', False)
 
-        min_kelvin = getattr(features, 'min_kelvin', None)
-        max_kelvin = getattr(features, 'max_kelvin', None)
+        min_kelvin = features.get('min_kelvin', None)
+        max_kelvin = features.get('max_kelvin', None)
 
         self.__kelvin_range = (min_kelvin, max_kelvin)
         self.__supports_temperature = min_kelvin is not None and max_kelvin is not None and min_kelvin != max_kelvin
@@ -141,7 +141,6 @@ class LIFXClient:
 
         # a callback that will set the results in the future
         def callback(*args):
-            print(args[0].__dict__)
             loop.call_soon_threadsafe(future.set_result, args)
 
         # call the method using the callback

--- a/controllers/lifx/lifx_controller/device/lifx_client.py
+++ b/controllers/lifx/lifx_controller/device/lifx_client.py
@@ -76,17 +76,19 @@ class LIFXClient:
         (powered, _) = await self.get_state()
         return powered
 
-    def set_power(self, turn_on: bool, duration: int):
-        self.connect()
-        self.__light.set_power(turn_on, duration)
+    async def set_power(self, turn_on: bool, duration: int):
+        await self.connect()
+
+        await self.__use_callback(self.__light.set_power, value=turn_on, duration=duration)
 
     async def get_colour(self):
         (_, colour) = await self.get_state()
         return colour
 
-    def set_colour(self, colour: LIFXColour, duration: int):
-        self.connect()
-        self.__light.set_color(colour.list, duration)
+    async def set_colour(self, colour: LIFXColour, duration: int):
+        await self.connect()
+
+        await self.__use_callback(self.__light.set_color, value=colour.list, duration=duration)
 
     async def __set_features(self):
         (_, version) = await self.__use_callback(self.__light.get_version)
@@ -105,7 +107,7 @@ class LIFXClient:
         return port
 
     @classmethod
-    async def __use_callback(cls, method: Callable, *args):
+    async def __use_callback(cls, method: Callable, **kwargs):
         loop = get_running_loop()
 
         # create a future we can await to capture the callback results
@@ -116,7 +118,7 @@ class LIFXClient:
             loop.call_soon_threadsafe(future.set_result, args)
 
         # call the method passing the args
-        method(callback, *args)
+        method(callb=callback, **kwargs)
 
         # return the result by awaiting the future
         return await future

--- a/controllers/lifx/lifx_controller/device/lifx_client.py
+++ b/controllers/lifx/lifx_controller/device/lifx_client.py
@@ -120,10 +120,13 @@ class LIFXClient:
 
         features = features_map[version.product]
 
-        self.__supports_colour = features['color']
+        self.__supports_colour = getattr(features, 'color', False)
 
-        self.__kelvin_range = (features['min_kelvin'], features['max_kelvin'])
-        self.__supports_temperature = features['min_kelvin'] != features['max_kelvin']
+        min_kelvin = getattr(features, 'min_kelvin', None)
+        max_kelvin = getattr(features, 'max_kelvin', None)
+
+        self.__kelvin_range = (min_kelvin, max_kelvin)
+        self.__supports_temperature = min_kelvin is not None and max_kelvin is not None and min_kelvin != max_kelvin
 
     @classmethod
     def __find_free_port(cls):

--- a/controllers/lifx/lifx_controller/device/lifx_client.py
+++ b/controllers/lifx/lifx_controller/device/lifx_client.py
@@ -62,20 +62,27 @@ class LIFXClient:
 
             await self.__set_features()
 
-    async def get_power(self):
+    async def get_state(self):
         await self.connect()
 
-        (_, power_level) = await self.__use_callback(self.__light.get_power)
+        (_, response) = await self.__use_callback(self.__light.get_color)
 
-        return power_level.power_level > 0
+        powered = response.power_level > 0
+        colour = LIFXColour(response.color)
+
+        return (powered, colour)
+
+    async def get_power(self):
+        (powered, _) = await self.get_state()
+        return powered
 
     def set_power(self, turn_on: bool, duration: int):
         self.connect()
         self.__light.set_power(turn_on, duration)
 
-    def get_colour(self):
-        self.connect()
-        return LIFXColour(self.__light.get_color())
+    async def get_colour(self):
+        (_, colour) = await self.get_state()
+        return colour
 
     def set_colour(self, colour: LIFXColour, duration: int):
         self.connect()

--- a/controllers/lifx/lifx_controller/device/lifx_light.py
+++ b/controllers/lifx/lifx_controller/device/lifx_light.py
@@ -1,13 +1,11 @@
 from typing import TypedDict, Union
 
-from lifxlan import WorkflowException
-
 from lifx_controller.device.lifx_client import LIFXClient
 from lifx_controller.device.lifx_colour import LIFXColour
 from powerpi_common.config import Config
-from powerpi_common.logger import Logger
 from powerpi_common.device import AdditionalStateDevice, DeviceStatus
 from powerpi_common.device.mixin import PollableMixin
+from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
 
 
@@ -52,12 +50,9 @@ class LIFXLightDevice(AdditionalStateDevice, PollableMixin):
         is_powered: Union[int, None] = None
         colour: Union[LIFXColour, None] = None
 
-        try:
-            is_powered = self.__light.get_power()
-            colour = self.__light.get_colour()
-        except WorkflowException:
-            # this means the light is probably off
-            pass
+        is_powered = await self.__light.get_power()
+        print(is_powered)
+        colour = await self.__light.get_colour()
 
         changed = False
         new_state = self.state
@@ -85,7 +80,7 @@ class LIFXLightDevice(AdditionalStateDevice, PollableMixin):
 
             new_additional_state = lifx_colour.to_json()
 
-            self.__light.set_colour(lifx_colour, self.__duration)
+            await self.__light.set_colour(lifx_colour, self.__duration)
 
         return new_additional_state
 
@@ -100,7 +95,7 @@ class LIFXLightDevice(AdditionalStateDevice, PollableMixin):
         return keys
 
     async def _turn_on(self):
-        self.__light.set_power(True, self.__duration)
+        await self.__light.set_power(True, self.__duration)
 
     async def _turn_off(self):
-        self.__light.set_power(False, self.__duration)
+        await self.__light.set_power(False, self.__duration)

--- a/controllers/lifx/lifx_controller/device/lifx_light.py
+++ b/controllers/lifx/lifx_controller/device/lifx_light.py
@@ -50,9 +50,7 @@ class LIFXLightDevice(AdditionalStateDevice, PollableMixin):
         is_powered: Union[int, None] = None
         colour: Union[LIFXColour, None] = None
 
-        is_powered = await self.__light.get_power()
-        print(is_powered)
-        colour = await self.__light.get_colour()
+        (is_powered, colour) = await self.__light.get_state()
 
         changed = False
         new_state = self.state

--- a/controllers/lifx/poetry.lock
+++ b/controllers/lifx/poetry.lock
@@ -1,4 +1,16 @@
 [[package]]
+name = "aiolifx"
+version = "0.8.4"
+description = "API for local communication with LIFX devices over a LAN with asyncio."
+category = "main"
+optional = false
+python-versions = ">=3.4"
+
+[package.dependencies]
+bitstring = "*"
+ifaddr = "*"
+
+[[package]]
 name = "APScheduler"
 version = "3.9.1"
 description = "In-process task scheduler with Cron-like capabilities"
@@ -192,18 +204,6 @@ description = "A fast and thorough lazy object proxy."
 category = "dev"
 optional = false
 python-versions = ">=3.6"
-
-[[package]]
-name = "lifxlan"
-version = "1.2.7"
-description = "API for local communication with LIFX devices over a LAN."
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-bitstring = "*"
-ifaddr = "*"
 
 [[package]]
 name = "mccabe"
@@ -507,9 +507,13 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "11fd59a52e772f1e8e95fe5f177b924290298200591d3d372929f564d4c44819"
+content-hash = "2ba10b51823893e6d461153d83f7b199b27505a5d1fad7dc6cfa4ee1c08ce868"
 
 [metadata.files]
+aiolifx = [
+    {file = "aiolifx-0.8.4-py3-none-any.whl", hash = "sha256:9bfd5e2da62232463a0f15b3acae80c8c3a255d6ac2c2fd366bb8a50f535bd3f"},
+    {file = "aiolifx-0.8.4.tar.gz", hash = "sha256:af96c1a2602847094823ca53ff6a3ed2f6bfa01af7b3c6fcbf68eaf67e960f02"},
+]
 APScheduler = [
     {file = "APScheduler-3.9.1-py2.py3-none-any.whl", hash = "sha256:ddc25a0ddd899de44d7f451f4375fb971887e65af51e41e5dcf681f59b8b2c9a"},
     {file = "APScheduler-3.9.1.tar.gz", hash = "sha256:65e6574b6395498d371d045f2a8a7e4f7d50c6ad21ef7313d15b1c7cf20df1e3"},
@@ -691,9 +695,6 @@ lazy-object-proxy = [
     {file = "lazy_object_proxy-1.7.1-cp39-cp39-win32.whl", hash = "sha256:2130db8ed69a48a3440103d4a520b89d8a9405f1b06e2cc81640509e8bf6548f"},
     {file = "lazy_object_proxy-1.7.1-cp39-cp39-win_amd64.whl", hash = "sha256:677ea950bef409b47e51e733283544ac3d660b709cfce7b187f5ace137960d61"},
     {file = "lazy_object_proxy-1.7.1-pp37.pp38-none-any.whl", hash = "sha256:d66906d5785da8e0be7360912e99c9188b70f52c422f9fc18223347235691a84"},
-]
-lifxlan = [
-    {file = "lifxlan-1.2.7.tar.gz", hash = "sha256:603f144b38ccef637b1f5297b47b5c2b82b23ac5c2e4ccad976f15719da36ba8"},
 ]
 mccabe = [
     {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},

--- a/controllers/lifx/pyproject.toml
+++ b/controllers/lifx/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lifx_controller"
-version = "0.1.7"
+version = "0.2.0"
 description = "PowerPi LIFX Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/lifx/pyproject.toml
+++ b/controllers/lifx/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.9"
-lifxlan = "~=1.2.7"
+aiolifx = "~=0.8.4"
 
 [tool.poetry.group.powerpi.dependencies]
 powerpi-common = {path = "../../common/python", develop = true}

--- a/controllers/lifx/tests/device/test_lifx_client.py
+++ b/controllers/lifx/tests/device/test_lifx_client.py
@@ -1,0 +1,145 @@
+import asyncio
+from typing import Callable, Tuple
+from unittest.mock import MagicMock, Mock, PropertyMock
+
+import pytest
+from lifx_controller.device.lifx_client import LIFXClient
+from lifx_controller.device.lifx_colour import LIFXColour
+from pytest_mock import MockerFixture
+
+
+class TestLIFXClient:
+    pytestmark = pytest.mark.asyncio
+
+    @pytest.mark.parametrize('data', [
+        (1, True, True),
+        (18, False, True),
+        (51, False, False)
+    ])
+    async def test_connect(self, subject: LIFXClient, mock_light: MagicMock, mocker: MockerFixture, data: Tuple[int, bool, bool]):
+        product, supports_colour, supports_temperature = data
+
+        def get_version(callb: Callable):
+            mock_version = mocker.Mock()
+            type(mock_version).product = PropertyMock(return_value=product)
+
+            callb(None, mock_version)
+
+        mock_light.return_value.get_version = get_version
+
+        await subject.connect()
+
+        mock_light.assert_called_once_with(
+            asyncio.get_running_loop(), subject.mac_address, subject.address
+        )
+
+        assert subject.supports_colour is supports_colour
+        assert subject.supports_temperature is supports_temperature
+
+    async def test_get_state(self, subject: LIFXClient, mock_colour: MagicMock):
+        result = await subject.get_state()
+
+        assert result[0] is True
+
+        assert result[1].hue == 1
+        assert result[1].saturation == 2
+        assert result[1].brightness == 3
+        assert result[1].temperature == 4
+
+    async def test_get_power(self, subject: LIFXClient, mock_colour: MagicMock):
+        result = await subject.get_power()
+
+        assert result is True
+
+    async def test_get_colour(self, subject: LIFXClient, mock_colour: MagicMock):
+        result = await subject.get_colour()
+
+        assert result.hue == 1
+        assert result.saturation == 2
+        assert result.brightness == 3
+        assert result.temperature == 4
+
+    async def test_set_power(self, subject: LIFXClient, mock_light: MagicMock):
+        def set_power(callb: Callable, value: bool, duration: int):
+            assert value is True
+            assert duration == 10
+
+            callb(None, None)
+
+        mock_light.return_value.set_power = set_power
+
+        await subject.set_power(True, 10)
+
+    @pytest.mark.parametrize('data', [
+        (1, 3000, 3000),
+        (1, 2000, 2500),
+        (1, 10000, 9000),
+        (51, 0, 0),
+    ])
+    async def test_set_colour(self, subject: LIFXClient, mock_light: MagicMock, mocker: MockerFixture, data: Tuple[int, int, int]):
+        product, actual_temperature, expected_temperature = data
+
+        def get_version(callb: Callable):
+            mock_version = mocker.Mock()
+            type(mock_version).product = PropertyMock(return_value=product)
+
+            callb(None, mock_version)
+
+        mock_light.return_value.get_version = get_version
+
+        def set_colour(callb: Callable, value: Tuple[int, int, int, int], duration: int):
+            assert value[0] == 1
+            assert value[1] == 2
+            assert value[2] == 3
+            assert value[3] == expected_temperature
+
+            assert duration == 10
+
+            callb(None, None)
+
+        mock_light.return_value.set_color = set_colour
+
+        await subject.set_colour(LIFXColour((1, 2, 3, actual_temperature)), 10)
+
+    @pytest.fixture
+    def subject(self, mocker: MockerFixture):
+        self.logger = mocker.Mock()
+
+        client = LIFXClient(self.logger)
+        client.address = '127.0.0.1'
+        client.mac_address = 'AA:BB:CC:DD:EE:FF'
+
+        return client
+
+    @pytest.fixture
+    def mock_light(self, mocker: MockerFixture):
+        mock_connection = mocker.Mock()
+        mock_connection.getsockname.return_value = ('127.0.0.1', 1337)
+
+        mock_socket = mocker.patch('lifx_controller.device.lifx_client.socket')
+        mock_socket.return_value.__enter__.return_value = mock_connection
+
+        mock_light = mocker.patch('lifx_controller.device.lifx_client.Light')
+
+        def get_version(callb: Callable):
+            mock_version = mocker.Mock()
+            type(mock_version).product = PropertyMock(return_value=1)
+
+            callb(None, mock_version)
+
+        mock_light.return_value.get_version = get_version
+
+        return mock_light
+
+    @pytest.fixture
+    def mock_colour(self, mock_light: MagicMock, mocker: MockerFixture):
+        def get_colour(callb: Callable):
+            mock_colour = mocker.Mock()
+            type(mock_colour).power_level = PropertyMock(return_value=65535)
+            type(mock_colour).color = PropertyMock(return_value=(1, 2, 3, 4))
+
+            callb(None, mock_colour)
+
+        mock_light.return_value.get_color = get_colour
+
+        return mock_light

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -106,7 +106,7 @@ services:
             - mosquitto
 
     lifx-controller:
-        image: twilkin/powerpi-lifx-controller:0.1.7
+        image: twilkin/powerpi-lifx-controller:0.2.0
         networks:
             - powerpi
         deploy:


### PR DESCRIPTION
Resolves #202 by using the `aiolifx` library in `lifx-controller` which should improve performance as it uses an async interface when communicating with LIFX, meaning there should be no blocking calls if it's already performing one operation (e.g. polling) when we request another (e.g. turning a light on).