### PR TITLE
#286 Add support for hiding message queue when not using sensors

### DIFF
--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: powerpi
 description: A Helm chart for deploying the PowerPi home automation stack
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 0.1.1
 dependencies:
   # services

--- a/kubernetes/charts/mosquitto/Chart.yaml
+++ b/kubernetes/charts/mosquitto/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: mosquitto
 description: A Helm chart for deploying the mosquitto message queue for PowerPi
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 2.0.15

--- a/kubernetes/charts/mosquitto/templates/config-map.yaml
+++ b/kubernetes/charts/mosquitto/templates/config-map.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: mosquitto-config
-  {{- include "powerpi.labels" . }}
+  {{- include "powerpi.labels.no-version" . }}
 data:
   mosquitto.conf: |-
     {{- .Files.Get "mosquitto.conf" | indent 4 }}

--- a/kubernetes/charts/mosquitto/templates/service.yaml
+++ b/kubernetes/charts/mosquitto/templates/service.yaml
@@ -1,6 +1,9 @@
+{{- $type := ternary "LoadBalancer" "NodePort" .Values.global.useSensors }}
+
 {{- $data := dict
-  "Type" "LoadBalancer"
+  "Type" $type
   "PortName" "mqtt"
   "Port" 1883
 }}
+
 {{- include "powerpi.service" (merge (dict "Params" $data) . )}}

--- a/kubernetes/charts/smarter-device-manager/templates/config-map.yaml
+++ b/kubernetes/charts/smarter-device-manager/templates/config-map.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: smarter-device-manager-config
-  {{- include "powerpi.labels" . }}
+  {{- include "powerpi.labels.no-version" . }}
 data:
   device-config.yaml: |-
 {{ .Files.Get "device-config.yaml" | indent 4 }}

--- a/kubernetes/charts/ui/templates/config-map.yaml
+++ b/kubernetes/charts/ui/templates/config-map.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: nginx-config
-  {{- include "powerpi.labels" . }}
+  {{- include "powerpi.labels.no-version" . }}
 data:
   nginx.conf: |-
 {{ .Files.Get "nginx.conf" | indent 4 }}

--- a/kubernetes/templates/_deployment.tpl
+++ b/kubernetes/templates/_deployment.tpl
@@ -19,7 +19,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-    {{- include "powerpi.selector.no-version" . | indent 4 }}
+    {{- include "powerpi.selector" . | indent 4 }}
 
   template:
     metadata:

--- a/kubernetes/templates/_deployment.tpl
+++ b/kubernetes/templates/_deployment.tpl
@@ -19,11 +19,11 @@ metadata:
 spec:
   selector:
     matchLabels:
-    {{- include "powerpi.selector" . | indent 4 }}
+    {{- include "powerpi.selector.no-version" . | indent 4 }}
 
   template:
     metadata:
-    {{- include "powerpi.labels" . | indent 4 }}
+    {{- include "powerpi.labels.no-version" . | indent 4 }}
 
       {{- if or $hasAnnotations $config $hasConfig }}
       annotations:

--- a/kubernetes/templates/_labels.tpl
+++ b/kubernetes/templates/_labels.tpl
@@ -1,22 +1,18 @@
-{{- define "powerpi.selector.no-version" }}
+{{- define "powerpi.selector" }}
   app.kubernetes.io/name: {{ .Chart.Name }}
   app.kubernetes.io/component: {{ .Values.component }}
   app.kubernetes.io/part-of: powerpi
   app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
-{{- define "powerpi.selector" }}
-  {{- include "powerpi.selector.no-version" . }}
-  app.kubernetes.io/version: {{ .Chart.AppVersion }}
-  helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-{{- end }}
-
-{{- define "powerpi.labels" }}
+{{- define "powerpi.labels.no-version" }}
   labels:
     {{- include "powerpi.selector" . | indent 2 }}
 {{- end }}
 
-{{- define "powerpi.labels.no-version" }}
-  labels:
-    {{- include "powerpi.selector.no-version" . | indent 2 }}
+
+{{- define "powerpi.labels" }}
+  {{- include "powerpi.labels.no-version" . }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 {{- end }}

--- a/kubernetes/templates/_labels.tpl
+++ b/kubernetes/templates/_labels.tpl
@@ -1,13 +1,22 @@
-{{- define "powerpi.selector" }}
+{{- define "powerpi.selector.no-version" }}
   app.kubernetes.io/name: {{ .Chart.Name }}
-  app.kubernetes.io/version: {{ .Chart.AppVersion }}
   app.kubernetes.io/component: {{ .Values.component }}
   app.kubernetes.io/part-of: powerpi
   app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "powerpi.selector" }}
+  {{- include "powerpi.selector.no-version" . }}
+  app.kubernetes.io/version: {{ .Chart.AppVersion }}
   helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 {{- end }}
 
 {{- define "powerpi.labels" }}
   labels:
     {{- include "powerpi.selector" . | indent 2 }}
+{{- end }}
+
+{{- define "powerpi.labels.no-version" }}
+  labels:
+    {{- include "powerpi.selector.no-version" . | indent 2 }}
 {{- end }}

--- a/kubernetes/templates/config-map.yaml
+++ b/kubernetes/templates/config-map.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config
-  {{- include "powerpi.labels" . }}
+  {{- include "powerpi.labels.no-version" . }}
 data:
 {{ (.Files.Glob "config/*.json").AsConfig | indent 2 }}
 {{- end }}

--- a/kubernetes/templates/issuer.yaml
+++ b/kubernetes/templates/issuer.yaml
@@ -13,7 +13,7 @@ spec:
     {{- end }}
     email: {{ .Values.global.certificateEmail }}
     privateKeySecretRef:
-      name: letsencrypt
+      name: letsencrypt-private-key
     solvers:
     - http01:
         ingress:

--- a/kubernetes/values.yaml
+++ b/kubernetes/values.yaml
@@ -17,6 +17,9 @@ global:
   # whether PowerPi is deployed in a kubernetes cluster (true) or on a single node (false)
   useCluster: false
 
+  # whether to allow access to the message queue from outside of kubernetes (to support sensors publishing events)
+  useSensors: false
+
   # whether to use FreeDNS or not
   freeDNS: false
 


### PR DESCRIPTION
- Resolves #286 by adding `useSensors` variable which will use a `LoadBalancer` for the message queue service, otherwise hiding it inside the cluster.
- Fixes deployment issues when the following change:
  - The versions in the config map forcing a reload every time the version changes, even if the config does not.
  - The versions were in the selector which couldn't be updated for stateful sets.