### PR TITLE
#206 Fix aqara door sensor

### DIFF
--- a/controllers/zigbee/pyproject.toml
+++ b/controllers/zigbee/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zigbee_controller"
-version = "0.1.8"
+version = "0.1.9"
 description = "PowerPi ZigBee Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/zigbee/zigbee_controller/sensor/aqara/door_window_sensor.py
+++ b/controllers/zigbee/zigbee_controller/sensor/aqara/door_window_sensor.py
@@ -1,15 +1,16 @@
 from typing import Any, Dict, List
 
-from zigpy.zcl.clusters.general import Basic, OnOff as OnOffCluster
-from zigpy.zcl.foundation import Attribute, TypeValue
-
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
 from powerpi_common.sensor import Sensor
 from powerpi_common.sensor.mixin.battery import BatteryMixin
 from zigbee_controller.device import ZigbeeController
-from zigbee_controller.zigbee import ClusterAttributeListener, ClusterGeneralCommandListener, \
-    OnOff, OpenClose, ZigbeeMixin
+from zigbee_controller.zigbee import (ClusterAttributeListener,
+                                      ClusterGeneralCommandListener, OnOff,
+                                      OpenClose, ZigbeeMixin)
+from zigpy.zcl.clusters.general import Basic
+from zigpy.zcl.clusters.general import OnOff as OnOffCluster
+from zigpy.zcl.foundation import Attribute, TypeValue
 
 
 class AqaraDoorWindowSensor(Sensor, ZigbeeMixin, BatteryMixin):
@@ -100,7 +101,7 @@ class AqaraDoorWindowSensor(Sensor, ZigbeeMixin, BatteryMixin):
         device = self._zigbee_device
 
         def parse(args: List[List[Attribute]]):
-            attribute_id = OnOffCluster.attridx['on_off']
+            attribute_id = OnOffCluster.attributes_by_name['on_off'].id
 
             for reports in args:
                 try:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -128,7 +128,7 @@ services:
         environment:
             - ENV=ZIGBEE_DEVICE=/dev/ttyACM0:DATABASE_PATH=/var/data/zigbee.db
             - CONTROLLER_NAME=zigbee-controller
-            - IMAGE=twilkin/powerpi-zigbee-controller:0.1.8
+            - IMAGE=twilkin/powerpi-zigbee-controller:0.1.9
             - DEVICE=/dev/ttyACM0
             - VOLUME=/srv/docker-volumes/powerpi/zigbee-controller
         volumes:


### PR DESCRIPTION
Resolves #206
Aqara door/window sensor was broken by update to `zigpy` as the attribute id property `attridx` was replaced by `attribute_by_name` which returns a different value (the name not the id).