### PR TITLE
#240 Fix certbot cron schedule

### DIFF
--- a/.github/scripts/tag.sh
+++ b/.github/scripts/tag.sh
@@ -139,6 +139,7 @@ tag_service "controllers/zigbee" "zigbee-controller"
 tag_service "esp8266" "powerpi-sensor"
 
 tag_service "services/babel-fish" "babel-fish"
+tag_service "docker" "certbot"
 tag_service "services/clacks-config" "clacks-config"
 tag_service "services/deep-thought" "deep-thought"
 tag_service "docker" "device-mapper"

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -193,7 +193,7 @@ services:
               target: /etc/nginx/conf.d/default.conf
 
     certbot:
-        image: twilkin/powerpi-certbot:0.0.5
+        image: twilkin/powerpi-certbot:0.0.6
         networks:
             - powerpi
         deploy:

--- a/services/certbot/Dockerfile
+++ b/services/certbot/Dockerfile
@@ -6,10 +6,9 @@ RUN addgroup -g 101 certbot \
     && adduser --disabled-password -u 101 -G certbot certbot
 RUN mkdir -p /opt/certbot \
     && chown -R certbot.certbot /opt/certbot
-USER certbot
 
 # setup crontab to renew
-COPY --chown=certbot:certbot services/certbot/crontab /etc/crontabs/certbot
+COPY services/certbot/crontab /etc/crontabs/certbot
 
 # add the renew script
 WORKDIR /opt/certbot
@@ -17,4 +16,4 @@ COPY --chown=certbot:certbot services/certbot/renew.sh ./
 RUN chmod +x renew.sh
 
 # wait on cron
-ENTRYPOINT ["crond", "-f"]
+ENTRYPOINT ["crond", "-f", "-d", "8"]

--- a/services/certbot/Dockerfile
+++ b/services/certbot/Dockerfile
@@ -1,4 +1,4 @@
-FROM certbot/certbot:arm64v8-v1.29.0
+FROM certbot/certbot:arm64v8-v1.32.1
 LABEL description="PowerPi Certbot automatic SSL certificate renewal"
 
 # use non-root user


### PR DESCRIPTION
- Fixes #240 by correcting the permissions of the certbot crontab and output the log to stddev.
- Updates certbot to v1.32.1.
- Add certbot service to the tag pipeline.