### PR TITLE
#190, #213, #215 More UI filter fixes and improvements

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -156,7 +156,7 @@ services:
             - FREEDNS_PASSWORD=/var/run/secrets/powerpi_freedns
 
     nginx:
-        image: twilkin/powerpi-nginx:1.3.3
+        image: twilkin/powerpi-nginx:1.3.4
         networks:
             - powerpi
         ports:

--- a/services/nginx/ui/package.json
+++ b/services/nginx/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@powerpi/ui",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "description": "PowerPi UI",
     "private": true,
     "license": "GPL-3.0-only",

--- a/services/nginx/ui/src/components/Components/Filter/Filter.tsx
+++ b/services/nginx/ui/src/components/Components/Filter/Filter.tsx
@@ -16,7 +16,10 @@ const Filter = ({ onClear, className, children }: FilterProps) => {
 
     const [showFilter, setShowFilter] = useState<boolean | undefined>(undefined);
 
-    const closeFilter = useCallback(() => setShowFilter(false), []);
+    const closeFilter = useCallback(
+        () => setShowFilter((current) => (current !== undefined ? false : undefined)),
+        []
+    );
 
     useOnClickOutside(filterRef, closeFilter);
 

--- a/services/nginx/ui/src/components/Devices/DeviceList.tsx
+++ b/services/nginx/ui/src/components/Devices/DeviceList.tsx
@@ -64,7 +64,7 @@ const DeviceList = () => {
                                             })}
                                             title={`Device ${device.name} is currently ${device.state}.`}
                                         >
