### PR TITLE
#238 Change shutdown service to wait for NTP

### DIFF
--- a/services/shutdown/Makefile
+++ b/services/shutdown/Makefile
@@ -7,7 +7,7 @@ TARGET_OS?=linux
 TARGET_ARCH?=arm64
 
 # the version of the shutdown service
-VERSION=0.0.1
+VERSION=0.0.2
 
 all: compile
 

--- a/services/shutdown/README.md
+++ b/services/shutdown/README.md
@@ -72,6 +72,8 @@ The service takes the following command line arguments:
     	The port number for the MQTT broker (default 1883)
   -topic string
     	The topic base for the MQTT broker (default "powerpi")
+  -allowQuickShutdown
+      If true allow a message within 2 minutes of service starting to initiate a shutdown (default false)
 ```
 
 ## Testing

--- a/services/shutdown/powerpi-shutdown.service
+++ b/services/shutdown/powerpi-shutdown.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Service to listen for shutdown events and turn off the computer.
-After=multi-user.target
+After=time-sync.target
 StartLimitBurst=20
 
 [Service]


### PR DESCRIPTION
- Fixes #238 by changing the `shutdown` service to wait for NTP before starting the service, so a Pi won't shutdown immediately it turns on.