### PR TITLE
#111 Add health-checks for UI, deep-thought, database and mosquitto

### DIFF
--- a/common/node/common/package.json
+++ b/common/node/common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@powerpi/common",
-    "version": "0.0.11",
+    "version": "0.0.12",
     "description": "PowerPi Common Typescript library",
     "private": true,
     "license": "GPL-3.0-only",

--- a/common/node/common/src/services/mqtt.ts
+++ b/common/node/common/src/services/mqtt.ts
@@ -24,6 +24,10 @@ export class MqttService {
         this.consumers = {};
     }
 
+    public get connected() {
+        return this.client?.connected ?? false;
+    }
+
     private get clientId() {
         const prefix = this.config.service.indexOf("/")
             ? this.config.service.split("/").slice(-1)[0]

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: powerpi
 description: A Helm chart for deploying the PowerPi home automation stack
 type: application
-version: 0.1.4
-appVersion: 0.1.2
+version: 0.1.5
+appVersion: 0.1.3
 dependencies:
   # services
   - name: babel-fish

--- a/kubernetes/charts/database/Chart.yaml
+++ b/kubernetes/charts/database/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: database
 description: A Helm chart for deploying the Postgres database for PowerPi
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 15.2-alpine3.17

--- a/kubernetes/charts/database/templates/stateful-set.yaml
+++ b/kubernetes/charts/database/templates/stateful-set.yaml
@@ -40,6 +40,11 @@
       )
     )
   )
+  "Probe" (dict
+    "Tcp" true
+    "ReadinessInitialDelay" 25
+    "LivenessInitialDelay" 50
+  )
 }}
 
 {{- include "powerpi.deployment" (merge (dict "Params" $data) . )}}

--- a/kubernetes/charts/deep-thought/Chart.yaml
+++ b/kubernetes/charts/deep-thought/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: deep-thought
 description: A Helm chart for the PowerPi deep-thought API service
 type: application
-version: 0.1.0
-appVersion: 0.5.21
+version: 0.1.1
+appVersion: 0.6.0

--- a/kubernetes/charts/deep-thought/templates/deployment.yaml
+++ b/kubernetes/charts/deep-thought/templates/deployment.yaml
@@ -97,5 +97,10 @@
     )
   )
   "Secret" $secrets
+  "Probe" (dict
+    "Http" "/api/health"
+    "ReadinessInitialDelay" 10
+    "LivenessInitialDelay" 20
+  )
 }}
-{{- include "powerpi.deployment" (merge (dict "Params" $data) . )}}
+{{- include "powerpi.deployment" (merge (dict "Params" $data) . ) }}

--- a/kubernetes/charts/mosquitto/Chart.yaml
+++ b/kubernetes/charts/mosquitto/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: mosquitto
 description: A Helm chart for deploying the mosquitto message queue for PowerPi
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 2.0.15

--- a/kubernetes/charts/mosquitto/templates/stateful-set.yaml
+++ b/kubernetes/charts/mosquitto/templates/stateful-set.yaml
@@ -26,6 +26,11 @@
       "SubPath" "mosquitto.conf"
     )
   )
+  "Probe" (dict
+    "Tcp" true
+    "ReadinessInitialDelay" 5
+    "LivenessInitialDelay" 10
+  )
 }}
 
 {{- include "powerpi.deployment" (merge (dict "Params" $data) . )}}

--- a/kubernetes/charts/ui/Chart.yaml
+++ b/kubernetes/charts/ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ui
 description: A Helm chart for the PowerPi UI service
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 1.4.0

--- a/kubernetes/charts/ui/nginx.conf
+++ b/kubernetes/charts/ui/nginx.conf
@@ -6,6 +6,11 @@ server {
         try_files $uri /index.html;
     }
 
+    location /health {
+        return 200 'OK';
+        add_header Content-Type text/plain;
+    }
+
     location = /favicon.ico { 
         log_not_found off; 
         access_log off; 

--- a/kubernetes/charts/ui/templates/deployment.yaml
+++ b/kubernetes/charts/ui/templates/deployment.yaml
@@ -13,7 +13,7 @@
     )
   )
   "Probe" (dict
-    "Http" "/LICENSE"
+    "Http" "/health"
     "ReadinessInitialDelay" 5
     "LivenessInitialDelay" 10
   )

--- a/kubernetes/charts/ui/templates/deployment.yaml
+++ b/kubernetes/charts/ui/templates/deployment.yaml
@@ -12,5 +12,10 @@
       "SubPath" "nginx.conf"
     )
   )
