### PR TITLE
#265 Update orchestrator to re-broadcast referenced device capabilities

### DIFF
--- a/common/pytest/powerpi_common_test/device/mixin/__init__.py
+++ b/common/pytest/powerpi_common_test/device/mixin/__init__.py
@@ -2,4 +2,4 @@ from .initialisable import (InitialisableMixinTestBase,
                             InitialisableMixinTestBaseNew)
 from .orchestrator import (DeviceOrchestratorMixinTestBase,
                            DeviceOrchestratorMixinTestBaseNew)
-from .pollable import PollableMixingTestBaseNew, PollableMixinTestBase
+from .pollable import PollableMixinTestBase, PollableMixinTestBaseNew

--- a/common/pytest/powerpi_common_test/device/mixin/__init__.py
+++ b/common/pytest/powerpi_common_test/device/mixin/__init__.py
@@ -1,4 +1,5 @@
 from .initialisable import (InitialisableMixinTestBase,
                             InitialisableMixinTestBaseNew)
-from .orchestrator import DeviceOrchestratorMixinTestBase
+from .orchestrator import (DeviceOrchestratorMixinTestBase,
+                           DeviceOrchestratorMixinTestBaseNew)
 from .pollable import PollableMixingTestBaseNew, PollableMixinTestBase

--- a/common/pytest/powerpi_common_test/device/mixin/orchestrator.py
+++ b/common/pytest/powerpi_common_test/device/mixin/orchestrator.py
@@ -1,7 +1,7 @@
 from abc import ABC
 
 import pytest
-
+from powerpi_common.device.mixin import DeviceOrchestratorMixin
 from pytest_mock import MockerFixture
 
 
@@ -18,4 +18,15 @@ class DeviceOrchestratorMixinTestBase(ABC):
     async def test_on_referenced_device_status_implemented(self, mocker: MockerFixture):
         subject = self.create_subject(mocker)
 
+        await subject.on_referenced_device_status('test_device', 'on')
+
+
+class DeviceOrchestratorMixinTestBaseNew(ABC):
+    def test_devices(self, subject: DeviceOrchestratorMixin):
+        devices = subject.devices
+        assert devices is not None
+        assert len(devices) > 0
+
+    @pytest.mark.asyncio
+    async def test_on_referenced_device_status_implemented(self, subject: DeviceOrchestratorMixin):
         await subject.on_referenced_device_status('test_device', 'on')

--- a/common/pytest/powerpi_common_test/device/mixin/pollable.py
+++ b/common/pytest/powerpi_common_test/device/mixin/pollable.py
@@ -26,7 +26,7 @@ class PollableMixinTestBase(ABC):
         assert subject.poll_frequency >= 10
 
 
-class PollableMixingTestBaseNew(ABC):
+class PollableMixinTestBaseNew(ABC):
     @pytest.mark.asyncio
     async def test_poll_implemented(self, subject: PollableMixin):
         await subject.poll()

--- a/common/python/powerpi_common/device/consumers/__init__.py
+++ b/common/python/powerpi_common/device/consumers/__init__.py
@@ -1,3 +1,4 @@
+from .capability_event_consumer import CapabilityEventConsumer
 from .change_event_consumer import DeviceChangeEventConsumer
 from .initial_status_event_consumer import DeviceInitialStatusEventConsumer
 from .status_event_consumer import DeviceStatusEventConsumer

--- a/common/python/powerpi_common/device/consumers/capability_event_consumer.py
+++ b/common/python/powerpi_common/device/consumers/capability_event_consumer.py
@@ -1,0 +1,18 @@
+from powerpi_common.config import Config
+from powerpi_common.logger import Logger
+from powerpi_common.mqtt import MQTTConsumer
+from powerpi_common.typing import DeviceType
+
+
+class CapabilityEventConsumer(MQTTConsumer):
+    def __init__(
+        self,
+        device: DeviceType,
+        config: Config,
+        logger: Logger
+    ):
+        topic = f'device/{device.name}/capability'
+
+        MQTTConsumer.__init__(
+            self, topic, config, logger
+        )

--- a/common/python/powerpi_common/device/mixin/__init__.py
+++ b/common/python/powerpi_common/device/mixin/__init__.py
@@ -1,5 +1,5 @@
 from .additional_state import AdditionalState, AdditionalStateMixin
-from .capability import CapabilityMixin
+from .capability import Capability, CapabilityMixin
 from .initialisable import InitialisableMixin
 from .orchestrator import DeviceOrchestratorMixin
 from .pollable import PollableMixin

--- a/common/python/powerpi_common/device/mixin/capability.py
+++ b/common/python/powerpi_common/device/mixin/capability.py
@@ -1,7 +1,13 @@
 from abc import ABC
+from collections import namedtuple
 from typing import Union
 
 from powerpi_common.util.data import DataType, Range
+
+Capability = namedtuple(
+    'Capability',
+    ['brightness', 'temperature', 'hue', 'saturation']
+)
 
 
 class CapabilityMixin(ABC):

--- a/common/python/powerpi_common/device/mixin/orchestrator.py
+++ b/common/python/powerpi_common/device/mixin/orchestrator.py
@@ -7,13 +7,13 @@ from powerpi_common.device.consumers.capability_event_consumer import \
     CapabilityEventConsumer
 from powerpi_common.device.consumers.status_event_consumer import \
     DeviceStatusEventConsumer
-from powerpi_common.device.mixin import Capability, CapabilityMixin
 from powerpi_common.device.types import DeviceStatus
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient, MQTTMessage
 from powerpi_common.typing import DeviceManagerType, DeviceType
 from powerpi_common.util.data import DataType, Range
 
+from .capability import Capability, CapabilityMixin
 from .initialisable import InitialisableMixin
 
 

