### PR TITLE
#103 Add ConditionDevice to macro-controller

### DIFF
--- a/controllers/macro/README.md
+++ b/controllers/macro/README.md
@@ -9,6 +9,7 @@ The service is built using python, with dependencies using [poetry](https://pyth
 This controller provides the following virtual devices:
 
 -   **Composite** - Group several devices together so they can be turned on/off together (in the order they are defined), as well as have additional settings applied in a group (e.g. brightness).
+-   **Condition** - Send an on or off command to the specified device only if the condition (specified in `on_condition` and `off_condition` respectively) is satisfied. For example this is useful if a device is connected to a remote socket and it cannot turn on until that socket is enabled.
 -   **Delay** - Wait for the specified interval for turn on or turn off. Used if a device takes a few seconds to start-up, and we don't want the next step to happen before it's ready.
 -   **Log** - A device used for testing, will simply output the specified log message when turned on or off.
 -   **Mutex** - A device that will ensure all the devices in the off device specification are off before attempting to turn the devices in the on device specification, akin to a mutually exclusive lock, the on devices cannot be on if the off devices are on.

--- a/controllers/macro/macro_controller/device/condition.py
+++ b/controllers/macro/macro_controller/device/condition.py
@@ -60,7 +60,7 @@ class ConditionDevice(Device, DeviceOrchestratorMixin, PollableMixin):
         await self.poll()
 
     async def poll(self):
-        pass
+        await self.set_new_state(self.device.state)
 
     async def _turn_on(self):
         if not self.__on_condition or await self.__check_condition(DeviceStatus.ON):

--- a/controllers/macro/macro_controller/device/condition.py
+++ b/controllers/macro/macro_controller/device/condition.py
@@ -1,0 +1,38 @@
+from powerpi_common.config import Config
+from powerpi_common.device import Device, DeviceManager, DeviceStatus
+from powerpi_common.device.mixin import DeviceOrchestratorMixin, PollableMixin
+from powerpi_common.logger import Logger
+from powerpi_common.mqtt import MQTTClient
+
+
+#pylint: disable=too-many-ancestors
+class ConditionDevice(Device, DeviceOrchestratorMixin, PollableMixin):
+    #pylint: disable=too-many-arguments
+    def __init__(
+        self,
+        config: Config,
+        logger: Logger,
+        mqtt_client: MQTTClient,
+        device_manager: DeviceManager,
+        device: str,
+        **kwargs
+    ):
+        Device.__init__(
+            self, config, logger, mqtt_client, **kwargs
+        )
+        DeviceOrchestratorMixin.__init__(
+            self, config, logger, mqtt_client, device_manager, [device]
+        )
+        PollableMixin.__init__(self, config, **kwargs)
+
+    async def on_referenced_device_status(self, _: str, __: DeviceStatus):
+        await self.poll()
+
+    async def poll(self):
+        pass
+
+    async def _turn_on(self):
+        pass
+
+    async def _turn_off(self):
+        pass

--- a/controllers/macro/macro_controller/device/condition.py
+++ b/controllers/macro/macro_controller/device/condition.py
@@ -1,8 +1,13 @@
+from typing import Union
+
+from powerpi_common.condition import (ConditionParser, Expression,
+                                      ParseException)
 from powerpi_common.config import Config
 from powerpi_common.device import Device, DeviceManager, DeviceStatus
 from powerpi_common.device.mixin import DeviceOrchestratorMixin, PollableMixin
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
+from powerpi_common.variable import VariableManager
 
 
 #pylint: disable=too-many-ancestors
@@ -14,7 +19,10 @@ class ConditionDevice(Device, DeviceOrchestratorMixin, PollableMixin):
         logger: Logger,
         mqtt_client: MQTTClient,
         device_manager: DeviceManager,
+        variable_manager: VariableManager,
         device: str,
+        on_condition: Union[Expression, None] = None,
+        off_condition: Union[Expression, None] = None,
         **kwargs
     ):
         Device.__init__(
@@ -24,6 +32,15 @@ class ConditionDevice(Device, DeviceOrchestratorMixin, PollableMixin):
             self, config, logger, mqtt_client, device_manager, [device]
         )
         PollableMixin.__init__(self, config, **kwargs)
+
+        self.__variable_manager = variable_manager
+        self.__on_condition = on_condition
+        self.__off_condition = off_condition
+
+    async def initialise(self):
+        await DeviceOrchestratorMixin.initialise(self)
+
+        self.__validate()
 
     async def on_referenced_device_status(self, _: str, __: DeviceStatus):
         await self.poll()
@@ -36,3 +53,23 @@ class ConditionDevice(Device, DeviceOrchestratorMixin, PollableMixin):
 
     async def _turn_off(self):
         pass