-                                            {(!filters.visible || filters.search) && (
+                                            {(!filters.visible || filters.search !== undefined) && (
                                                 <td>
                                                     <FontAwesomeIcon
                                                         title={`This device is ${

--- a/services/nginx/ui/src/components/History/HistoryList.tsx
+++ b/services/nginx/ui/src/components/History/HistoryList.tsx
@@ -1,7 +1,11 @@
 import { History } from "@powerpi/api";
 import { useEffect, useMemo } from "react";
 import { chain as _ } from "underscore";
-import { useGetHistory, useInvalidateHistory } from "../../hooks/history";
+import {
+    useGetHistory,
+    useInvalidateHistory,
+    useSocketIORefreshHistory,
+} from "../../hooks/history";
 import AbbreviatingTime from "../Components/AbbreviatingTime";
 import Filter from "../Components/Filter";
 import InfiniteScrollList from "../Components/InfiniteScrollList";
@@ -43,6 +47,9 @@ const HistoryList = () => {
     useEffect(() => {
         invalidateHistory();
     }, [filters, invalidateHistory]);
+
+    // when a socket.io messages arrives, also refresh the history in case it should be displayed
+    useSocketIORefreshHistory();
 
     return (
         <>

--- a/services/nginx/ui/src/components/History/HistoryList.tsx
+++ b/services/nginx/ui/src/components/History/HistoryList.tsx
@@ -1,5 +1,6 @@
 import { History } from "@powerpi/api";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo } from "react";
+import { useQueryClient } from "react-query";
 import { chain as _ } from "underscore";
 import { useGetHistory } from "../../hooks/history";
 import AbbreviatingTime from "../Components/AbbreviatingTime";
@@ -19,51 +20,32 @@ const HistoryList = () => {
         onMessageTypeFilterChange,
     } = useHistoryFilter();
 
-    const [lastDate, setLastDate] = useState<Date | undefined>(filters.end ?? undefined);
-
     const records = 30;
 
-    const { isHistoryLoading, isHistoryError, history } = useGetHistory(
+    const { isHistoryError, history, historyFetchNextPage, hasHistoryNextPage } = useGetHistory(
         records,
         filters.start ?? undefined,
-        lastDate,
+        filters.end ?? undefined,
         filters.type !== "" ? filters.type : undefined,
         filters.entity !== "" ? filters.entity : undefined,
         filters.action !== "" ? filters.action : undefined
     );
 
-    const loadMore = useCallback(() => {
-        // only load more if it's not already loading
-        if (!isHistoryLoading) {
-            // find the current last element
-            const currentLastDate = _(history?.data).last().value()?.timestamp;
-
-            setLastDate(currentLastDate);
-        }
-    }, [history?.data, isHistoryLoading]);
-
-    // cache the history so we don't lose the data when loading the next page
-    const [historyCache, setHistoryCache] = useState<History[]>([]);
-    useEffect(() => {
-        if (!isHistoryLoading && history?.data && history.data.length > 0) {
-            setHistoryCache((cache) =>
-                _([...cache, ...(history.data ?? [])])
-                    .uniq((record) => JSON.stringify(record))
-                    .value()
-            );
-        }
-    }, [history?.data, isHistoryLoading]);
-
-    const hasMore = useMemo(
-        () => historyCache.length < (history?.records ?? 0),
-        [history?.records, historyCache.length]
+    const historyCache = useMemo(
+        () =>
+            _(history?.pages?.reduce((acc, page) => acc.concat(page?.data ?? []), [] as History[]))
+                .uniq((record) => JSON.stringify(record))
+                .value(),
+        [history?.pages]
     );
 
     // when the filters change clear the cache and last dates
+    const queryClient = useQueryClient();
     useEffect(() => {
-        setHistoryCache([]);
-        setLastDate(filters.end ?? undefined);
-    }, [filters]);
+        const clear = async () => await queryClient.invalidateQueries("history");
+
+        clear();
+    }, [filters, queryClient]);
 
     return (
         <>
@@ -77,7 +59,10 @@ const HistoryList = () => {
             </Filter>
 
             <div className={styles.list}>
-                <InfiniteScrollList hasMore={hasMore} loadMore={loadMore}>
+                <InfiniteScrollList
+                    hasMore={hasHistoryNextPage ?? false}
+                    loadMore={historyFetchNextPage}
+                >
                     <table>
                         <thead>
                             <tr>

--- a/services/nginx/ui/src/components/History/HistoryList.tsx
+++ b/services/nginx/ui/src/components/History/HistoryList.tsx
@@ -1,8 +1,7 @@
 import { History } from "@powerpi/api";
 import { useEffect, useMemo } from "react";
-import { useQueryClient } from "react-query";
 import { chain as _ } from "underscore";
-import { useGetHistory } from "../../hooks/history";
+import { useGetHistory, useInvalidateHistory } from "../../hooks/history";
 import AbbreviatingTime from "../Components/AbbreviatingTime";
 import Filter from "../Components/Filter";
 import InfiniteScrollList from "../Components/InfiniteScrollList";
@@ -39,13 +38,11 @@ const HistoryList = () => {
         [history?.pages]
     );
 
-    // when the filters change clear the cache and last dates
-    const queryClient = useQueryClient();
+    // when the filters change invalidate the history we have loaded
+    const invalidateHistory = useInvalidateHistory();
     useEffect(() => {
-        const clear = async () => await queryClient.invalidateQueries("history");
-
-        clear();
-    }, [filters, queryClient]);
+        invalidateHistory();
+    }, [filters, invalidateHistory]);
 
     return (
         <>

--- a/services/nginx/ui/src/hooks/history.ts
+++ b/services/nginx/ui/src/hooks/history.ts
@@ -1,6 +1,6 @@
 import { History } from "@powerpi/api";
 import PaginationResponse from "@powerpi/api/dist/src/Pagination";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useInfiniteQuery, useQuery, useQueryClient, UseQueryResult } from "react-query";
 import { chain as _ } from "underscore";
 import useAPI from "./api";
@@ -125,4 +125,23 @@ export function useGetHistoryRange(
         isHistoryError: isError,
         history: data,
     };
+}
+
+export function useSocketIORefreshHistory() {
+    const api = useAPI();
+
+    const invalidateHistory = useInvalidateHistory();
+
+    // handle socket.io updates
+    useEffect(() => {
+        const refresh = async () => await invalidateHistory();
+
+        api.addDeviceListener(refresh);
+        api.addSensorListener(refresh);
+
+        return () => {
+            api.removeDeviceListener(refresh);
+            api.removeSensorListener(refresh);
+        };
+    }, [api, invalidateHistory]);
 }

--- a/services/nginx/ui/src/hooks/history.ts
+++ b/services/nginx/ui/src/hooks/history.ts
@@ -1,7 +1,7 @@
 import { History } from "@powerpi/api";
 import PaginationResponse from "@powerpi/api/dist/src/Pagination";
 import { useCallback, useMemo } from "react";
-import { useInfiniteQuery, useQuery, UseQueryResult } from "react-query";
+import { useInfiniteQuery, useQuery, useQueryClient, UseQueryResult } from "react-query";
 import { chain as _ } from "underscore";
 import useAPI from "./api";
 
@@ -45,6 +45,12 @@ function extractResult<TRecord>(result: UseQueryResult<TRecord[], unknown>, prop
     };
 }
 
+export function useInvalidateHistory() {
+    const queryClient = useQueryClient();
+
+    return useCallback(async () => await queryClient.invalidateQueries("history"), [queryClient]);
+}
+
 export function useGetHistory(
     records: number,
     start?: Date,
@@ -74,7 +80,6 @@ export function useGetHistory(
         ) => {
             const previousTimestamp = _(allPages.at(-2)?.data).last().value()?.timestamp;
             const lastTimestamp = _(lastPage?.data).last().value()?.timestamp;
-            console.log(`pages: ${previousTimestamp} ${lastTimestamp}`);
 
             if (!lastTimestamp || !previousTimestamp || lastTimestamp < previousTimestamp) {
                 // we still have some pages so return the date to query to


### PR DESCRIPTION
- Resolves #190 by using `react-query`'s `useInfiniteQuery` to retrieve the history which simplifies the storage of the existing records and retrieving more.
- Resolves #213 by only closing the filter panel when it's open, not in `undefined` state.
- Resolves #215 by adding listeners for the `socket.io` messages in a hook `useSocketIORefreshHistory` and invalidating the history infinite query when one comes in.
- Fix for warning in `DevicesList` where some text was being written to a `<tr>` in what should have been an undefined check.