--- a/common/python/powerpi_common/device/mixin/orchestrator.py
+++ b/common/python/powerpi_common/device/mixin/orchestrator.py
@@ -22,6 +22,7 @@ class DeviceOrchestratorMixin(InitialisableMixin, CapabilityMixin):
     Mixin to add device orchestrator functionality (for devices that
     control other devices.)
     '''
+
     class ReferencedDeviceStateEventListener(DeviceStatusEventConsumer):
         def __init__(
             self,

--- a/common/python/powerpi_common/device/mixin/orchestrator.py
+++ b/common/python/powerpi_common/device/mixin/orchestrator.py
@@ -101,9 +101,7 @@ class DeviceOrchestratorMixin(InitialisableMixin, CapabilityMixin):
             device['colour'][DataType.HUE]
             if 'colour' in device and DataType.HUE in device['colour']
             else False
-            for device in self.__capabilities.values()
-        ) and any(
-            device['colour'][DataType.SATURATION]
+            and device['colour'][DataType.SATURATION]
             if 'colour' in device and DataType.SATURATION in device['colour']
             else False
             for device in self.__capabilities.values()
@@ -142,14 +140,17 @@ class DeviceOrchestratorMixin(InitialisableMixin, CapabilityMixin):
         Method to refresh the orchestrator devices' capabilities based on the changed
         capability from the referenced device.
         '''
-        new_capabilities = {**self.__capabilities}
-        new_capabilities[device_name] = capability
+        current = None
+        if device_name in self.__capabilities:
+            current = self.__capabilities[device_name]
 
-        if new_capabilities != self.__capabilities:
-            # the capabilities have been updated
-            self.__capabilities = new_capabilities
+        if current != capability:
+            # the capabilities for this referenced device have been updated
+            self.__capabilities[device_name] = capability
 
-            self.on_capability_change()
+            if len(self.__capabilities.keys()) == len(self.devices):
+                # broadcast when we have the capabilities for all the referenced devices
+                self.on_capability_change()
 
     async def initialise(self):
         for device in self.devices:

--- a/common/python/powerpi_common/device/mixin/orchestrator.py
+++ b/common/python/powerpi_common/device/mixin/orchestrator.py
@@ -91,7 +91,7 @@ class DeviceOrchestratorMixin(InitialisableMixin, CapabilityMixin):
     @CapabilityMixin.supports_brightness.getter
     def supports_brightness(self):
         return any(
-            device[DataType.BRIGHTNESS] if DataType.BRIGHTNESS in device else None
+            device[DataType.BRIGHTNESS] if DataType.BRIGHTNESS in device else False
             for device in self.__capabilities.values()
         )
 
@@ -100,12 +100,12 @@ class DeviceOrchestratorMixin(InitialisableMixin, CapabilityMixin):
         return any(
             device['colour'][DataType.HUE]
             if 'colour' in device and DataType.HUE in device['colour']
-            else None
+            else False
             for device in self.__capabilities.values()
         ) and any(
             device['colour'][DataType.SATURATION]
             if 'colour' in device and DataType.SATURATION in device['colour']
-            else None
+            else False
             for device in self.__capabilities.values()
         )
 

--- a/common/python/pyproject.toml
+++ b/common/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "powerpi-common"
-version = "0.2.12"
+version = "0.2.13"
 description = "PowerPi Common Python Library"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/common/python/tests/device/mixin/test_capability.py
+++ b/common/python/tests/device/mixin/test_capability.py
@@ -92,7 +92,7 @@ class TestCapabilityMixin:
         else:
             powerpi_mqtt_producer.assert_not_called()
 