+
+    def __validate(self):
+        '''
+        Try and run the conditions to verify they're valid
+        '''
+        parser = ConditionParser(self.__variable_manager, {})
+
+        success = True
+        try:
+            if self.__on_condition is not None:
+                success &= parser.conditional_expression(self.__on_condition)
+
+            if self.__off_condition is not None:
+                success &= parser.conditional_expression(self.__off_condition)
+        except ParseException as ex:
+            self.log_exception(ex)
+            raise ex
+
+        if not success:
+            raise ParseException('Could not validate condition')

--- a/controllers/macro/macro_controller/device/condition.py
+++ b/controllers/macro/macro_controller/device/condition.py
@@ -1,3 +1,7 @@
+from asyncio import get_event_loop, sleep, wait_for
+from asyncio.exceptions import CancelledError as AsyncCancelledError
+from asyncio.exceptions import TimeoutError as AsyncTimeoutError
+from contextlib import suppress
 from typing import Union
 
 from powerpi_common.condition import (ConditionParser, Expression,
@@ -23,6 +27,8 @@ class ConditionDevice(Device, DeviceOrchestratorMixin, PollableMixin):
         device: str,
         on_condition: Union[Expression, None] = None,
         off_condition: Union[Expression, None] = None,
+        timeout=30,
+        interval=1,
         **kwargs
     ):
         Device.__init__(
@@ -37,6 +43,9 @@ class ConditionDevice(Device, DeviceOrchestratorMixin, PollableMixin):
 
         self.__on_condition = on_condition
         self.__off_condition = off_condition
+
+        self.__timeout = timeout
+        self.__interval = interval
 
     @property
     def device(self):
@@ -62,28 +71,51 @@ class ConditionDevice(Device, DeviceOrchestratorMixin, PollableMixin):
             self.device.turn_off()
 
     async def __check_condition(self, status: DeviceStatus):
-        try:
-            return self.__execute_parser(status)
-        except ParseException as ex:
-            self.__logger.exception(ex)
-
-        return False
-
-    def __execute_parser(self, status: DeviceStatus):
         condition = self.__on_condition if status == DeviceStatus.ON else self.__off_condition
-
         parser = ConditionParser(self.__variable_manager, {})
-        return parser.conditional_expression(condition)
+
+        # this will be set to True if the condition evaluates to true before the timeout
+        success = False
+
+        # use the condition to decide when to perform the action (if at all)
+        def attempt():
+            try:
+                return parser.conditional_expression(condition)
+            except ParseException as ex:
+                self.__logger.exception(ex)
+
+            return False
+
+        # repeat the condition check every interval seconds until the timeout seconds
+        # with early termination if the condition evaluates to true
+        async def repeat_condition_check():
+            nonlocal success
+
+            while True:
+                if attempt():
+                    success = True
+                    break
+
+                await sleep(self.__interval)
+
+        # schedule the condition check in a task and wait for it to pass or timeout
+        with suppress(AsyncCancelledError) and suppress(AsyncTimeoutError):
+            task = get_event_loop().create_task(repeat_condition_check)
+            await wait_for(task, self.__timeout)
+
+        return success
 
     def __validate(self):
         '''
         Try and run the conditions to verify they're valid
         '''
+        parser = ConditionParser(self.__variable_manager, {})
+
         try:
             if self.__on_condition is not None:
-                self.__execute_parser(DeviceStatus.ON)
+                parser.conditional_expression(self.__on_condition)
 
             if self.__off_condition is not None:
-                self.__execute_parser(DeviceStatus.OFF)
+                parser.conditional_expression(self.__off_condition)
         except ParseException as ex:
             self.log_exception(ex)

--- a/controllers/macro/macro_controller/device/condition.py
+++ b/controllers/macro/macro_controller/device/condition.py
@@ -64,11 +64,11 @@ class ConditionDevice(Device, DeviceOrchestratorMixin, PollableMixin):
 
     async def _turn_on(self):
         if not self.__on_condition or await self.__check_condition(DeviceStatus.ON):
-            self.device.turn_on()
+            await self.device.turn_on()
 
     async def _turn_off(self):
         if not self.__off_condition or await self.__check_condition(DeviceStatus.OFF):
-            self.device.turn_off()
+            await self.device.turn_off()
 
     async def __check_condition(self, status: DeviceStatus):
         condition = self.__on_condition if status == DeviceStatus.ON else self.__off_condition
@@ -100,7 +100,7 @@ class ConditionDevice(Device, DeviceOrchestratorMixin, PollableMixin):
 
         # schedule the condition check in a task and wait for it to pass or timeout
         with suppress(AsyncCancelledError) and suppress(AsyncTimeoutError):
-            task = get_event_loop().create_task(repeat_condition_check)
+            task = get_event_loop().create_task(repeat_condition_check())
             await wait_for(task, self.__timeout)
 
         return success

--- a/controllers/macro/macro_controller/device/condition.py
+++ b/controllers/macro/macro_controller/device/condition.py
@@ -85,7 +85,7 @@ class ConditionDevice(Device, DeviceOrchestratorMixin, PollableMixin):
             try:
                 return parser.conditional_expression(condition)
             except ParseException as ex:
-                self.__logger.exception(ex)
+                self.log_exception(ex)
 
             return False
 

--- a/controllers/macro/macro_controller/device/container.py
+++ b/controllers/macro/macro_controller/device/container.py
@@ -49,7 +49,8 @@ def add_devices(container):
             config=container.common.config,
             logger=container.common.logger,
             mqtt_client=container.common.mqtt_client,
-            device_manager=container.common.device.device_manager
+            device_manager=container.common.device.device_manager,
+            variable_manager=container.common.variable.variable_manager
         )
     )
 

--- a/controllers/macro/macro_controller/device/container.py
+++ b/controllers/macro/macro_controller/device/container.py
@@ -1,6 +1,6 @@
 from dependency_injector import containers, providers
-
 from macro_controller.device.composite import CompositeDevice
+from macro_controller.device.condition import ConditionDevice
 from macro_controller.device.delay import DelayDevice
 from macro_controller.device.factory import RemoteDeviceFactory
 from macro_controller.device.log import LogDevice
@@ -34,6 +34,18 @@ def add_devices(container):
         'composite_device',
         providers.Factory(
             CompositeDevice,
+            config=container.common.config,
+            logger=container.common.logger,
+            mqtt_client=container.common.mqtt_client,
+            device_manager=container.common.device.device_manager
+        )
+    )
+
+    setattr(
+        device_container,
+        'condition_device',
+        providers.Factory(
+            ConditionDevice,
             config=container.common.config,
             logger=container.common.logger,
             mqtt_client=container.common.mqtt_client,

--- a/controllers/macro/macro_controller/device/log.py
+++ b/controllers/macro/macro_controller/device/log.py
@@ -1,6 +1,6 @@
 from powerpi_common.config import Config
-from powerpi_common.logger import Logger
 from powerpi_common.device import Device
+from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
 
 
@@ -18,7 +18,7 @@ class LogDevice(Device):
         self.__message = message
 
     async def _turn_on(self):
-        self._logger.info(f'{self}: on: {self.__message}')
+        self.log_info(f'{self}: on: {self.__message}')
 
     async def _turn_off(self):
-        self._logger.info(f'{self}: off: {self.__message}')
+        self.log_info(f'{self}: off: {self.__message}')

--- a/controllers/macro/pyproject.toml
+++ b/controllers/macro/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "macro_controller"
-version = "1.1.10"
+version = "1.1.11"
 description = "PowerPi Macro Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/macro/tests/device/test_condition.py
+++ b/controllers/macro/tests/device/test_condition.py
@@ -1,0 +1,170 @@
+from asyncio import Future
+from unittest.mock import PropertyMock
+
+import pytest
+from macro_controller.device.condition import ConditionDevice
+from powerpi_common.device import DeviceStatus
+from powerpi_common_test.device import DeviceTestBase
+from powerpi_common_test.device.mixin import (DeviceOrchestratorMixinTestBase,
+                                              PollableMixinTestBase)
+from pytest_mock import MockerFixture
+
+
+class TestCondition(DeviceTestBase, DeviceOrchestratorMixinTestBase, PollableMixinTestBase):
+    def get_subject(self, mocker: MockerFixture):
+        # pylint: disable=attribute-defined-outside-init
+        self.device_manager = mocker.Mock()
+        self.variable_manager = mocker.Mock()
+
+        self.device = mocker.Mock()
+        future = Future()
+        future.set_result(None)
+        self.device.turn_on.return_value = future
+        self.device.turn_off.return_value = future
+
+        self.device_manager.get_device = lambda name: self.device if name == 'test_device' else None
+
+        return ConditionDevice(
+            self.config, self.logger, self.mqtt_client, self.device_manager, self.variable_manager,
+            name='condition', device='test_device',
+            on_condition={
+                'when': [{'equals': [{'var': 'device.on.state'}, 'on']}]
+            },
+            off_condition={
+                'when': [{'equals': [{'var': 'device.off.state'}, 'off']}]
+            },
+            timeout=0.3,
+            interval=0.1,
+            poll_frequency=60
+        )
+
+    async def test_initialise(self, mocker: MockerFixture):
+        subject = self.create_subject(mocker)
+
+        await subject.initialise()
+
+        self.variable_manager.get_device.assert_has_calls([
+            mocker.call('on'),
+            mocker.call('off')
+        ])
+
+    @pytest.mark.parametrize('state', [DeviceStatus.ON, DeviceStatus.OFF])
+    async def test_poll_updates_state(self, mocker: MockerFixture, state: DeviceStatus):
+        subject = self.create_subject(mocker)
+
+        on_device_variable = mocker.Mock()
+        type(on_device_variable).state = PropertyMock(
+            return_value=state
+        )
+
+        off_device_variable = mocker.Mock()
+        type(off_device_variable).state = PropertyMock(
+            return_value=state
+        )
+
+        def get_variable(name: str):
+            if name == DeviceStatus.ON:
+                return on_device_variable
+            if name == DeviceStatus.OFF:
+                return off_device_variable
+            return None
+        self.variable_manager.get_device = get_variable
+
+        assert subject.state == DeviceStatus.UNKNOWN
+
+        await subject.poll()
+
+        assert subject.state == state
+
+    async def test_poll_no_condition(self, subject: ConditionDevice):
+        assert subject.state == DeviceStatus.UNKNOWN
+
+        await subject.poll()
+
+        assert subject.state == DeviceStatus.UNKNOWN
+
+        self.variable_manager.get_device.assert_not_called()
+
+    @pytest.mark.parametrize('state', [DeviceStatus.ON, DeviceStatus.OFF])
+    async def test_turn_x_condition_true(self, mocker: MockerFixture, state: DeviceStatus):
+        subject = self.create_subject(mocker)
+
+        opposite = DeviceStatus.OFF if state == DeviceStatus.ON else DeviceStatus.ON
+
+        device_variable = mocker.Mock()
+        type(device_variable).state = PropertyMock(
+            side_effect=[opposite, state]
+        )
+
+        self.variable_manager.get_device = lambda name: device_variable if name == state else None
+
+        assert subject.state == DeviceStatus.UNKNOWN
+
+        if state == DeviceStatus.ON:
+            await subject.turn_on()
+        else:
+            await subject.turn_off()
+
+        assert subject.state == state
+
+        if state == DeviceStatus.ON:
+            self.device.turn_on.assert_called_once()
+            self.device.turn_off.assert_not_called()
+        else:
+            self.device.turn_off.assert_called_once()
+            self.device.turn_on.assert_not_called()
+
+    @pytest.mark.parametrize('state', [DeviceStatus.ON, DeviceStatus.OFF])
+    async def test_turn_x_condition_false(self, mocker: MockerFixture, state: DeviceStatus):
+        subject = self.create_subject(mocker)
+
+        opposite = DeviceStatus.OFF if state == DeviceStatus.ON else DeviceStatus.ON
+
+        device_variable = mocker.Mock()
+        type(device_variable).state = PropertyMock(
+            side_effect=[opposite, opposite, opposite]
+        )
+
+        self.variable_manager.get_device = lambda name: device_variable if name == state else None
+
+        assert subject.state == DeviceStatus.UNKNOWN
+
+        if state == DeviceStatus.ON:
+            await subject.turn_on()
+        else:
+            await subject.turn_off()
+
+        assert subject.state == state
+
+        self.device.turn_on.assert_not_called()
+        self.device.turn_off.assert_not_called()
+
+    @pytest.mark.parametrize('state', [DeviceStatus.ON, DeviceStatus.OFF])
+    async def test_turn_x_condition_none(self, subject: ConditionDevice, state: DeviceStatus):
+        assert subject.state == DeviceStatus.UNKNOWN
+
+        if state == DeviceStatus.ON:
+            await subject.turn_on()
+        else:
+            await subject.turn_off()
+
+        assert subject.state == state
+
+        self.variable_manager.get_device.assert_not_called()
+
+        if state == DeviceStatus.ON:
+            self.device.turn_on.assert_called_once()
+            self.device.turn_off.assert_not_called()
+        else:
+            self.device.turn_off.assert_called_once()
+            self.device.turn_on.assert_not_called()
+
+    @pytest.fixture
+    def subject(self, mocker: MockerFixture):
+        self.create_subject(mocker)
+
+        return ConditionDevice(
+            self.config, self.logger, self.mqtt_client, self.device_manager, self.variable_manager,
+            name='condition', device='test_device',
+            poll_frequency=60
+        )

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -69,7 +69,7 @@ services:
             - deep-thought
 
     macro-controller:
-        image: twilkin/powerpi-macro-controller:1.1.10
+        image: twilkin/powerpi-macro-controller:1.1.11
         networks:
             - powerpi
         deploy:


### PR DESCRIPTION
Resolves #103 by adding `ConditionDevice` to `macro-controller` which takes a device name, as well as an on and off condition.

When requesting to turn on, it will check the `on_condition` for (by default) 30 seconds waiting 1 second between checks.
- If within this interval the condition evaluates to true, it will send the on command to the device. 
- If this times out (returns false until timeout elapses) it will not send the command.
- If no condition is specified it will send the on command as normal.

This behaviour is duplicated for turning a device off, except it uses the `off_condition` property.