### PR TITLE
#243 Support device turn on/off failure not updating state

### DIFF
--- a/common/python/powerpi_common/device/device.py
+++ b/common/python/powerpi_common/device/device.py
@@ -3,13 +3,13 @@ from asyncio import Lock
 from typing import Awaitable, Callable, Union
 
 from powerpi_common.config import Config
+from powerpi_common.device.types import DeviceStatus
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
 
 from .base import BaseDevice
 from .consumers import (DeviceChangeEventConsumer,
                         DeviceInitialStatusEventConsumer)
-from .types import DeviceStatus
 
 
 class Device(BaseDevice, DeviceChangeEventConsumer):

--- a/common/python/powerpi_common/device/device.py
+++ b/common/python/powerpi_common/device/device.py
@@ -24,6 +24,7 @@ class Device(BaseDevice, DeviceChangeEventConsumer):
         config: Config,
         logger: Logger,
         mqtt_client: MQTTClient,
+        listener=True,
         **kwargs
     ):
         BaseDevice.__init__(self, **kwargs)
@@ -36,7 +37,8 @@ class Device(BaseDevice, DeviceChangeEventConsumer):
 
         self.__lock = Lock()
 
-        mqtt_client.add_consumer(self)
+        if listener:
+            mqtt_client.add_consumer(self)
 
         # add listener to get the initial state from the queue, if there is one
         DeviceInitialStatusEventConsumer(self, config, logger, mqtt_client)

--- a/common/python/powerpi_common/device/manager.py
+++ b/common/python/powerpi_common/device/manager.py
@@ -2,13 +2,13 @@ from copy import deepcopy
 from typing import Any, Dict, List, Union
 
 from powerpi_common.config import Config
+from powerpi_common.device.types import DeviceConfigType
 from powerpi_common.logger import Logger
 from powerpi_common.typing import DeviceType, SensorType
 from powerpi_common.util import ismixin
 
 from .factory import DeviceFactory
 from .mixin import InitialisableMixin
-from .types import DeviceConfigType
 
 
 class DeviceManager(InitialisableMixin):

--- a/common/python/pyproject.toml
+++ b/common/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "powerpi-common"
-version = "0.2.8"
+version = "0.2.9"
 description = "PowerPi Common Python Library"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/common/python/tests/device/test_device.py
+++ b/common/python/tests/device/test_device.py
@@ -1,7 +1,7 @@
-from pytest_mock import MockerFixture
-
-from powerpi_common.device import Device
+import pytest
+from powerpi_common.device import Device, DeviceStatus
 from powerpi_common_test.device import DeviceTestBase
+from pytest_mock import MockerFixture
 
 
 class DeviceImpl(Device):
@@ -12,12 +12,48 @@ class DeviceImpl(Device):
         )
 
     async def _turn_on(self):
-        pass
+        return True
 
     async def _turn_off(self):
-        pass
+        return True
 
 
 class TestDevice(DeviceTestBase):
     def get_subject(self, _: MockerFixture):
         return DeviceImpl(self.config, self.logger, self.mqtt_client)
+
+
+class BadDeviceImpl(Device):
+    def __init__(self, config, logger, mqtt_client):
+        Device.__init__(
+            self, config, logger, mqtt_client,
+            name='test'
+        )
+
+    async def _turn_on(self):
+        return False
+
+    async def _turn_off(self):
+        return False
+
+
+class TestBadDevice:
+    @pytest.mark.asyncio
+    async def test_turn_on(self, subject: BadDeviceImpl):
+        assert subject.state == DeviceStatus.UNKNOWN
+
+        await subject.turn_on()
+
+        assert subject.state == DeviceStatus.UNKNOWN
+
+    @pytest.mark.asyncio
+    async def test_turn_off(self, subject: BadDeviceImpl):
+        assert subject.state == DeviceStatus.UNKNOWN
+
+        await subject.turn_off()
+
+        assert subject.state == DeviceStatus.UNKNOWN
+
+    @pytest.fixture
+    def subject(self, mocker: MockerFixture):
+        return BadDeviceImpl(mocker.Mock(), mocker.Mock(), mocker.Mock())

--- a/controllers/node/node_controller/device/container.py
+++ b/controllers/node/node_controller/device/container.py
@@ -66,6 +66,7 @@ def add_devices(container):
             RemoteNodeDevice,
             config=container.common.config,
             logger=container.common.logger,
-            mqtt_client=container.common.mqtt_client
+            mqtt_client=container.common.mqtt_client,
+            listener=False
         )
     )

--- a/controllers/node/node_controller/device/remote_node.py
+++ b/controllers/node/node_controller/device/remote_node.py
@@ -31,8 +31,8 @@ class RemoteNodeDevice(Device, PollableMixin):
 
     async def _turn_on(self):
         # there's nothing we can do to turn the remote device on
-        pass
+        return False
 
     async def _turn_off(self):
         # there's nothing we can do to turn the remote device off
-        pass
+        return False

--- a/controllers/node/pyproject.toml
+++ b/controllers/node/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "node_controller"
-version = "0.0.1"
+version = "0.0.2"
 description = "PowerPi Node Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/node/tests/device/test_remote_node.py
+++ b/controllers/node/tests/device/test_remote_node.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Tuple
 from unittest.mock import PropertyMock
 
@@ -44,3 +45,42 @@ class TestRemoteNodeDevice(DeviceTestBase, PollableMixinTestBase):
         await subject.poll()
 
         assert subject.state == state
+
+    @pytest.mark.asyncio
+    async def test_turn_on(self, mocker: MockerFixture):
+        subject = self.create_subject(mocker)
+
+        assert subject.state == DeviceStatus.UNKNOWN
+
+        await subject.turn_on()
+
+        assert subject.state == DeviceStatus.UNKNOWN
+
+    @pytest.mark.asyncio
+    async def test_turn_off(self, mocker: MockerFixture):
+        subject = self.create_subject(mocker)
+
+        assert subject.state == DeviceStatus.UNKNOWN
+
+        await subject.turn_off()
+
+        assert subject.state == DeviceStatus.UNKNOWN
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('times', [1, 2])
+    async def test_change_message(self, mocker: MockerFixture, times: int):
+        subject = self.create_subject(mocker)
+
+        assert subject.state == DeviceStatus.UNKNOWN
+
+        mocker.patch.object(self.config, 'message_age_cutoff', 120)
+
+        message = {
+            'state': 'on',
+            'timestamp': int(datetime.utcnow().timestamp() * 1000)
+        }
+
+        for _ in range(1, times):
+            await subject.on_message(message, subject.name, 'change')
+
+            assert subject.state == DeviceStatus.UNKNOWN

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -125,7 +125,7 @@ services:
         environment:
             - ENV=DEVICE_FATAL=true
             - CONTROLLER_NAME=node-controller
-            - IMAGE=twilkin/powerpi-node-controller:0.0.1
+            - IMAGE=twilkin/powerpi-node-controller:0.0.2
             - DEVICE=/dev/i2c-1:/dev/gpiomem
             - VOLUME=/etc/hostname:/etc/nodehostname
         volumes:


### PR DESCRIPTION
Resolves #243:
- Support returning true/false from `Device._turn_on` and `Device._turn_off`. If the response is false then don't update the state.
- Allow a device to indicate that it doesn't want to subscribe to that device's events so it will never receive the change event.
- Update `node-controller` to make `RemoteNodeDevice` return false from the on/off methods and not subscribe to the change event.