-    @ pytest.fixture
+    @pytest.fixture
     def subject(
         self,
         powerpi_config: Config,

--- a/common/python/tests/device/mixin/test_orchestrator.py
+++ b/common/python/tests/device/mixin/test_orchestrator.py
@@ -1,14 +1,15 @@
+from typing import Dict, List
+
 import pytest
-
-from pytest_mock import MockerFixture
-
 from powerpi_common.device import Device, DeviceStatus
 from powerpi_common.device.mixin import DeviceOrchestratorMixin
-from powerpi_common_test.device import DeviceTestBase
-from powerpi_common_test.device.mixin import DeviceOrchestratorMixinTestBase
+from powerpi_common.mqtt.consumer import MQTTConsumer
+from powerpi_common_test.device.mixin import DeviceOrchestratorMixinTestBaseNew
+from pytest_mock import MockerFixture
 
 
 class DeviceImpl(Device, DeviceOrchestratorMixin):
+    # pylint: disable=too-many-ancestors
     def __init__(self, config, logger, mqtt_client, device_manager, **kwargs):
         Device.__init__(self, config, logger, mqtt_client, **kwargs)
         DeviceOrchestratorMixin.__init__(
@@ -33,38 +34,16 @@ class DummyDevice:
         self.name = name
 
 
-class TestDeviceOrchestratorMixin(DeviceTestBase, DeviceOrchestratorMixinTestBase):
-    pytestmark = pytest.mark.asyncio
+class TestDeviceOrchestratorMixin(DeviceOrchestratorMixinTestBaseNew):
 
-    def get_subject(self, mocker: MockerFixture):
-        self.device_manager = mocker.Mock()
-
-        self.devices = [f'device{i}' for i in range(0, 4)]
-
-        device = DeviceImpl(
-            self.config, self.logger, self.mqtt_client, self.device_manager,
-            name='orchestrator',
-            devices=self.devices
-        )
-
-        return device
-
+    @pytest.mark.asyncio
     @pytest.mark.parametrize('state', ['on', 'off', 'unknown'])
-    async def test_on_referenced_device_status_called(self, mocker: MockerFixture, state: str):
-        self.consumers = {}
-
-        def mock_add_consumer():
-            def add_consumer(consumer):
-                self.consumers[consumer.topic] = consumer
-
-            self.mqtt_client.add_consumer = add_consumer
-
-        subject = self.create_subject(mocker, mock_add_consumer)
-
-        def get_device(device_name: str):
-            return DummyDevice(device_name)
-        self.device_manager.get_device = get_device
-
+    async def test_on_referenced_device_status_called(
+        self,
+        subject: DeviceImpl,
+        devices: List[str],
+        state: str
+    ):
         await subject.initialise()
 
         message = {
@@ -74,12 +53,54 @@ class TestDeviceOrchestratorMixin(DeviceTestBase, DeviceOrchestratorMixinTestBas
 
         assert subject.state == 'unknown'
 
-        await self.consumers['device/device0/status'].on_message(message, self.devices[0], 'status')
+        await self.consumers['device/device0/status'].on_message(message, devices[0], 'status')
 
-        assert subject.current_device == self.devices[0]
+        assert subject.current_device == devices[0]
         assert subject.state == state
 
-        await self.consumers['device/device2/status'].on_message(message, self.devices[2], 'status')
+        await self.consumers['device/device2/status'].on_message(message, devices[2], 'status')
 
-        assert subject.current_device == self.devices[2]
+        assert subject.current_device == devices[2]
         assert subject.state == state
+
+    @pytest.fixture
+    def subject(
+        self,
+        powerpi_config,
+        powerpi_logger,
+        mqtt_client,
+        device_manager,
+        devices,
+    ):
+        # pylint: disable=too-many-arguments
+        return DeviceImpl(
+            powerpi_config, powerpi_logger, mqtt_client, device_manager,
+            name='orchestrator',
+            devices=devices
+        )
+
+    @pytest.fixture
+    def mqtt_client(self, powerpi_mqtt_client):
+        self.consumers: Dict[str, MQTTConsumer] = {}
+
+        def add_consumer(consumer: MQTTConsumer):
+            self.consumers[consumer.topic] = consumer
+
+        powerpi_mqtt_client.add_consumer = add_consumer
+
+        return powerpi_mqtt_client
+
+    @pytest.fixture
+    def devices(self):
+        return [f'device{i}' for i in range(0, 4)]
+
+    @pytest.fixture
+    def device_manager(self, mocker: MockerFixture):
+        manager = mocker.Mock()
+
+        def get_device(device_name: str):
+            return DummyDevice(device_name)
+
+        manager.get_device = get_device
+
+        return manager

--- a/common/python/tests/device/mixin/test_orchestrator.py
+++ b/common/python/tests/device/mixin/test_orchestrator.py
@@ -1,9 +1,10 @@
-from typing import Dict, List
+from typing import Dict, List, Union
 
 import pytest
 from powerpi_common.device import Device, DeviceStatus
 from powerpi_common.device.mixin import DeviceOrchestratorMixin
 from powerpi_common.mqtt.consumer import MQTTConsumer
+from powerpi_common.util.data import Range
 from powerpi_common_test.device.mixin import DeviceOrchestratorMixinTestBaseNew
 from pytest_mock import MockerFixture
 
@@ -62,6 +63,130 @@ class TestDeviceOrchestratorMixin(DeviceOrchestratorMixinTestBaseNew):
 
         assert subject.current_device == devices[2]
         assert subject.state == state
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('brightness', [True, False])
+    @pytest.mark.parametrize('temperature', [Range(1000, 2000), False])
+    @pytest.mark.parametrize('colour', [True, False])
+    async def test_on_referenced_device_capability_called(
+        self,
+        subject: DeviceImpl,
+        devices: List[str],
+        brightness: bool,
+        temperature: Union[Range, bool],
+        colour: bool
+    ):
+        #pylint: disable=too-many-arguments
+
+        assert subject.supports_brightness is False
+        assert subject.supports_colour_temperature is False
+        assert subject.supports_colour_hue_and_saturation is False
+
+        await subject.initialise()
+
+        message = {
+            'timestamp': 0
+        }
+
+        if brightness:
+            message['brightness'] = True
+
+        if temperature or colour:
+            message['colour'] = {}
+
+            if temperature:
+                message['colour']['temperature'] = {
+                    'min': 1000,
+                    'max': 2000,
+                }
+
+            if colour:
+                message['colour']['hue'] = True
+                message['colour']['saturation'] = True
+
+        await self.consumers['device/device0/capability'] \
+            .on_message(message, devices[0], 'capability')
+
+        assert subject.supports_brightness is brightness
+        assert subject.supports_colour_hue_and_saturation is colour
+
+        if temperature is False:
+            assert subject.supports_colour_temperature is False
+        else:
+            assert subject.supports_colour_temperature.min == temperature.min
+            assert subject.supports_colour_temperature.max == temperature.max
+
+        # now test an update
+        message = {'timestamp': 0}
+
+        await self.consumers['device/device0/capability'] \
+            .on_message(message, devices[0], 'capability')
+
+        assert subject.supports_brightness is False
+        assert subject.supports_colour_temperature is False
+        assert subject.supports_colour_hue_and_saturation is False
+
+    @pytest.mark.asyncio
+    async def test_on_referenced_device_capability_many_temperatures(
+        self,
+        subject: DeviceImpl,
+        devices: List[str],
+    ):
+        assert subject.supports_colour_temperature is False
+
+        await subject.initialise()
+
+        message = {
+            'timestamp': 0,
+            'colour': {
+                'temperature': {
+                    'min': 1000,
+                    'max': 2000
+                }
+            }
+        }
+
+        await self.consumers['device/device0/capability'] \
+            .on_message(message, devices[0], 'capability')
+
+        assert subject.supports_colour_temperature.min == 1000
+        assert subject.supports_colour_temperature.max == 2000
+
+        # now add another which should extend the range
+
+        message = {
+            'timestamp': 0,
+            'colour': {
+                'temperature': {
+                    'min': 999,
+                    'max': 2001
+                }
+            }
+        }
+
+        await self.consumers['device/device2/capability'] \
+            .on_message(message, devices[2], 'capability')
+
+        assert subject.supports_colour_temperature.min == 999
+        assert subject.supports_colour_temperature.max == 2001
+
+        # now add another which shouldn't change anything
+
+        message = {
+            'timestamp': 0,
+            'colour': {
+                'temperature': {
+                    'min': 1001,
+                    'max': 1999
+                }
+            }
+        }
+
+        await self.consumers['device/device1/capability'] \
+            .on_message(message, devices[1], 'capability')
+
+        assert subject.supports_colour_temperature.min == 999
+        assert subject.supports_colour_temperature.max == 2001
 
     @pytest.fixture
     def subject(

--- a/controllers/lifx/tests/device/test_lifx_light.py
+++ b/controllers/lifx/tests/device/test_lifx_light.py
@@ -9,13 +9,13 @@ from lifx_controller.device.lifx_light import LIFXLightDevice
 from powerpi_common.util.data import Range
 from powerpi_common_test.device import AdditionalStateDeviceTestBaseNew
 from powerpi_common_test.device.mixin import (InitialisableMixinTestBaseNew,
-                                              PollableMixingTestBaseNew)
+                                              PollableMixinTestBaseNew)
 from pytest_mock import MockerFixture
 
 
 class TestLIFXLightDevice(
     AdditionalStateDeviceTestBaseNew,
-    PollableMixingTestBaseNew,
+    PollableMixinTestBaseNew,
     InitialisableMixinTestBaseNew
 ):
     @pytest.mark.asyncio

--- a/controllers/macro/poetry.lock
+++ b/controllers/macro/poetry.lock
@@ -233,7 +233,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "powerpi-common"
-version = "0.2.10"
+version = "0.2.13"
 description = "PowerPi Common Python Library"
 category = "dev"
 optional = false
@@ -253,7 +253,7 @@ url = "../../common/python"
 
 [[package]]
 name = "powerpi-common-test"
-version = "0.2.4"
+version = "0.2.6"
 description = "PowerPi Common Python Test Library"
 category = "dev"
 optional = false

--- a/controllers/macro/pyproject.toml
+++ b/controllers/macro/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "macro_controller"
-version = "1.1.12"
+version = "1.1.13"
 description = "PowerPi Macro Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/macro/tests/conftest.py
+++ b/controllers/macro/tests/conftest.py
@@ -1,0 +1,6 @@
+# pylint: disable=unused-import
+
+import pytest
+from powerpi_common_test.fixture import (powerpi_config, powerpi_logger,
+                                         powerpi_mqtt_client,
+                                         powerpi_mqtt_producer)

--- a/controllers/macro/tests/device/test_composite.py
+++ b/controllers/macro/tests/device/test_composite.py
@@ -1,100 +1,87 @@
 from asyncio import Future
-from typing import List, Tuple
-from unittest.mock import PropertyMock, patch
+from typing import Dict, List, Tuple
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
-
+from macro_controller.device import CompositeDevice
+from powerpi_common_test.device import AdditionalStateDeviceTestBaseNew
+from powerpi_common_test.device.mixin import (
+    DeviceOrchestratorMixinTestBaseNew, PollableMixinTestBaseNew)
 from pytest_mock import MockerFixture
 
-from macro_controller.device import CompositeDevice
-from powerpi_common_test.device import AdditionalStateDeviceTestBase
-from powerpi_common_test.device.mixin import DeviceOrchestratorMixinTestBase, PollableMixinTestBase
 
+class TestCompositeDevice(
+    AdditionalStateDeviceTestBaseNew,
+    DeviceOrchestratorMixinTestBaseNew,
+    PollableMixinTestBaseNew
+):
 
-class TestCompositeDevice(AdditionalStateDeviceTestBase, DeviceOrchestratorMixinTestBase, PollableMixinTestBase):
-    def get_subject(self, mocker: MockerFixture):
-        self.device_manager = mocker.Mock()
-
-        self.devices = {f'device{i}': mocker.Mock() for i in range(0, 4)}
-
-        self.device_manager.get_device = lambda name: self.devices[name]
-
-        future = Future()
-        future.set_result(None)
-        for device in self.devices.values():
-            for method in ['turn_on', 'turn_off', 'change_power_and_additional_state']:
-                mocker.patch.object(
-                    device,
-                    method,
-                    return_value=future
-                )
-
-        return CompositeDevice(
-            self.config, self.logger, self.mqtt_client, self.device_manager,
-            ['device0', 'device1', 'device2', 'device3'],
-            name='composite', poll_frequency=60
-        )
-
-    async def test_all_on(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
+    @pytest.mark.asyncio
+    async def test_all_on(
+        self,
+        subject: CompositeDevice,
+        devices: Dict[str, MagicMock]
+    ):
         # store the order they were called
-        self.order = []
+        order = []
 
         def mock(name: str):
             async def turn_on():
-                self.order.append(name)
+                order.append(name)
             return turn_on
 
-        for name, device in self.devices.items():
+        for name, device in devices.items():
             device.turn_on = mock(name)
 
         await subject.turn_on()
 
         # ensure they were called in the correct order
-        assert self.order == ['device0', 'device1', 'device2', 'device3']
+        assert order == ['device0', 'device1', 'device2', 'device3']
 
-    async def test_all_off(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
+    @pytest.mark.asyncio
+    async def test_all_off(
+        self,
+        subject: CompositeDevice,
+        devices: Dict[str, MagicMock]
+    ):
         # store the order they were called
-        self.order = []
+        order = []
 
         def mock(name: str):
             async def turn_off():
-                self.order.append(name)
+                order.append(name)
             return turn_off
 
-        for name, device in self.devices.items():
+        for name, device in devices.items():
             device.turn_off = mock(name)
 
         await subject.turn_off()
 
         # ensure they were called in the correct order
-        assert self.order == ['device3', 'device2', 'device1', 'device0']
+        assert order == ['device3', 'device2', 'device1', 'device0']
 
+    @pytest.mark.asyncio
     @pytest.mark.parametrize('states', [
         ('on', ['device0', 'device1', 'device2', 'device3']),
         ('off', ['device3', 'device2', 'device1', 'device0'])
     ])
     async def test_all_change_power_and_additional_state(
         self,
-        mocker: MockerFixture,
+        subject: CompositeDevice,
+        devices: Dict[str, MagicMock],
         states: Tuple[str, List[str]]
     ):
         (new_state, expected_order) = states
 
-        subject = self.create_subject(mocker)
-
         # store the order they were called
-        self.order = []
+        order = []
 
         def mock(name: str):
             async def change_power_and_additional_state(_: str, __: dict):
-                self.order.append(name)
+                order.append(name)
             return change_power_and_additional_state
 
-        for name, device in self.devices.items():
+        for name, device in devices.items():
             device.change_power_and_additional_state = mock(name)
 
         new_additional_state = {'something': 'else'}
@@ -105,11 +92,14 @@ class TestCompositeDevice(AdditionalStateDeviceTestBase, DeviceOrchestratorMixin
             await subject.change_power_and_additional_state(new_state, new_additional_state)
 
         # ensure they were called in the correct order
-        assert self.order == expected_order
+        assert order == expected_order
 
-    async def test_all_change_power_and_additional_state_unsupported(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
+    @pytest.mark.asyncio
+    async def test_all_change_power_and_additional_state_unsupported(
+        self,
+        subject: CompositeDevice,
+        devices: Dict[str, MagicMock]
+    ):
         new_state = 'on'
         new_additional_state = {'something': 'else'}
 
@@ -118,9 +108,10 @@ class TestCompositeDevice(AdditionalStateDeviceTestBase, DeviceOrchestratorMixin
 
             await subject.change_power_and_additional_state(new_state, new_additional_state)
 
-        for device in self.devices.values():
+        for device in devices.values():
             device.turn_on.assert_called_once()
 
+    @pytest.mark.asyncio
     @pytest.mark.parametrize('states', [
         ('unknown', 'on', ['unknown', 'unknown', 'unknown', 'on']),
         ('unknown', 'off', ['unknown', 'unknown', 'unknown', 'off']),
@@ -134,23 +125,61 @@ class TestCompositeDevice(AdditionalStateDeviceTestBase, DeviceOrchestratorMixin
     ])
     async def test_on_referenced_device_status(
         self,
-        mocker: MockerFixture,
+        subject: CompositeDevice,
+        devices: Dict[str, MagicMock],
         states: Tuple[str, str, List[str]]
     ):
         (initial_state, update_state, expected_states) = states
 
-        subject = self.create_subject(mocker)
-
         assert subject.state == 'unknown'
 
         # initialise the devices
-        for device in self.devices.values():
+        for device in devices.values():
             type(device).state = PropertyMock(return_value=initial_state)
 
-        for device, expected in zip(self.devices.values(), expected_states):
+        for device, expected in zip(devices.values(), expected_states):
             type(device).state = PropertyMock(return_value=update_state)
             await subject.on_referenced_device_status(device.name, update_state)
 
             assert subject.state == expected
 
         assert subject.state == update_state
+
+    @pytest.fixture
+    def subject(
+        self,
+        powerpi_config,
+        powerpi_logger,
+        powerpi_mqtt_client,
+        device_manager
+    ):
+        return CompositeDevice(
+            powerpi_config, powerpi_logger, powerpi_mqtt_client, device_manager,
+            devices=['device0', 'device1', 'device2', 'device3'],
+            name='composite',
+            poll_frequency=60
+        )
+
+    @pytest.fixture
+    def devices(self, mocker: MockerFixture):
+        devices = {f'device{i}': mocker.Mock() for i in range(0, 4)}
+
+        future = Future()
+        future.set_result(True)
+        for method in ['turn_on', 'turn_off', 'change_power_and_additional_state']:
+            for device in devices.values():
+                mocker.patch.object(
+                    device,
+                    method,
+                    return_value=future
+                )
+
+        return devices
+
+    @pytest.fixture
+    def device_manager(self, devices: Dict[str, MagicMock], mocker: MockerFixture):
+        manager = mocker.MagicMock()
+
+        manager.get_device = lambda name: devices[name]
+
+        return manager

--- a/controllers/macro/tests/device/test_condition.py
+++ b/controllers/macro/tests/device/test_condition.py
@@ -1,57 +1,44 @@
 from asyncio import Future
-from unittest.mock import PropertyMock
+from unittest.mock import MagicMock, Mock, PropertyMock
 
 import pytest
 from macro_controller.device.condition import ConditionDevice
 from powerpi_common.device import DeviceStatus
-from powerpi_common_test.device import DeviceTestBase
-from powerpi_common_test.device.mixin import (DeviceOrchestratorMixinTestBase,
-                                              PollableMixinTestBase)
+from powerpi_common_test.device import DeviceTestBaseNew
+from powerpi_common_test.device.mixin import (
+    DeviceOrchestratorMixinTestBaseNew, PollableMixingTestBaseNew)
 from pytest_mock import MockerFixture
 
 
-class TestCondition(DeviceTestBase, DeviceOrchestratorMixinTestBase, PollableMixinTestBase):
-    def get_subject(self, mocker: MockerFixture):
-        # pylint: disable=attribute-defined-outside-init
-        self.device_manager = mocker.Mock()
-        self.variable_manager = mocker.Mock()
+class TestCondition(
+    DeviceTestBaseNew,
+    DeviceOrchestratorMixinTestBaseNew,
+    PollableMixingTestBaseNew
+):
 
-        self.device = mocker.Mock()
-        future = Future()
-        future.set_result(None)
-        self.device.turn_on.return_value = future
-        self.device.turn_off.return_value = future
-
-        self.device_manager.get_device = lambda name: self.device if name == 'test_device' else None
-
-        return ConditionDevice(
-            self.config, self.logger, self.mqtt_client, self.device_manager, self.variable_manager,
-            name='condition', device='test_device',
-            on_condition={
-                'when': [{'equals': [{'var': 'device.on.state'}, 'on']}]
-            },
-            off_condition={
-                'when': [{'equals': [{'var': 'device.off.state'}, 'off']}]
-            },
-            timeout=0.3,
-            interval=0.1,
-            poll_frequency=60
-        )
-
-    async def test_initialise(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
+    @pytest.mark.asyncio
+    async def test_initialise(
+        self,
+        subject: ConditionDevice,
+        variable_manager: Mock,
+        mocker: MockerFixture
+    ):
         await subject.initialise()
 
-        self.variable_manager.get_device.assert_has_calls([
+        variable_manager.get_device.assert_has_calls([
             mocker.call('on'),
             mocker.call('off')
         ])
 
+    @pytest.mark.asyncio
     @pytest.mark.parametrize('state', [DeviceStatus.ON, DeviceStatus.OFF])
-    async def test_poll_updates_state(self, mocker: MockerFixture, state: DeviceStatus):
-        subject = self.create_subject(mocker)
-
+    async def test_poll_updates_state(
+        self,
+        subject: ConditionDevice,
+        variable_manager: Mock,
+        mocker: MockerFixture,
+        state: DeviceStatus
+    ):
         on_device_variable = mocker.Mock()
         type(on_device_variable).state = PropertyMock(
             return_value=state
@@ -68,7 +55,7 @@ class TestCondition(DeviceTestBase, DeviceOrchestratorMixinTestBase, PollableMix
             if name == DeviceStatus.OFF:
                 return off_device_variable
             return None
-        self.variable_manager.get_device = get_variable
+        variable_manager.get_device = get_variable
 
         assert subject.state == DeviceStatus.UNKNOWN
 
@@ -76,19 +63,33 @@ class TestCondition(DeviceTestBase, DeviceOrchestratorMixinTestBase, PollableMix
 
         assert subject.state == state
 
-    async def test_poll_no_condition(self, subject: ConditionDevice):
+    @pytest.mark.asyncio
+    async def test_poll_no_condition(
+        self,
+        no_condition_subject: ConditionDevice,
+        variable_manager: Mock
+    ):
+        subject = no_condition_subject
+
         assert subject.state == DeviceStatus.UNKNOWN
 
         await subject.poll()
 
         assert subject.state == DeviceStatus.UNKNOWN
 
-        self.variable_manager.get_device.assert_not_called()
+        variable_manager.get_device.assert_not_called()
 
+    @pytest.mark.asyncio
     @pytest.mark.parametrize('state', [DeviceStatus.ON, DeviceStatus.OFF])
-    async def test_turn_x_condition_true(self, mocker: MockerFixture, state: DeviceStatus):
-        subject = self.create_subject(mocker)
-
+    async def test_turn_x_condition_true(
+        self,
+        subject: ConditionDevice,
+        device: MagicMock,
+        variable_manager: Mock,
+        mocker: MockerFixture,
+        state: DeviceStatus
+    ):
+        #pylint: disable=too-many-arguments
         opposite = DeviceStatus.OFF if state == DeviceStatus.ON else DeviceStatus.ON
 
         device_variable = mocker.Mock()
@@ -96,7 +97,7 @@ class TestCondition(DeviceTestBase, DeviceOrchestratorMixinTestBase, PollableMix
             side_effect=[opposite, state]
         )
 
-        self.variable_manager.get_device = lambda name: device_variable if name == state else None
+        variable_manager.get_device = lambda name: device_variable if name == state else None
 
         assert subject.state == DeviceStatus.UNKNOWN
 
@@ -108,16 +109,23 @@ class TestCondition(DeviceTestBase, DeviceOrchestratorMixinTestBase, PollableMix
         assert subject.state == state
 
         if state == DeviceStatus.ON:
-            self.device.turn_on.assert_called_once()
-            self.device.turn_off.assert_not_called()
+            device.turn_on.assert_called_once()
+            device.turn_off.assert_not_called()
         else:
-            self.device.turn_off.assert_called_once()
-            self.device.turn_on.assert_not_called()
+            device.turn_off.assert_called_once()
+            device.turn_on.assert_not_called()
 
+    @pytest.mark.asyncio
     @pytest.mark.parametrize('state', [DeviceStatus.ON, DeviceStatus.OFF])
-    async def test_turn_x_condition_false(self, mocker: MockerFixture, state: DeviceStatus):
-        subject = self.create_subject(mocker)
-
+    async def test_turn_x_condition_false(
+        self,
+        subject: ConditionDevice,
+        device: MagicMock,
+        variable_manager: Mock,
+        mocker: MockerFixture,
+        state: DeviceStatus
+    ):
+        #pylint: disable=too-many-arguments
         opposite = DeviceStatus.OFF if state == DeviceStatus.ON else DeviceStatus.ON
 
         device_variable = mocker.Mock()
@@ -125,7 +133,7 @@ class TestCondition(DeviceTestBase, DeviceOrchestratorMixinTestBase, PollableMix
             side_effect=[opposite, opposite, opposite]
         )
 
-        self.variable_manager.get_device = lambda name: device_variable if name == state else None
+        variable_manager.get_device = lambda name: device_variable if name == state else None
 
         assert subject.state == DeviceStatus.UNKNOWN
 
@@ -136,11 +144,20 @@ class TestCondition(DeviceTestBase, DeviceOrchestratorMixinTestBase, PollableMix
 
         assert subject.state == state
 
-        self.device.turn_on.assert_not_called()
-        self.device.turn_off.assert_not_called()
+        device.turn_on.assert_not_called()
+        device.turn_off.assert_not_called()
 
+    @pytest.mark.asyncio
     @pytest.mark.parametrize('state', [DeviceStatus.ON, DeviceStatus.OFF])
-    async def test_turn_x_condition_none(self, subject: ConditionDevice, state: DeviceStatus):
+    async def test_turn_x_condition_none(
+        self,
+        no_condition_subject: ConditionDevice,
+        device: MagicMock,
+        variable_manager: Mock,
+        state: DeviceStatus
+    ):
+        subject = no_condition_subject
+
         assert subject.state == DeviceStatus.UNKNOWN
 
         if state == DeviceStatus.ON:
@@ -150,21 +167,76 @@ class TestCondition(DeviceTestBase, DeviceOrchestratorMixinTestBase, PollableMix
 
         assert subject.state == state
 
-        self.variable_manager.get_device.assert_not_called()
+        variable_manager.get_device.assert_not_called()
 
         if state == DeviceStatus.ON:
-            self.device.turn_on.assert_called_once()
-            self.device.turn_off.assert_not_called()
+            device.turn_on.assert_called_once()
+            device.turn_off.assert_not_called()
         else:
-            self.device.turn_off.assert_called_once()
-            self.device.turn_on.assert_not_called()
+            device.turn_off.assert_called_once()
+            device.turn_on.assert_not_called()
 
     @pytest.fixture
-    def subject(self, mocker: MockerFixture):
-        self.create_subject(mocker)
-
+    def subject(
+        self,
+        powerpi_config,
+        powerpi_logger,
+        powerpi_mqtt_client,
+        device_manager,
+        variable_manager
+    ):
+        #pylint: disable=too-many-arguments
         return ConditionDevice(
-            self.config, self.logger, self.mqtt_client, self.device_manager, self.variable_manager,
-            name='condition', device='test_device',
+            powerpi_config, powerpi_logger, powerpi_mqtt_client, device_manager, variable_manager,
+            name='condition',
+            device='test_device',
+            on_condition={
+                'when': [{'equals': [{'var': 'device.on.state'}, 'on']}]
+            },
+            off_condition={
+                'when': [{'equals': [{'var': 'device.off.state'}, 'off']}]
+            },
+            timeout=0.3,
+            interval=0.1,
             poll_frequency=60
         )
+
+    @pytest.fixture
+    def no_condition_subject(
+        self,
+        powerpi_config,
+        powerpi_logger,
+        powerpi_mqtt_client,
+        device_manager,
+        variable_manager
+    ):
+        #pylint: disable=too-many-arguments
+        return ConditionDevice(
+            powerpi_config, powerpi_logger, powerpi_mqtt_client, device_manager, variable_manager,
+            name='condition',
+            device='test_device',
+            poll_frequency=60
+        )
+
+    @pytest.fixture
+    def device(self, mocker: MockerFixture):
+        device = mocker.MagicMock()
+
+        future = Future()
+        future.set_result(None)
+        device.turn_on.return_value = future
+        device.turn_off.return_value = future
+
+        return device
+
+    @pytest.fixture
+    def device_manager(self, device: MagicMock, mocker: MockerFixture):
+        manager = mocker.MagicMock()
+
+        manager.get_device = lambda name: device if name == 'test_device' else None
+
+        return manager
+
+    @pytest.fixture
+    def variable_manager(self, mocker: MockerFixture):
+        return mocker.Mock()

--- a/controllers/macro/tests/device/test_condition.py
+++ b/controllers/macro/tests/device/test_condition.py
@@ -6,14 +6,14 @@ from macro_controller.device.condition import ConditionDevice
 from powerpi_common.device import DeviceStatus
 from powerpi_common_test.device import DeviceTestBaseNew
 from powerpi_common_test.device.mixin import (
-    DeviceOrchestratorMixinTestBaseNew, PollableMixingTestBaseNew)
+    DeviceOrchestratorMixinTestBaseNew, PollableMixinTestBaseNew)
 from pytest_mock import MockerFixture
 
 
 class TestCondition(
     DeviceTestBaseNew,
     DeviceOrchestratorMixinTestBaseNew,
-    PollableMixingTestBaseNew
+    PollableMixinTestBaseNew
 ):
 
     @pytest.mark.asyncio

--- a/controllers/macro/tests/device/test_delay.py
+++ b/controllers/macro/tests/device/test_delay.py
@@ -1,12 +1,19 @@
-from pytest_mock import MockerFixture
-
+import pytest
 from macro_controller.device import DelayDevice
-from powerpi_common_test.device import DeviceTestBase
+from powerpi_common_test.device import DeviceTestBaseNew
 
 
-class TestDelayDevice(DeviceTestBase):
-    def get_subject(self, _: MockerFixture):
+class TestDelayDevice(DeviceTestBaseNew):
+    @pytest.fixture
+    def subject(
+        self,
+        powerpi_config,
+        powerpi_logger,
+        powerpi_mqtt_client
+    ):
         return DelayDevice(
-            self.config, self.logger, self.mqtt_client, 0.1, 0.1,
+            powerpi_config, powerpi_logger, powerpi_mqtt_client,
+            start=0.1,
+            end=0.1,
             name='delay'
         )

--- a/controllers/macro/tests/device/test_log.py
+++ b/controllers/macro/tests/device/test_log.py
@@ -1,14 +1,18 @@
-from pytest_mock import MockerFixture
-
+import pytest
 from macro_controller.device import LogDevice
-from powerpi_common_test.device import DeviceTestBase
+from powerpi_common_test.device import DeviceTestBaseNew
 
 
-class TestLogDevice(DeviceTestBase):
-    def get_subject(self, _: MockerFixture):
-        self.message = 'test message'
-
+class TestLogDevice(DeviceTestBaseNew):
+    @pytest.fixture
+    def subject(
+        self,
+        powerpi_config,
+        powerpi_logger,
+        powerpi_mqtt_client
+    ):
         return LogDevice(
-            self.config, self.logger, self.mqtt_client, self.message,
-            name='log'
+            powerpi_config, powerpi_logger, powerpi_mqtt_client,
+            name='log',
+            message='test message'
         )

--- a/controllers/macro/tests/device/test_mutex.py
+++ b/controllers/macro/tests/device/test_mutex.py
@@ -6,14 +6,14 @@ import pytest
 from macro_controller.device import MutexDevice
 from powerpi_common_test.device import DeviceTestBaseNew
 from powerpi_common_test.device.mixin import (
-    DeviceOrchestratorMixinTestBaseNew, PollableMixingTestBaseNew)
+    DeviceOrchestratorMixinTestBaseNew, PollableMixinTestBaseNew)
 from pytest_mock import MockerFixture
 
 
 class TestMutexDevice(
     DeviceTestBaseNew,
     DeviceOrchestratorMixinTestBaseNew,
-    PollableMixingTestBaseNew
+    PollableMixinTestBaseNew
 ):
     @pytest.mark.asyncio
     async def test_all_on(self, subject: MutexDevice, devices: List[MagicMock]):

--- a/controllers/macro/tests/device/test_mutex.py
+++ b/controllers/macro/tests/device/test_mutex.py
@@ -1,68 +1,41 @@
 from asyncio import Future
 from typing import List, Tuple
-from unittest.mock import PropertyMock
+from unittest.mock import MagicMock, PropertyMock
 
 import pytest
-
+from macro_controller.device import MutexDevice
+from powerpi_common_test.device import DeviceTestBaseNew
+from powerpi_common_test.device.mixin import (
+    DeviceOrchestratorMixinTestBaseNew, PollableMixingTestBaseNew)
 from pytest_mock import MockerFixture
 
-from macro_controller.device import MutexDevice
-from powerpi_common_test.device import DeviceTestBase
-from powerpi_common_test.device.mixin import DeviceOrchestratorMixinTestBase, PollableMixinTestBase
 
-
-class TestMutexDevice(DeviceTestBase, DeviceOrchestratorMixinTestBase, PollableMixinTestBase):
-    def get_subject(self, mocker: MockerFixture):
-        self.device_manager = mocker.Mock()
-
-        self.devices = [mocker.Mock() for _ in range(4)]
-
-        future = Future()
-        future.set_result(None)
-        for method in ['turn_on', 'turn_off']:
-            for device in self.devices:
-                mocker.patch.object(
-                    device,
-                    method,
-                    return_value=future
-                )
-
-        def get_device(name: str):
-            i = int(name)
-            return self.devices[i]
-
-        self.device_manager.get_device = get_device
-
-        return MutexDevice(
-            self.config, self.logger, self.mqtt_client, self.device_manager,
-            off_devices=[0, 1],
-            on_devices=[2, 3],
-            name='mutex',
-            poll_frequency=60
-        )
-
-    async def test_all_on(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
+class TestMutexDevice(
+    DeviceTestBaseNew,
+    DeviceOrchestratorMixinTestBaseNew,
+    PollableMixingTestBaseNew
+):
+    @pytest.mark.asyncio
+    async def test_all_on(self, subject: MutexDevice, devices: List[MagicMock]):
         await subject.turn_on()
 
-        self.devices[0].turn_off.assert_called_once()
-        self.devices[1].turn_off.assert_called_once()
+        devices[0].turn_off.assert_called_once()
+        devices[1].turn_off.assert_called_once()
 
-        self.devices[2].turn_on.assert_called_once()
-        self.devices[3].turn_on.assert_called_once()
+        devices[2].turn_on.assert_called_once()
+        devices[3].turn_on.assert_called_once()
 
-    async def test_all_off(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
+    @pytest.mark.asyncio
+    async def test_all_off(self, subject: MutexDevice, devices: List[MagicMock]):
         await subject.turn_off()
 
-        self.devices[0].turn_off.assert_called_once()
-        self.devices[1].turn_off.assert_called_once()
+        devices[0].turn_off.assert_called_once()
+        devices[1].turn_off.assert_called_once()
 
-        self.devices[2].turn_off.assert_called_once()
-        self.devices[3].turn_off.assert_called_once()
+        devices[2].turn_off.assert_called_once()
+        devices[3].turn_off.assert_called_once()
 
+    @pytest.mark.asyncio
     @pytest.mark.parametrize('states', [
         ('unknown', 'on', 'off', ['unknown', 'on'], ['unknown', 'unknown']),
         ('unknown', 'off', 'on', ['unknown', 'off'], ['unknown', 'unknown']),
@@ -77,30 +50,73 @@ class TestMutexDevice(DeviceTestBase, DeviceOrchestratorMixinTestBase, PollableM
     ])
     async def test_on_referenced_device_status(
         self,
-        mocker: MockerFixture,
+        subject: MutexDevice,
+        devices: List[MagicMock],
         states: Tuple[str, str, str, List[str]]
     ):
         (initial_state, on_update_state, off_update_state,
          expected_on_states, expected_off_states) = states
 
-        subject = self.create_subject(mocker)
-
         assert subject.state == 'unknown'
 
         # initialise the devices
-        for device in self.devices:
+        for device in devices:
             type(device).state = PropertyMock(return_value=initial_state)
 
-        for device, expected in zip([self.devices[0], self.devices[1]], expected_off_states):
+        for device, expected in zip([devices[0], devices[1]], expected_off_states):
             type(device).state = PropertyMock(return_value=off_update_state)
             await subject.on_referenced_device_status(device.name, off_update_state)
 
             assert subject.state == expected
 
-        for device, expected in zip([self.devices[2], self.devices[3]], expected_on_states):
+        for device, expected in zip([devices[2], devices[3]], expected_on_states):
             type(device).state = PropertyMock(return_value=on_update_state)
             await subject.on_referenced_device_status(device.name, on_update_state)
 
             assert subject.state == expected
 
         assert subject.state == on_update_state
+
+    @pytest.fixture
+    def subject(
+        self,
+        powerpi_config,
+        powerpi_logger,
+        powerpi_mqtt_client,
+        device_manager
+    ):
+        return MutexDevice(
+            powerpi_config, powerpi_logger, powerpi_mqtt_client, device_manager,
+            off_devices=[0, 1],
+            on_devices=[2, 3],
+            name='mutex',
+            poll_frequency=60
+        )
+
+    @pytest.fixture
+    def devices(self, mocker: MockerFixture):
+        devices = [mocker.MagicMock() for _ in range(4)]
+
+        future = Future()
+        future.set_result(True)
+        for method in ['turn_on', 'turn_off']:
+            for device in devices:
+                mocker.patch.object(
+                    device,
+                    method,
+                    return_value=future
+                )
+
+        return devices
+
+    @pytest.fixture
+    def device_manager(self, devices: List[MagicMock], mocker: MockerFixture):
+        manager = mocker.MagicMock()
+
+        def get_device(name: str):
+            i = int(name)
+            return devices[i]
+
+        manager.get_device = get_device
+
+        return manager

--- a/controllers/macro/tests/device/test_variable.py
+++ b/controllers/macro/tests/device/test_variable.py
@@ -1,14 +1,17 @@
-from pytest_mock import MockerFixture
-
+import pytest
 from macro_controller.device import VariableDevice
-from powerpi_common_test.device import DeviceTestBase
+from powerpi_common_test.device import DeviceTestBaseNew
 
 
-class TestVariableDevice(DeviceTestBase):
-    def get_subject(self, _: MockerFixture):
-        self.message = 'test message'
-
+class TestVariableDevice(DeviceTestBaseNew):
+    @pytest.fixture
+    def subject(
+        self,
+        powerpi_config,
+        powerpi_logger,
+        powerpi_mqtt_client
+    ):
         return VariableDevice(
-            self.config, self.logger, self.mqtt_client,
+            powerpi_config, powerpi_logger, powerpi_mqtt_client,
             name='variable'
         )

--- a/controllers/zigbee/tests/device/test_zigbee_light.py
+++ b/controllers/zigbee/tests/device/test_zigbee_light.py
@@ -6,7 +6,7 @@ import pytest
 from powerpi_common.device.mixin import AdditionalState
 from powerpi_common_test.device import AdditionalStateDeviceTestBaseNew
 from powerpi_common_test.device.mixin import (InitialisableMixinTestBaseNew,
-                                              PollableMixingTestBaseNew)
+                                              PollableMixinTestBaseNew)
 from pytest_mock import MockerFixture
 from zigbee_controller.device.zigbee_light import ZigbeeLight
 from zigpy.exceptions import DeliveryError
@@ -17,7 +17,7 @@ from zigpy.zcl.foundation import Status
 class TestZigbeeeLight(
     AdditionalStateDeviceTestBaseNew,
     InitialisableMixinTestBaseNew,
-    PollableMixingTestBaseNew
+    PollableMixinTestBaseNew
 ):
     def test_duration(self, subject: ZigbeeLight):
         assert subject.duration == 13

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -69,7 +69,7 @@ services:
             - deep-thought
 
     macro-controller:
-        image: twilkin/powerpi-macro-controller:1.1.12
+        image: twilkin/powerpi-macro-controller:1.1.13
         networks:
             - powerpi
         deploy:


### PR DESCRIPTION
- Resolves #265:
  - Add `CapabilityMixin` to `DeviceOrchestratorMixin` and capture referenced device capabilities into own capabilities.
  - Broadcast capability when all referenced devices have broadcast their own.
  - Bump `macro-controller` so devices can use new code.
  - No need to bump others as their referenced devices will need broadcast capabilities.
- #237 
  - Upgraded `macro-controller` tests.
  - Changed affected tests in `powerpi-common`: