### PR TITLE
#208 Add device categories

### DIFF
--- a/common/node/api/package.json
+++ b/common/node/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@powerpi/api",
-    "version": "0.0.12",
+    "version": "0.0.13",
     "description": "PowerPi API Common Typescript library",
     "private": true,
     "license": "GPL-3.0-only",

--- a/common/node/api/src/BaseDevice.ts
+++ b/common/node/api/src/BaseDevice.ts
@@ -4,4 +4,5 @@ export default interface BaseDevice {
     visible: boolean;
     type: string;
     location?: string;
+    categories?: string[];
 }

--- a/common/node/common-test/package.json
+++ b/common/node/common-test/package.json
@@ -27,6 +27,6 @@
         "typescript": "^4.7.4"
     },
     "dependencies": {
-        "@powerpi/common": "^0.0.10"
+        "@powerpi/common": "^0.0.11"
     }
 }

--- a/common/node/common/package.json
+++ b/common/node/common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@powerpi/common",
-    "version": "0.0.10",
+    "version": "0.0.11",
     "description": "PowerPi Common Typescript library",
     "private": true,
     "license": "GPL-3.0-only",

--- a/common/node/common/src/models/config.ts
+++ b/common/node/common/src/models/config.ts
@@ -9,6 +9,7 @@ export interface IDeviceConfig {
     display_name?: string;
     visible?: boolean;
     location?: string;
+    categories?: string[];
 }
 
 export interface IDeviceConfigFile {

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
               target: /mosquitto/config/mosquitto.conf
 
     clacks-config:
-        image: twilkin/powerpi-clacks-config:0.2.2
+        image: twilkin/powerpi-clacks-config:0.2.3
         networks:
             - powerpi
         deploy:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -31,7 +31,7 @@ services:
             - FILE_PATH=docker/config
 
     deep-thought:
-        image: twilkin/powerpi-deep-thought:0.5.15
+        image: twilkin/powerpi-deep-thought:0.5.16
         networks:
             - powerpi
         deploy:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -156,7 +156,7 @@ services:
             - FREEDNS_PASSWORD=/var/run/secrets/powerpi_freedns
 
     nginx:
-        image: twilkin/powerpi-nginx:1.3.4
+        image: twilkin/powerpi-nginx:1.3.5
         networks:
             - powerpi
         ports:

--- a/services/babel-fish/package.json
+++ b/services/babel-fish/package.json
@@ -27,7 +27,7 @@
         "@jovotech/platform-core": "^4.2.22",
         "@jovotech/server-express": "^4.0.0",
         "@powerpi/api": "^0.0.13",
-        "@powerpi/common": "^0.0.10",
+        "@powerpi/common": "^0.0.11",
         "source-map-support": "^0.5.19"
     },
     "devDependencies": {

--- a/services/babel-fish/package.json
+++ b/services/babel-fish/package.json
@@ -26,7 +26,7 @@
         "@jovotech/platform-alexa": "^4.2.22",
         "@jovotech/platform-core": "^4.2.22",
         "@jovotech/server-express": "^4.0.0",
-        "@powerpi/api": "^0.0.12",
+        "@powerpi/api": "^0.0.13",
         "@powerpi/common": "^0.0.10",
         "source-map-support": "^0.5.19"
     },

--- a/services/clacks-config/package.json
+++ b/services/clacks-config/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@powerpi/clacks-config",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "description": "PowerPi config retrieval from GitHub pushing to message queue",
     "private": true,
     "license": "GPL-3.0-only",

--- a/services/clacks-config/package.json
+++ b/services/clacks-config/package.json
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@octokit/rest": "^18.12.0",
-        "@powerpi/common": "^0.0.10",
+        "@powerpi/common": "^0.0.11",
         "ajv": "^8.11.0",
         "ajv-formats": "2.1.1",
         "typedi": "^0.10.0",

--- a/services/clacks-config/src/schema/devices/BaseDevice.schema.json
+++ b/services/clacks-config/src/schema/devices/BaseDevice.schema.json
@@ -24,6 +24,13 @@
         "location": {
             "description": "The physical room location of this device",
             "type": "string"
+        },
+        "categories": {
+            "description": "The list of categories this device belongs to",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
         }
     },
     "required": ["name", "type"]

--- a/services/clacks-config/test/services/validator/devices/commonDeviceTests.ts
+++ b/services/clacks-config/test/services/validator/devices/commonDeviceTests.ts
@@ -46,6 +46,16 @@ export default function commonDeviceTests(validFile: object) {
         testValid({ sensors: [], ...validFile, devices: [{ ...device, visible: true }] });
     });
 
+    test("Categories", () => {
+        const device = getDevice(validFile);
+
+        testValid({
+            sensors: [],
+            ...validFile,
+            devices: [{ ...device, categories: ["TV", "Music"] }],
+        });
+    });
+
     return {
         getDevice,
         testValid,

--- a/services/clacks-config/test/services/validator/devices/commonDeviceTests.ts
+++ b/services/clacks-config/test/services/validator/devices/commonDeviceTests.ts
@@ -28,10 +28,22 @@ export default function commonDeviceTests(validFile: object) {
     test("Valid file", () => testValid({ sensors: [], ...validFile }));
 
     test("No name", () => {
-        const device = getDevice(validFile);
+        const device = { ...getDevice(validFile) };
         delete device.name;
 
         testInvalid({ sensors: [], ...validFile, devices: [device] });
+    });
+
+    test("Location", () => {
+        const device = getDevice(validFile);
+
+        testValid({ sensors: [], ...validFile, devices: [{ ...device, location: "LivingRoom" }] });
+    });
+
+    test("Visible", () => {
+        const device = getDevice(validFile);
+
+        testValid({ sensors: [], ...validFile, devices: [{ ...device, visible: true }] });
     });
 
     return {

--- a/services/clacks-config/test/services/validator/devices/commonSensorTests.ts
+++ b/services/clacks-config/test/services/validator/devices/commonSensorTests.ts
@@ -46,6 +46,16 @@ export default function commonSensorTests(validFile: object) {
         testValid({ devices: [], ...validFile, sensors: [{ ...sensor, visible: true }] });
     });
 
+    test("Categories", () => {
+        const sensor = getSensor(validFile);
+
+        testValid({
+            devices: [],
+            ...validFile,
+            sensors: [{ ...sensor, categories: ["TV", "Music"] }],
+        });
+    });
+
     return {
         getSensor,
         testValid,

--- a/services/clacks-config/test/services/validator/devices/commonSensorTests.ts
+++ b/services/clacks-config/test/services/validator/devices/commonSensorTests.ts
@@ -28,10 +28,22 @@ export default function commonSensorTests(validFile: object) {
     test("Valid file", () => testValid({ sensors: [], ...validFile }));
 
     test("No name", () => {
-        const sensor = getSensor(validFile);
+        const sensor = { ...getSensor(validFile) };
         delete sensor.name;
 
         testInvalid({ devices: [], ...validFile, sensors: [sensor] });
+    });
+
+    test("Location", () => {
+        const sensor = getSensor(validFile);
+
+        testValid({ devices: [], ...validFile, sensors: [{ ...sensor, location: "LivingRoom" }] });
+    });
+
+    test("Visible", () => {
+        const sensor = getSensor(validFile);
+
+        testValid({ devices: [], ...validFile, sensors: [{ ...sensor, visible: true }] });
     });
 
     return {

--- a/services/deep-thought/package.json
+++ b/services/deep-thought/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@powerpi/deep-thought",
-    "version": "0.5.15",
+    "version": "0.5.16",
     "description": "PowerPi API",
     "private": true,
     "license": "GPL-3.0-only",

--- a/services/deep-thought/package.json
+++ b/services/deep-thought/package.json
@@ -19,7 +19,7 @@
         "start:prd": "node dist/src/app.js"
     },
     "dependencies": {
-        "@powerpi/api": "^0.0.12",
+        "@powerpi/api": "^0.0.13",
         "@powerpi/common": "^0.0.10",
         "@tsed/common": "^6.115.0",
         "@tsed/core": "^6.115.0",

--- a/services/deep-thought/package.json
+++ b/services/deep-thought/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "@powerpi/api": "^0.0.13",
-        "@powerpi/common": "^0.0.10",
+        "@powerpi/common": "^0.0.11",
         "@tsed/common": "^6.115.0",
         "@tsed/core": "^6.115.0",
         "@tsed/di": "^6.115.0",

--- a/services/deep-thought/src/services/deviceState.ts
+++ b/services/deep-thought/src/services/deviceState.ts
@@ -40,6 +40,7 @@ export default class DeviceStateService extends DeviceStateListener {
             type: device.type,
             visible: device.visible ?? true,
             location: device.location,
+            categories: device.categories,
             state: DeviceState.Unknown,
             since: -1,
         }));

--- a/services/energy-monitor/package.json
+++ b/services/energy-monitor/package.json
@@ -19,7 +19,7 @@
         "start:prd": "node dist/src/index.js"
     },
     "dependencies": {
-        "@powerpi/common": "^0.0.10",
+        "@powerpi/common": "^0.0.11",
         "axios": "^0.27.2",
         "dateformat": "^4.6.3",
         "typedi": "^0.10.0"

--- a/services/light-fantastic/package.json
+++ b/services/light-fantastic/package.json
@@ -19,7 +19,7 @@
         "start:prd": "node dist/src/index.js"
     },
     "dependencies": {
-        "@powerpi/common": "^0.0.10",
+        "@powerpi/common": "^0.0.11",
         "luxon": "^2.0.2",
         "typedi": "^0.10.0"
     },

--- a/services/nginx/ui/package.json
+++ b/services/nginx/ui/package.json
@@ -22,7 +22,7 @@
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/free-solid-svg-icons": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.1.18",
-        "@powerpi/api": "^0.0.12",
+        "@powerpi/api": "^0.0.13",
         "chart.js": "^3.7.0",
         "chartjs-adapter-luxon": "^1.1.0",
         "classnames": "^2.3.1",

--- a/services/nginx/ui/package.json
+++ b/services/nginx/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@powerpi/ui",
-    "version": "1.3.4",
+    "version": "1.3.5",
     "description": "PowerPi UI",
     "private": true,
     "license": "GPL-3.0-only",

--- a/services/nginx/ui/src/components/Components/ListFilter/ListFilter.module.scss
+++ b/services/nginx/ui/src/components/Components/ListFilter/ListFilter.module.scss
@@ -1,5 +1,6 @@
 .filter {
     display: flex;
+    text-transform: capitalize;
 
     &:not(:first-child) {
         padding-left: 1rem;

--- a/services/nginx/ui/src/components/Components/ListFilter/ListFilter.module.scss
+++ b/services/nginx/ui/src/components/Components/ListFilter/ListFilter.module.scss
@@ -1,8 +1,12 @@
+.title {
+    margin: 0;
+}
+
 .filter {
     display: flex;
     text-transform: capitalize;
 
-    &:not(:first-child) {
+    &:not(:nth-child(2)) {
         padding-left: 1rem;
     }
 

--- a/services/nginx/ui/src/components/Components/ListFilter/ListFilter.module.scss
+++ b/services/nginx/ui/src/components/Components/ListFilter/ListFilter.module.scss
@@ -5,4 +5,9 @@
     &:not(:first-child) {
         padding-left: 1rem;
     }
+
+    &.meta {
+        text-transform: none;
+        font-style: italic;
+    }
 }

--- a/services/nginx/ui/src/components/Components/ListFilter/ListFilter.module.scss
+++ b/services/nginx/ui/src/components/Components/ListFilter/ListFilter.module.scss
@@ -1,3 +1,7 @@
 .filter {
     display: flex;
+
+    &:not(:first-child) {
+        padding-left: 1rem;
+    }
 }

--- a/services/nginx/ui/src/components/Components/ListFilter/ListFilter.module.scss.d.ts
+++ b/services/nginx/ui/src/components/Components/ListFilter/ListFilter.module.scss.d.ts
@@ -3,6 +3,7 @@
 interface CssExports {
   'filter': string;
   'meta': string;
+  'title': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/services/nginx/ui/src/components/Components/ListFilter/ListFilter.module.scss.d.ts
+++ b/services/nginx/ui/src/components/Components/ListFilter/ListFilter.module.scss.d.ts
@@ -2,6 +2,7 @@
 // Please do not change this file!
 interface CssExports {
   'filter': string;
+  'meta': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/services/nginx/ui/src/components/Components/ListFilter/ListFilter.tsx
+++ b/services/nginx/ui/src/components/Components/ListFilter/ListFilter.tsx
@@ -10,6 +10,7 @@ export interface IListFilter {
 }
 
 interface ListFilterProps<TListType extends IListFilter> {
+    title: string;
     values?: TListType[];
     filters: string[];
     onChange: (event: ChangeEvent<HTMLInputElement>) => void;
@@ -17,6 +18,7 @@ interface ListFilterProps<TListType extends IListFilter> {
 }
 
 export default function ListFilter<TListType extends IListFilter>({
+    title,
     values,
     filters,
     onChange,
@@ -26,6 +28,8 @@ export default function ListFilter<TListType extends IListFilter>({
 
     return (
         <FilterGroup>
+            <h4 className={styles.title}>{title}:</h4>
+
             <Loading loading={!values}>
                 <label className={classNames(styles.filter, styles.meta)}>
                     <input

--- a/services/nginx/ui/src/components/Components/ListFilter/ListFilter.tsx
+++ b/services/nginx/ui/src/components/Components/ListFilter/ListFilter.tsx
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import { ChangeEvent, ReactNode, useMemo } from "react";
 import FilterGroup from "../FilterGroup";
 import Loading from "../Loading";
@@ -26,18 +27,23 @@ export default function ListFilter<TListType extends IListFilter>({
     return (
         <FilterGroup>
             <Loading loading={!values}>
-                <label className={styles.filter}>
+                <label className={classNames(styles.filter, styles.meta)}>
                     <input
                         type="checkbox"
                         value={undefined}
                         checked={allChecked}
                         onChange={onChange}
                     />
-                    <em>All</em>
+                    All
                 </label>
 
                 {values?.map((value) => (
-                    <label key={value.key} className={styles.filter}>
+                    <label
+                        key={value.key}
+                        className={classNames(styles.filter, {
+                            [styles.meta]: value.key === "unspecified",
+                        })}
+                    >
                         <input
                             type="checkbox"
                             value={value.key}

--- a/services/nginx/ui/src/components/Components/ListFilter/ListFilter.tsx
+++ b/services/nginx/ui/src/components/Components/ListFilter/ListFilter.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, ReactNode } from "react";
+import { ChangeEvent, ReactNode, useMemo } from "react";
 import FilterGroup from "../FilterGroup";
 import Loading from "../Loading";
 import styles from "./ListFilter.module.scss";
@@ -21,9 +21,21 @@ export default function ListFilter<TListType extends IListFilter>({
     onChange,
     element,
 }: ListFilterProps<TListType>) {
+    const allChecked = useMemo(() => (values ?? []).length === filters.length, [filters, values]);
+
     return (
         <FilterGroup>
             <Loading loading={!values}>
+                <label className={styles.filter}>
+                    <input
+                        type="checkbox"
+                        value={undefined}
+                        checked={allChecked}
+                        onChange={onChange}
+                    />
+                    <em>All</em>
+                </label>
+
                 {values?.map((value) => (
                     <label key={value.key} className={styles.filter}>
                         <input

--- a/services/nginx/ui/src/components/Devices/DeviceFilter.tsx
+++ b/services/nginx/ui/src/components/Devices/DeviceFilter.tsx
@@ -8,8 +8,10 @@ interface DeviceFilterProps {
     filters: Filters;
     types: IListFilter[];
     locations: IListFilter[];
+    categories: IListFilter[];
     onTypeChange: (event: ChangeEvent<HTMLInputElement>) => void;
     onLocationChange: (event: ChangeEvent<HTMLInputElement>) => void;
+    onCategoryChange: (event: ChangeEvent<HTMLInputElement>) => void;
     onVisibleChange: () => void;
 }
 
@@ -17,8 +19,10 @@ const DeviceFilter = ({
     filters,
     types,
     locations,
+    categories,
     onTypeChange,
     onLocationChange,
+    onCategoryChange,
     onVisibleChange,
 }: DeviceFilterProps) => {
     return (
@@ -40,6 +44,13 @@ const DeviceFilter = ({
                 filters={filters.locations}
                 onChange={onLocationChange}
                 element={(location) => <>{location.value}</>}
+            />
+
+            <ListFilter
+                values={categories}
+                filters={filters.categories}
+                onChange={onCategoryChange}
+                element={(category) => <>{category.value}</>}
             />
 
             <FilterGroup>

--- a/services/nginx/ui/src/components/Devices/DeviceFilter.tsx
+++ b/services/nginx/ui/src/components/Devices/DeviceFilter.tsx
@@ -28,6 +28,7 @@ const DeviceFilter = ({
     return (
         <div>
             <ListFilter
+                title="Device Types"
                 values={types}
                 filters={filters.types}
                 onChange={onTypeChange}
@@ -40,6 +41,7 @@ const DeviceFilter = ({
             />
 
             <ListFilter
+                title="Locations"
                 values={locations}
                 filters={filters.locations}
                 onChange={onLocationChange}
@@ -47,6 +49,7 @@ const DeviceFilter = ({
             />
 
             <ListFilter
+                title="Categories"
                 values={categories}
                 filters={filters.categories}
                 onChange={onCategoryChange}

--- a/services/nginx/ui/src/components/Devices/DeviceList.tsx
+++ b/services/nginx/ui/src/components/Devices/DeviceList.tsx
@@ -24,10 +24,12 @@ const DeviceList = () => {
         filtered,
         types,
         locations,
+        categories,
         onClear,
         filteredCount,
         onTypeChange,
         onLocationChange,
+        onCategoryChange,
         onVisibleChange,
         onSearchChange,
     } = useDeviceFilter(devices);
@@ -39,8 +41,10 @@ const DeviceList = () => {
                     filters={filters}
                     types={types}
                     locations={locations}
+                    categories={categories}
                     onTypeChange={onTypeChange}
                     onLocationChange={onLocationChange}
+                    onCategoryChange={onCategoryChange}
                     onVisibleChange={onVisibleChange}
                 />
             </Filter>

--- a/services/nginx/ui/src/components/Devices/useDeviceFilter.ts
+++ b/services/nginx/ui/src/components/Devices/useDeviceFilter.ts
@@ -148,7 +148,9 @@ export default function useDeviceFilter(devices?: Device[]) {
         (event: ChangeEvent<HTMLInputElement>) => {
             let filterTypes = [...filters.types];
 
-            if (event.target.checked) {
+            if (event.target.value === "") {
+                filterTypes = event.target.checked ? types.map((type) => type.key) : [];
+            } else if (event.target.checked) {
                 filterTypes.push(event.target.value);
             } else {
                 filterTypes = filterTypes.filter((type) => type !== event.target.value);
@@ -156,14 +158,18 @@ export default function useDeviceFilter(devices?: Device[]) {
 
             setFilters((currentFilter) => ({ ...currentFilter, types: filterTypes }));
         },
-        [filters.types, setFilters]
+        [filters.types, setFilters, types]
     );
 
     const onLocationChange = useCallback(
         (event: ChangeEvent<HTMLInputElement>) => {
             let filterLocations = [...filters.locations];
 
-            if (event.target.checked) {
+            if (event.target.value === "") {
+                filterLocations = event.target.checked
+                    ? locations.map((location) => location.key)
+                    : [];
+            } else if (event.target.checked) {
                 filterLocations.push(event.target.value);
             } else {
                 filterLocations = filterLocations.filter(
@@ -173,14 +179,18 @@ export default function useDeviceFilter(devices?: Device[]) {
 
             setFilters((currentFilter) => ({ ...currentFilter, locations: filterLocations }));
         },
-        [filters.locations, setFilters]
+        [filters.locations, locations, setFilters]
     );
 
     const onCategoryChange = useCallback(
         (event: ChangeEvent<HTMLInputElement>) => {
             let filterCategories = [...filters.categories];
 
-            if (event.target.checked) {
+            if (event.target.value === "") {
+                filterCategories = event.target.checked
+                    ? categories.map((category) => category.key)
+                    : [];
+            } else if (event.target.checked) {
                 filterCategories.push(event.target.value);
             } else {
                 filterCategories = filterCategories.filter(
@@ -190,7 +200,7 @@ export default function useDeviceFilter(devices?: Device[]) {
 
             setFilters((currentFilter) => ({ ...currentFilter, categories: filterCategories }));
         },
-        [filters.categories, setFilters]
+        [categories, filters.categories, setFilters]
     );
 
     const onVisibleChange = useCallback(

--- a/services/nginx/ui/src/components/Devices/useDeviceFilter.ts
+++ b/services/nginx/ui/src/components/Devices/useDeviceFilter.ts
@@ -38,7 +38,10 @@ export default function useDeviceFilter(devices?: Device[]) {
 
     // handle undefined in device location and categories
     const getDeviceLocation = useCallback((device: Device) => device.location ?? "unspecified", []);
-    const getDeviceCategories = useCallback((device: Device) => device.categories ?? [], []);
+    const getDeviceCategories = useCallback(
+        (device: Device) => device.categories ?? ["unspecified"],
+        []
+    );
 
     const locations = useMemo(
         () =>
@@ -73,7 +76,7 @@ export default function useDeviceFilter(devices?: Device[]) {
                 .flatten()
                 .uniq()
                 .map((category) => ({ key: category, value: category }))
-                .sort()
+                .sortBy((filter) => filter.value)
                 .value(),
         [devices, getDeviceCategories]
     );

--- a/services/nginx/ui/src/components/Devices/useDeviceFilter.ts
+++ b/services/nginx/ui/src/components/Devices/useDeviceFilter.ts
@@ -28,7 +28,7 @@ export default function useDeviceFilter(devices?: Device[]) {
             _(devices)
                 .uniq((device) => device.type)
                 .sortBy((device) => device.type)
-                .map((device) => ({ key: device.type, value: device.type }))
+                .map((device) => ({ key: device.type, value: device.type.replace("_", " ") }))
                 .value(),
         [devices]
     );

--- a/services/nginx/ui/src/components/Devices/useDeviceFilter.ts
+++ b/services/nginx/ui/src/components/Devices/useDeviceFilter.ts
@@ -114,13 +114,17 @@ export default function useDeviceFilter(devices?: Device[]) {
             }
 
             // apply the type filters
-            result &&= filters.types.includes(device.type);
+            if (filters.types.length > 0) {
+                result &&= filters.types.includes(device.type);
+            }
 
             // apply the location filters
-            result &&= filters.locations.includes(getDeviceLocation(device));
+            if (filters.locations.length > 0) {
+                result &&= filters.locations.includes(getDeviceLocation(device));
+            }
 
             // aply the category filters
-            if ((device.categories?.length ?? 0) > 0) {
+            if (filters.categories.length > 0) {
                 result &&= _(getDeviceCategories(device))
                     .any((category) => filters.categories.includes(category))
                     .value();

--- a/services/persistence/package.json
+++ b/services/persistence/package.json
@@ -19,7 +19,7 @@
         "start:prd": "node dist/src/index.js"
     },
     "dependencies": {
-        "@powerpi/common": "^0.0.10",
+        "@powerpi/common": "^0.0.11",
         "pg": "^8.7.3",
         "pg-hstore": "^2.3.4",
         "reflect-metadata": "^0.1.13",


### PR DESCRIPTION
Resolves #208:
- Update `clacks-config` schema to include an array of categories for devices and sensors.
- Update `common` library to return categories for devices.
- Update `api` response object to include categories for devices.
- Update `deep-thought` to return categories for devices from devices endpoint.
- UI changes:
  - Add category filters.
  - Don't filter by type/location/category if all of them are unselected.
  - Add an all option to `ListFilter` which checks them all if some are unchecked, all clears them all if all are already checked.
  - Add title to `ListFilter`.
  - Restyle all and unspecified options to make them easier to spot as they don't strictly exist.
  - Reformat the device type names that appear in the list.