+  "Probe" (dict
+    "Http" "/LICENSE.txt"
+    "ReadinessInitialDelay" 5
+    "LivenessInitialDelay" 10
+  )
 }}
 {{- include "powerpi.deployment" (merge (dict "Params" $data) . )}}

--- a/kubernetes/charts/ui/templates/deployment.yaml
+++ b/kubernetes/charts/ui/templates/deployment.yaml
@@ -13,7 +13,7 @@
     )
   )
   "Probe" (dict
-    "Http" "/LICENSE.txt"
+    "Http" "/LICENSE"
     "ReadinessInitialDelay" 5
     "LivenessInitialDelay" 10
   )

--- a/kubernetes/templates/_template.tpl
+++ b/kubernetes/templates/_template.tpl
@@ -195,6 +195,24 @@ template:
 
       {{- end }}
     
+    {{- if eq (empty .Params.Probe) false }}
+    readinessProbe:
+      {{- if eq (empty .Params.Probe.Http) false }}
+      httpGet:
+        path: {{ .Params.Probe.Http }}
+        port: {{ (index .Params.Ports 0).Name }}
+      initialDelaySeconds: {{ .Params.Probe.ReadinessInitialDelay }}
+      {{- end }}
+    
+    livenessProbe:
+      {{- if eq (empty .Params.Probe.Http) false }}
+      httpGet:
+        path: {{ .Params.Probe.Http }}
+        port: {{ (index .Params.Ports 0).Name }}
+      initialDelaySeconds: {{ .Params.Probe.LivenessInitialDelay }}
+      {{- end }}
+    {{- end }}
+
     restartPolicy: {{ .Params.RestartPolicy | default "Always" }}
 
     {{- if or (eq (empty .Params.Volumes) false) $config $hasVolumeClaim $hasConfig $hasSecret }}

--- a/kubernetes/templates/_template.tpl
+++ b/kubernetes/templates/_template.tpl
@@ -195,23 +195,23 @@ template:
 
       {{- end }}
     
-    {{- if eq (empty .Params.Probe) false }}
-    readinessProbe:
-      {{- if eq (empty .Params.Probe.Http) false }}
-      httpGet:
-        path: {{ .Params.Probe.Http }}
-        port: {{ (index .Params.Ports 0).Name }}
-      initialDelaySeconds: {{ .Params.Probe.ReadinessInitialDelay }}
+      {{- if eq (empty .Params.Probe) false }}
+      readinessProbe:
+        {{- if eq (empty .Params.Probe.Http) false }}
+        httpGet:
+          path: {{ .Params.Probe.Http }}
+          port: {{ (first .Params.Ports).Name }}
+        initialDelaySeconds: {{ .Params.Probe.ReadinessInitialDelay }}
+        {{- end }}
+      
+      livenessProbe:
+        {{- if eq (empty .Params.Probe.Http) false }}
+        httpGet:
+          path: {{ .Params.Probe.Http }}
+          port: {{ (first .Params.Ports).Name }}
+        initialDelaySeconds: {{ .Params.Probe.LivenessInitialDelay }}
+        {{- end }}
       {{- end }}
-    
-    livenessProbe:
-      {{- if eq (empty .Params.Probe.Http) false }}
-      httpGet:
-        path: {{ .Params.Probe.Http }}
-        port: {{ (index .Params.Ports 0).Name }}
-      initialDelaySeconds: {{ .Params.Probe.LivenessInitialDelay }}
-      {{- end }}
-    {{- end }}
 
     restartPolicy: {{ .Params.RestartPolicy | default "Always" }}
 

--- a/kubernetes/templates/_template.tpl
+++ b/kubernetes/templates/_template.tpl
@@ -156,6 +156,32 @@ template:
           {{ $element.Name }}: {{ $element.Value }}
           {{- end }}
 
+      {{- if eq (empty .Params.Probe) false }}
+      readinessProbe:
+        {{- if eq (empty .Params.Probe.Http) false }}
+        httpGet:
+          path: {{ .Params.Probe.Http }}
+          port: {{ (first .Params.Ports).Name }}
+        {{- end }}
+        {{- if .Params.Probe.Tcp }}
+        tcpSocket:
+          port: {{ (first .Params.Ports).Name }}
+        {{- end }}
+        initialDelaySeconds: {{ .Params.Probe.ReadinessInitialDelay }}
+      
+      livenessProbe:
+        {{- if eq (empty .Params.Probe.Http) false }}
+        httpGet:
+          path: {{ .Params.Probe.Http }}
+          port: {{ (first .Params.Ports).Name }}
+        {{- end }}
+        {{- if .Params.Probe.Tcp }}
+        tcpSocket:
+          port: {{ (first .Params.Ports).Name }}
+        {{- end }}
+        initialDelaySeconds: {{ .Params.Probe.LivenessInitialDelay }}
+      {{- end }}
+
       {{- if or (eq (empty .Params.Volumes) false) $config $hasVolumeClaim $hasConfig $hasSecret }}
       volumeMounts:
       {{- range $element := .Params.Volumes }}
