### PR TITLE
#183 device-mapper optional device and volume mount point

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -78,7 +78,7 @@ services:
             - mosquitto
 
     device-mapper-energenie:
-        image: twilkin/powerpi-device-mapper:0.0.6
+        image: twilkin/powerpi-device-mapper:0.0.7
         networks:
             - powerpi
         deploy:
@@ -115,7 +115,7 @@ services:
             - mosquitto
 
     device-mapper-zigbee:
-        image: twilkin/powerpi-device-mapper:0.0.6
+        image: twilkin/powerpi-device-mapper:0.0.7
         networks:
             - powerpi
         deploy:

--- a/services/device-mapper/start.sh
+++ b/services/device-mapper/start.sh
@@ -25,7 +25,18 @@ args=()
 # optional volume
 if [ -v VOLUME ]
 then
-    args+=("--mount type=bind,src=$VOLUME,dst=/var/data")
+    params=(${VOLUME//:/ })
+
+    src="${params[0]}"
+    dst="${params[1]:=/var/data}"
+
+    args+=("--mount type=bind,src=$src,dst=$dst")
+fi
+
+# optional device
+if [ -v DEVICE ]
+then
+    args+=("--device $DEVICE")
 fi
 
 # optional env array
@@ -40,7 +51,6 @@ echo "Starting $CONTROLLER_NAME"
 docker run \
     --privileged \
     --name $NAME \
-    --device $DEVICE \
     --network powerpi \
     ${args[@]} \
     $IMAGE \


### PR DESCRIPTION
Progress towards supporting #183
- Make device optional.
- Support passing the mount destination of a volume, as bluetooth needs `/var/run/dbus`.