### PR TITLE
#210, #209 Fix motion checks and clacks-config revalidate

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
               target: /mosquitto/config/mosquitto.conf
 
     clacks-config:
-        image: twilkin/powerpi-clacks-config:0.2.1
+        image: twilkin/powerpi-clacks-config:0.2.2
         networks:
             - powerpi
         deploy:

--- a/esp8266/configure.ac
+++ b/esp8266/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([powerpi-sensor], [0.2.3])
+AC_INIT([powerpi-sensor], [0.2.4])
 
 dnl The arguments the user can override
 AC_ARG_VAR([location], [The location of this sensor])

--- a/esp8266/src/clacks.h
+++ b/esp8266/src/clacks.h
@@ -34,8 +34,8 @@ struct ClacksConfig_s {
     // the number of intervals to skip between a transition
     unsigned short pirPostDetectSkip;
 
-    // the number of intervals to skip after detection
-    unsigned short pirPostMotionSkip;
+    // the number of checks after we stop seeing motion
+    unsigned short pirPostMotionCheck;
 } ClacksConfig_default = { false, 0, 0, 0, 0, 0 };
 
 typedef struct ClacksConfig_s ClacksConfig;

--- a/esp8266/src/pir.h
+++ b/esp8266/src/pir.h
@@ -15,8 +15,8 @@
 // the number of seconds to skip between a transition (5s)
 #define PIR_POST_DETECT_SKIP 5u
 
-// the number of seconds to skip after detection (20s)
-#define PIR_POST_MOTION_SKIP 20u
+// the number of checks (1/s) to perform after motion is no longer detected (20x)
+#define PIR_POST_MOTION_CHECK 20u
 
 // enum for the three possible motion states
 typedef enum PIRState {
@@ -36,6 +36,9 @@ PIRState pirPreviousState;
 // the counter for the skipped loops
 unsigned short pirCounter = 0;
 unsigned short pirCounterMax = 0;
+
+// the counter for how many times we've checked there is still no motion
+unsigned short pirCheckCounter = 0;
 
 void setupPIR();
 void configurePIR(ArduinoJson::JsonVariant config);

--- a/services/clacks-config/package.json
+++ b/services/clacks-config/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@powerpi/clacks-config",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "description": "PowerPi config retrieval from GitHub pushing to message queue",
     "private": true,
     "license": "GPL-3.0-only",

--- a/services/clacks-config/src/schema/devices/PowerPiSensor.schema.json
+++ b/services/clacks-config/src/schema/devices/PowerPiSensor.schema.json
@@ -44,8 +44,8 @@
                     "type": "integer",
                     "minimum": 1
                 },
-                "post_motion_skip": {
-                    "description": "The number of seconds to skip readings after motion was detected",
+                "post_motion_check": {
+                    "description": "The number of seconds to check motion is no longer detected to confirm",
                     "type": "integer",
                     "minimum": 1
                 }

--- a/services/clacks-config/src/services/GitHubConfigService.ts
+++ b/services/clacks-config/src/services/GitHubConfigService.ts
@@ -73,6 +73,8 @@ export default class GitHubConfigService {
     }
 
     private async validate(type: ConfigFileType, content: object) {
+        this.logger.info("Validating file", type);
+
         let valid = false;
 
         try {

--- a/services/clacks-config/src/services/GitHubConfigService.ts
+++ b/services/clacks-config/src/services/GitHubConfigService.ts
@@ -14,12 +14,15 @@ export default class GitHubConfigService {
     private logger: LoggerService;
     private handlerFactory: HandlerFactory;
     private validator: ValidatorService;
+    private validated: { [key: string]: boolean };
 
     constructor(private config: ConfigService) {
         this.publishService = Container.get(ConfigPublishService);
         this.logger = Container.get(LoggerService);
         this.handlerFactory = Container.get(HandlerFactory);
         this.validator = Container.get(ValidatorService);
+
+        this.validated = {};
     }
 
     public async start() {
@@ -43,22 +46,20 @@ export default class GitHubConfigService {
                 // check if this file has changed
                 if (typeConfig?.checksum === file.checksum) {
                     this.logger.info("File", type, "is unchanged");
+
+                    // should we re-validate it?
+                    if (!this.validated[type]) {
+                        this.validate(type, file.content);
+                    }
+
                     continue;
+                } else {
+                    // it's a new file so it's unvalidated
+                    this.validated[type] = false;
                 }
 
-                // validate the file is okay
-                try {
-                    const valid = await this.validator.validate(type, file.content);
-                    if (!valid) {
-                        throw new ValidationException(type, undefined);
-                    }
-                } catch (ex) {
-                    this.logger.error(ex);
-
-                    if (ex instanceof ValidationException) {
-                        this.publishService.publishConfigError(type, ex.message, ex.errors);
-                    }
-
+                // validate the new file, and don't publish if it's not okay
+                if (!this.validate(type, file.content)) {
                     continue;
                 }
 
@@ -69,6 +70,31 @@ export default class GitHubConfigService {
                 handler?.handle(file.content);
             }
         }
+    }
+
+    private async validate(type: ConfigFileType, content: object) {
+        let valid = false;
+
+        try {
+            valid = await this.validator.validate(type, content);
+
+            if (!valid) {
+                throw new ValidationException(type, undefined);
+            }
+        } catch (ex) {
+            this.logger.error(ex);
+
+            if (ex instanceof ValidationException) {
+                this.publishService.publishConfigError(type, ex.message, ex.errors);
+            }
+
+            valid = false;
+        }
+
+        // the file is validated, so don't do it again
+        this.validated[type] = true;
+
+        return valid;
     }
 
     private async login() {

--- a/services/clacks-config/src/services/ValidatorService.ts
+++ b/services/clacks-config/src/services/ValidatorService.ts
@@ -1,6 +1,6 @@
 import { ConfigFileType, LoggerService } from "@powerpi/common";
 import addFormats from "ajv-formats";
-import Ajv from "ajv/dist/2020";
+import Ajv, { AnySchema } from "ajv/dist/2020";
 import { Service } from "typedi";
 import loadSchema from "../schema";
 
@@ -41,7 +41,7 @@ export default class ValidatorService {
         return false;
     }
 
-    private addSchema<TSchema>(schema: TSchema) {
+    private addSchema(schema: { [key: string]: AnySchema }) {
         for (const type in schema) {
             const key = type as keyof typeof schema;
 


### PR DESCRIPTION
- Resolves #210 by checking multiple times if the motion is still undetected before publishing the message.
- Also required a `clacks-config` change so resolved #209 by checking the unchanged configs at start-up to ensure they're still valid.