@@ -193,24 +219,6 @@ template:
         readOnly: true
       {{- end }}
 
-      {{- end }}
-    
-      {{- if eq (empty .Params.Probe) false }}
-      readinessProbe:
-        {{- if eq (empty .Params.Probe.Http) false }}
-        httpGet:
-          path: {{ .Params.Probe.Http }}
-          port: {{ (first .Params.Ports).Name }}
-        initialDelaySeconds: {{ .Params.Probe.ReadinessInitialDelay }}
-        {{- end }}
-      
-      livenessProbe:
-        {{- if eq (empty .Params.Probe.Http) false }}
-        httpGet:
-          path: {{ .Params.Probe.Http }}
-          port: {{ (first .Params.Ports).Name }}
-        initialDelaySeconds: {{ .Params.Probe.LivenessInitialDelay }}
-        {{- end }}
       {{- end }}
 
     restartPolicy: {{ .Params.RestartPolicy | default "Always" }}

--- a/services/babel-fish/package.json
+++ b/services/babel-fish/package.json
@@ -27,7 +27,7 @@
         "@jovotech/platform-core": "^4.2.22",
         "@jovotech/server-express": "^4.0.0",
         "@powerpi/api": "^0.0.17",
-        "@powerpi/common": "^0.0.11",
+        "@powerpi/common": "^0.0.12",
         "source-map-support": "^0.5.19"
     },
     "devDependencies": {

--- a/services/clacks-config/package.json
+++ b/services/clacks-config/package.json
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@octokit/rest": "^18.12.0",
-        "@powerpi/common": "^0.0.11",
+        "@powerpi/common": "^0.0.12",
         "ajv": "^8.11.0",
         "ajv-formats": "2.1.1",
         "typedi": "^0.10.0",

--- a/services/deep-thought/package.json
+++ b/services/deep-thought/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "@powerpi/api": "^0.0.17",
-        "@powerpi/common": "^0.0.11",
+        "@powerpi/common": "^0.0.12",
         "@tsed/common": "^6.115.0",
         "@tsed/core": "^6.115.0",
         "@tsed/di": "^6.115.0",

--- a/services/deep-thought/package.json
+++ b/services/deep-thought/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@powerpi/deep-thought",
-    "version": "0.5.21",
+    "version": "0.6.0",
     "description": "PowerPi API",
     "private": true,
     "license": "GPL-3.0-only",

--- a/services/deep-thought/src/controllers/HealthController.ts
+++ b/services/deep-thought/src/controllers/HealthController.ts
@@ -18,10 +18,7 @@ export default class HealthController {
     async getHealth(@Res() response: Response) {
         response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
 
-        const status: { database?: boolean; mqtt: boolean } = {
-            database: undefined,
-            mqtt: true,
-        };
+        const status: { database?: boolean; mqtt?: boolean } = {};
 
         // check we can access the message queue
         status.mqtt = this.mqttService.connected;

--- a/services/deep-thought/src/controllers/HealthController.ts
+++ b/services/deep-thought/src/controllers/HealthController.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from "@tsed/common";
+
+@Controller("/health")
+export default class HealthController {
+    @Get("/")
+    getHealth() {
+        return true;
+    }
+}

--- a/services/deep-thought/src/controllers/HealthController.ts
+++ b/services/deep-thought/src/controllers/HealthController.ts
@@ -1,9 +1,43 @@
-import { Controller, Get } from "@tsed/common";
+import { Controller, Get, Res } from "@tsed/common";
+import { Response } from "express";
+import HttpStatus from "http-status-codes";
+import ConfigService from "../services/config";
+import DatabaseService from "../services/db";
+import MqttService from "../services/mqtt";
 
 @Controller("/health")
 export default class HealthController {
+    constructor(
+        private readonly configService: ConfigService,
+        private readonly dbService: DatabaseService,
+        private readonly mqttService: MqttService
+    ) {}
+
     @Get("/")
-    getHealth() {
-        return true;
+    async getHealth(@Res() response: Response) {
+        response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+
+        const status: { database?: boolean; mqtt: boolean } = {
+            database: undefined,
+            mqtt: true,
+        };
+
+        // check we can access the message queue
+        status.mqtt = this.mqttService.connected;
+
+        // only check the db connection if we have persistence
+        if (await this.configService.hasPersistence()) {
+            const result = await this.dbService.isAlive();
+
+            status.database = (result?.rowCount ?? 0) < 1;
+        }
+
+        response.send(status);
+
+        if (status.database === false || !status.mqtt) {
+            response.sendStatus(HttpStatus.INTERNAL_SERVER_ERROR);
+        } else {
+            response.sendStatus(HttpStatus.OK);
+        }
     }
 }

--- a/services/deep-thought/src/controllers/config.ts
+++ b/services/deep-thought/src/controllers/config.ts
@@ -12,16 +12,7 @@ export default class DeviceController {
         const hasDevices = this.configService.devices?.length > 0;
         const hasFloorplan = this.configService.floorplan?.floorplan !== undefined;
         const hasSensors = this.configService.sensors?.length > 0;
-
-        let hasPersistence: boolean;
-        try {
-            await this.configService.databaseURI;
-
-            // it worked so the db is configured
-            hasPersistence = true;
-        } catch {
-            hasPersistence = false;
-        }
+        const hasPersistence = await this.configService.hasPersistence();
 
         return {
             hasDevices,

--- a/services/deep-thought/src/services/config.ts
+++ b/services/deep-thought/src/services/config.ts
@@ -66,6 +66,17 @@ export default class ConfigService extends CommonConfigService {
     async getSessionSecret(): Promise<string> {
         return await this.getSecret("SESSION");
     }
+
+    async hasPersistence() {
+        try {
+            await this.databaseURI;
+
+            // it worked so the db is configured
+            return true;
+        } catch {
+            return false;
+        }
+    }
 }
 
 Container.override(CommonConfigService, ConfigService);

--- a/services/deep-thought/src/services/db.ts
+++ b/services/deep-thought/src/services/db.ts
@@ -136,6 +136,10 @@ export default class DatabaseService {
         );
     }
 
+    public async isAlive() {
+        return await this.query<{ value: number }>("SELECT 1");
+    }
+
     private async query<TResult extends QueryResultRow>(sql: string, params?: (string | Date)[]) {
         let client: PoolClient | undefined;
 

--- a/services/deep-thought/src/services/db.ts
+++ b/services/deep-thought/src/services/db.ts
@@ -137,7 +137,7 @@ export default class DatabaseService {
     }
 
     public async isAlive() {
-        return await this.query<{ value: number }>("SELECT 1");
+        return await this.query<{ value: number }>("SELECT 1 AS value");
     }
 
     private async query<TResult extends QueryResultRow>(sql: string, params?: (string | Date)[]) {

--- a/services/energy-monitor/package.json
+++ b/services/energy-monitor/package.json
@@ -19,7 +19,7 @@
         "start:prd": "node dist/src/index.js"
     },
     "dependencies": {
-        "@powerpi/common": "^0.0.11",
+        "@powerpi/common": "^0.0.12",
         "axios": "^0.27.2",
         "dateformat": "^4.6.3",
         "ts-command-line-args": "2.4.2",

--- a/services/light-fantastic/package.json
+++ b/services/light-fantastic/package.json
@@ -19,7 +19,7 @@
         "start:prd": "node dist/src/index.js"
     },
     "dependencies": {
-        "@powerpi/common": "^0.0.11",
+        "@powerpi/common": "^0.0.12",
         "luxon": "^2.5.2",
         "typedi": "^0.10.0"
     },

--- a/services/persistence/package.json
+++ b/services/persistence/package.json
@@ -19,7 +19,7 @@
         "start:prd": "node dist/src/index.js"
     },
     "dependencies": {
-        "@powerpi/common": "^0.0.11",
+        "@powerpi/common": "^0.0.12",
         "pg": "^8.7.3",
         "pg-hstore": "^2.3.4",
         "reflect-metadata": "^0.1.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1286,10 +1286,20 @@
     streamroller "^3.1.3"
     tslib "2.3.1"
 
-"@tsed/logger@>=6.2.2", "@tsed/logger@^6.0.0":
+"@tsed/logger@>=6.2.2":
   version "6.3.3"
   resolved "https://registry.yarnpkg.com/@tsed/logger/-/logger-6.3.3.tgz#2e4f43f5614866ba4e3cbd98539a677a566561a6"
   integrity sha512-L9gNYU7kJg2L3t4NdI6hW5hiPPrL9mCi74Uz+qIIif8ytd1wypRFCJC79P/0A3FDuUn3oMBWRUR+jywwvQnPcA==
+  dependencies:
+    colors "1.4.0"
+    date-format "^4.0.6"
+    semver "^7.3.5"
+    tslib "2.3.1"
+
+"@tsed/logger@^6.0.0":
+  version "6.3.4"
+  resolved "https://registry.yarnpkg.com/@tsed/logger/-/logger-6.3.4.tgz#760ae5b32da779f9e008987260bbef7113f120d1"
+  integrity sha512-oC/yARWdLIHSpXQYDUy8fIqP4rRnal6PqeysAJAfr4wSvLtClbAPawvwFzKIG3U2dvhBQHpOY1zFXLQd2lY4fA==
   dependencies:
     colors "1.4.0"
     date-format "^4.0.6"
@@ -1535,7 +1545,7 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
   integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
 
-"@types/express-serve-static-core@*", "@types/express-serve-static-core@^4.17.31":
+"@types/express-serve-static-core@*":
   version "4.17.31"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz#a1139efeab4e7323834bb0226e62ac019f474b2f"
   integrity sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==
@@ -1544,7 +1554,7 @@
     "@types/qs" "*"
     "@types/range-parser" "*"
 
-"@types/express-serve-static-core@^4.17.18":
+"@types/express-serve-static-core@^4.17.18", "@types/express-serve-static-core@^4.17.31", "@types/express-serve-static-core@^4.17.33":
   version "4.17.33"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz#de35d30a9d637dc1450ad18dd583d75d5733d543"
   integrity sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==
@@ -1554,19 +1564,19 @@
     "@types/range-parser" "*"
 
 "@types/express-session@^1.17.3":
-  version "1.17.5"
-  resolved "https://registry.yarnpkg.com/@types/express-session/-/express-session-1.17.5.tgz#13f48852b4aa60ff595835faeb4b4dda0ba0866e"
-  integrity sha512-l0DhkvNVfyUPEEis8fcwbd46VptfA/jmMwHfob2TfDMf3HyPLiB9mKD71LXhz5TMUobODXPD27zXSwtFQLHm+w==
+  version "1.17.7"
+  resolved "https://registry.yarnpkg.com/@types/express-session/-/express-session-1.17.7.tgz#ced215c1244cb594be10e39f2781ddcd650be9a6"
+  integrity sha512-L25080PBYoRLu472HY/HNCxaXY8AaGgqGC8/p/8+BYMhG0RDOLQ1wpXOpAzr4Gi5TGozTKyJv5BVODM5UNyVMw==
   dependencies:
     "@types/express" "*"
 
-"@types/express@*", "@types/express@^4.17.13":
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.15.tgz#9290e983ec8b054b65a5abccb610411953d417ff"
-  integrity sha512-Yv0k4bXGOH+8a+7bELd2PqHQsuiANB+A8a4gnQrkRWzrkKlb6KHaVvyXhqs04sVW/OWlbPyYxRgYlIXLfrufMQ==
+"@types/express@*", "@types/express@^4.17.12":
+  version "4.17.17"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.17.tgz#01d5437f6ef9cfa8668e616e13c2f2ac9a491ae4"
+  integrity sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==
   dependencies:
     "@types/body-parser" "*"
-    "@types/express-serve-static-core" "^4.17.31"
+    "@types/express-serve-static-core" "^4.17.33"
     "@types/qs" "*"
     "@types/serve-static" "*"
 
@@ -1580,10 +1590,10 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
-"@types/express@^4.17.12":
-  version "4.17.16"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.16.tgz#986caf0b4b850611254505355daa24e1b8323de8"
-  integrity sha512-LkKpqRZ7zqXJuvoELakaFYuETHjZkSol8EV6cNnyishutDBCCdv6+dsKPbKkCcIk57qRphOLY5sEgClw1bO3gA==
+"@types/express@^4.17.13":
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.15.tgz#9290e983ec8b054b65a5abccb610411953d417ff"
+  integrity sha512-Yv0k4bXGOH+8a+7bELd2PqHQsuiANB+A8a4gnQrkRWzrkKlb6KHaVvyXhqs04sVW/OWlbPyYxRgYlIXLfrufMQ==
   dependencies:
     "@types/body-parser" "*"
     "@types/express-serve-static-core" "^4.17.31"
@@ -1711,15 +1721,15 @@
   dependencies:
     "@types/express" "*"
 
-"@types/node@*", "@types/node@>=10.0.0", "@types/node@^18.6.4":
-  version "18.11.18"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.18.tgz#8dfb97f0da23c2293e554c5a50d61ef134d7697f"
-  integrity sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==
-
-"@types/node@^18.0.0":
+"@types/node@*", "@types/node@>=10.0.0", "@types/node@^18.0.0":
   version "18.15.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.15.5.tgz#3af577099a99c61479149b716183e70b5239324a"
   integrity sha512-Ark2WDjjZO7GmvsyFFf81MXuGTA/d6oP38anyxWOL6EREyBKAxKoFHwBhaZxCfLRLpO8JgVXwqOwSwa7jRcjew==
+
+"@types/node@^18.6.4":
+  version "18.11.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.18.tgz#8dfb97f0da23c2293e554c5a50d61ef134d7697f"
+  integrity sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==
 
 "@types/node@^18.7.2":
   version "18.14.1"
@@ -1945,7 +1955,15 @@
   dependencies:
     "@types/express" "*"
 
-"@types/serve-static@*", "@types/serve-static@^1.13.10":
+"@types/serve-static@*":
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.15.1.tgz#86b1753f0be4f9a1bee68d459fcda5be4ea52b5d"
+  integrity sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==
+  dependencies:
+    "@types/mime" "*"
+    "@types/node" "*"
+
+"@types/serve-static@^1.13.10":
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.15.0.tgz#c7930ff61afb334e121a9da780aac0d9b8f34155"
   integrity sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==
@@ -2732,7 +2750,7 @@ bluebird@^3.7.2:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
-body-parser@1.20.1, body-parser@^1.19.0:
+body-parser@1.20.1:
   version "1.20.1"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.1.tgz#b1812a8912c195cd371a3ee5e66faa2338a5c668"
   integrity sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==
@@ -2747,6 +2765,24 @@ body-parser@1.20.1, body-parser@^1.19.0:
     on-finished "2.4.1"
     qs "6.11.0"
     raw-body "2.5.1"
+    type-is "~1.6.18"
+    unpipe "1.0.0"
+
+body-parser@^1.19.0:
+  version "1.20.2"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.2.tgz#6feb0e21c4724d06de7ff38da36dad4f57a747fd"
+  integrity sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==
+  dependencies:
+    bytes "3.1.2"
+    content-type "~1.0.5"
+    debug "2.6.9"
+    depd "2.0.0"
+    destroy "1.2.0"
+    http-errors "2.0.0"
+    iconv-lite "0.4.24"
+    on-finished "2.4.1"
+    qs "6.11.0"
+    raw-body "2.5.2"
     type-is "~1.6.18"
     unpipe "1.0.0"
 
@@ -3292,10 +3328,10 @@ content-disposition@0.5.4:
   dependencies:
     safe-buffer "5.2.1"
 
-content-type@~1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
-  integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
+content-type@~1.0.4, content-type@~1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
+  integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
 
 convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.9.0"
@@ -3731,15 +3767,26 @@ engine.io-client@~6.2.3:
     ws "~8.2.3"
     xmlhttprequest-ssl "~2.0.0"
 
+engine.io-client@~6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-6.4.0.tgz#88cd3082609ca86d7d3c12f0e746d12db4f47c91"
+  integrity sha512-GyKPDyoEha+XZ7iEqam49vz6auPnNJ9ZBfy89f+rMMas8AuiMWOZ9PVzu8xb9ZC6rafUqiGHSCfu22ih66E+1g==
+  dependencies:
+    "@socket.io/component-emitter" "~3.1.0"
+    debug "~4.3.1"
+    engine.io-parser "~5.0.3"
+    ws "~8.11.0"
+    xmlhttprequest-ssl "~2.0.0"
+
 engine.io-parser@~5.0.3:
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-5.0.6.tgz#7811244af173e157295dec9b2718dfe42a64ef45"
   integrity sha512-tjuoZDMAdEhVnSFleYPCtdL2GXwVTGtNjoeJd9IhIG3C1xs9uwxqRNEu5WpnDZCaozwVlK/nuQhpodhXSIMaxw==
 
-engine.io@~6.2.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-6.2.1.tgz#e3f7826ebc4140db9bbaa9021ad6b1efb175878f"
-  integrity sha512-ECceEFcAaNRybd3lsGQKas3ZlMVjN3cyWwMP25D2i0zWfyiytVbTpRPa34qrr+FHddtpBVOmq4H/DCv1O0lZRA==
+engine.io@~6.4.1:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-6.4.1.tgz#8056b4526a88e779f9c280d820422d4e3eeaaae5"
+  integrity sha512-JFYQurD/nbsA5BSPmbaOSLa3tSVj8L6o4srSwXXY3NqE+gGUNmmPTbhn8tjzcCtSqhFgIeqef81ngny8JM25hw==
   dependencies:
     "@types/cookie" "^0.4.1"
     "@types/cors" "^2.8.12"
@@ -3750,7 +3797,7 @@ engine.io@~6.2.1:
     cors "~2.8.5"
     debug "~4.3.1"
     engine.io-parser "~5.0.3"
-    ws "~8.2.3"
+    ws "~8.11.0"
 
 enhanced-resolve@^5.0.0, enhanced-resolve@^5.10.0:
   version "5.12.0"
@@ -6779,17 +6826,17 @@ pg-int8@1.0.1:
   resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
   integrity sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
 
-pg-pool@^3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-3.5.2.tgz#ed1bed1fb8d79f1c6fd5fb1c99e990fbf9ddf178"
-  integrity sha512-His3Fh17Z4eg7oANLob6ZvH8xIVen3phEZh2QuyrIl4dQSDVEabNducv6ysROKpDNPSD+12tONZVWfSgMvDD9w==
+pg-pool@^3.5.2, pg-pool@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-3.6.0.tgz#3190df3e4747a0d23e5e9e8045bcd99bda0a712e"
+  integrity sha512-clFRf2ksqd+F497kWFyM21tMjeikn60oGDmqMT8UBrynEwVEX/5R5xd2sdvdo1cZCFlguORNpVuqxIj+aK4cfQ==
 
 pg-protocol@*:
   version "1.5.0"
   resolved "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz"
   integrity sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ==
 
-pg-protocol@^1.5.0, pg-protocol@^1.6.0:
+pg-protocol@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.6.0.tgz#4c91613c0315349363af2084608db843502f8833"
   integrity sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q==
@@ -6806,15 +6853,15 @@ pg-types@^2.1.0, pg-types@^2.2.0:
     postgres-interval "^1.1.0"
 
 pg@^8.6.0:
-  version "8.8.0"
-  resolved "https://registry.yarnpkg.com/pg/-/pg-8.8.0.tgz#a77f41f9d9ede7009abfca54667c775a240da686"
-  integrity sha512-UXYN0ziKj+AeNNP7VDMwrehpACThH7LUl/p8TDFpEUuSejCUIwGSfxpHsPvtM6/WXFy6SU4E5RG4IJV/TZAGjw==
+  version "8.10.0"
+  resolved "https://registry.yarnpkg.com/pg/-/pg-8.10.0.tgz#5b8379c9b4a36451d110fc8cd98fc325fe62ad24"
+  integrity sha512-ke7o7qSTMb47iwzOSaZMfeR7xToFdkE71ifIipOAAaLIM0DYzfOAXlgFFmYUIE2BcJtvnVlGCID84ZzCegE8CQ==
   dependencies:
     buffer-writer "2.0.0"
     packet-reader "1.0.0"
     pg-connection-string "^2.5.0"
-    pg-pool "^3.5.2"
-    pg-protocol "^1.5.0"
+    pg-pool "^3.6.0"
+    pg-protocol "^1.6.0"
     pg-types "^2.1.0"
     pgpass "1.x"
 
@@ -7083,6 +7130,16 @@ raw-body@2.5.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.5.1.tgz#fe1b1628b181b700215e5fd42389f98b71392857"
   integrity sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==
+  dependencies:
+    bytes "3.1.2"
+    http-errors "2.0.0"
+    iconv-lite "0.4.24"
+    unpipe "1.0.0"
+
+raw-body@2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.5.2.tgz#99febd83b90e08975087e8f1f9419a149366b68a"
+  integrity sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==
   dependencies:
     bytes "3.1.2"
     http-errors "2.0.0"
@@ -7702,12 +7759,14 @@ snake-case@^3.0.4:
     dot-case "^3.0.4"
     tslib "^2.0.3"
 
-socket.io-adapter@~2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz#b50a4a9ecdd00c34d4c8c808224daa1a786152a6"
-  integrity sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg==
+socket.io-adapter@~2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz#5de9477c9182fdc171cd8c8364b9a8894ec75d12"
+  integrity sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==
+  dependencies:
+    ws "~8.11.0"
 
-socket.io-client@^4.0.0, socket.io-client@^4.0.1:
+socket.io-client@^4.0.0:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-4.5.4.tgz#d3cde8a06a6250041ba7390f08d2468ccebc5ac9"
   integrity sha512-ZpKteoA06RzkD32IbqILZ+Cnst4xewU7ZYK12aS1mzHftFFjpoMz69IuhP/nL25pJfao/amoPI527KnuhFm01g==
@@ -7717,24 +7776,34 @@ socket.io-client@^4.0.0, socket.io-client@^4.0.1:
     engine.io-client "~6.2.3"
     socket.io-parser "~4.2.1"
 
+socket.io-client@^4.0.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-4.6.1.tgz#80d97d5eb0feca448a0fb6d69a7b222d3d547eab"
+  integrity sha512-5UswCV6hpaRsNg5kkEHVcbBIXEYoVbMQaHJBXJCyEQ+CiFPV1NIOY0XOFWG4XR4GZcB8Kn6AsRs/9cy9TbqVMQ==
+  dependencies:
+    "@socket.io/component-emitter" "~3.1.0"
+    debug "~4.3.2"
+    engine.io-client "~6.4.0"
+    socket.io-parser "~4.2.1"
+
 socket.io-parser@~4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.2.1.tgz#01c96efa11ded938dcb21cbe590c26af5eff65e5"
-  integrity sha512-V4GrkLy+HeF1F/en3SpUaM+7XxYXpuMUWLGde1kSSh5nQMN4hLrbPIkD+otwh6q9R6NOQBN4AMaOZ2zVjui82g==
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.2.2.tgz#1dd384019e25b7a3d374877f492ab34f2ad0d206"
+  integrity sha512-DJtziuKypFkMMHCm2uIshOYC7QaylbtzQwiMYDuCKy3OPkjLzu4B2vAhTlqipRHHzrI0NJeBAizTK7X+6m1jVw==
   dependencies:
     "@socket.io/component-emitter" "~3.1.0"
     debug "~4.3.1"
 
 socket.io@^4.1.2:
-  version "4.5.4"
-  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-4.5.4.tgz#a4513f06e87451c17013b8d13fdfaf8da5a86a90"
-  integrity sha512-m3GC94iK9MfIEeIBfbhJs5BqFibMtkRk8ZpKwG2QwxV0m/eEhPIV4ara6XCF1LWNAus7z58RodiZlAH71U3EhQ==
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-4.6.1.tgz#62ec117e5fce0692fa50498da9347cfb52c3bc70"
+  integrity sha512-KMcaAi4l/8+xEjkRICl6ak8ySoxsYG+gG6/XfRCPJPQ/haCRIJBTL4wIl8YCsmtaBovcAXGLOShyVWQ/FG8GZA==
   dependencies:
     accepts "~1.3.4"
     base64id "~2.0.0"
     debug "~4.3.2"
-    engine.io "~6.2.1"
-    socket.io-adapter "~2.4.0"
+    engine.io "~6.4.1"
+    socket.io-adapter "~2.5.2"
     socket.io-parser "~4.2.1"
 
 sockjs@^0.3.24:
@@ -8322,17 +8391,12 @@ typedi@^0.10.0:
   resolved "https://registry.npmjs.org/typedi/-/typedi-0.10.0.tgz"
   integrity sha512-v3UJF8xm68BBj6AF4oQML3ikrfK2c9EmZUyLOfShpJuItAqVBHWP/KtpGinkSsIiP6EZyyb6Z3NXyW9dgS9X1w==
 
-typescript@^4.2.3, typescript@^4.2.4:
+typescript@^4.2.3:
   version "4.9.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
   integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
 
-typescript@^4.3.5:
-  version "4.7.4"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
-
-typescript@^4.7.4:
+typescript@^4.2.4, typescript@^4.3.5, typescript@^4.7.4:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
@@ -8891,7 +8955,7 @@ ws@^8.11.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.12.0.tgz#485074cc392689da78e1828a9ff23585e06cddd8"
   integrity sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==
 
-ws@^8.4.2:
+ws@^8.4.2, ws@~8.11.0:
   version "8.11.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.11.0.tgz#6a0d36b8edfd9f96d8b25683db2f8d7de6e8e143"
   integrity sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==


### PR DESCRIPTION
- Add health-check for UI by return 200 from `/health` if NGINX is up.
- Add health-check for `deep-thought` by adding `HealthController` which returns 200 if database (if enabled) and MQTT are accessible.
- Add health-check for database by initiating TCP connection to Postgres port.
- Add health-check for mosquitto by initiating TCP connection to MQTT port.
- Include updates for packages used by `deep-thought`.