### PR TITLE
Unrelated fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release Helm Chart
+name: Release PowerPi
 
 on:
   push:
@@ -21,13 +21,13 @@ jobs:
     
     - name: Add chart directory
       run: ln -s kubernetes charts
-    
+
+    - name: Tag services
+      shell: bash
+      run: "${GITHUB_WORKSPACE}/.github/scripts/tag.sh"
+
     - name: Package and upload helm chart
       shell: bash
       run: "${GITHUB_WORKSPACE}/.github/scripts/release.sh"
       env:
         CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-    
-    - name: Tag services
-      shell: bash
-      run: "${GITHUB_WORKSPACE}/.github/scripts/tag.sh"

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -45,7 +45,7 @@ Finally once the plugins are enabled, the stack can be deployed by adding the He
 microk8s helm repo add powerpi https://twilkin.github.io/powerpi
 
 # Deploy your stack
-microk8s helm upgrade --install --namespace powerpi --create-namespace -f __OVERRIDE__ powerpi/powerpi powerpi
+microk8s helm upgrade --install --namespace powerpi --create-namespace -f __OVERRIDE__ powerpi powerpi/powerpi
 ```
 
 ## Updating
@@ -57,7 +57,7 @@ When changes have been made to PowerPi the images will be updated on [Docker Hub
 microk8s helm repo update
 
 # Deploy your stack
-microk8s helm upgrade --install --namespace powerpi -f __OVERRIDE__ powerpi/powerpi powerpi
+microk8s helm upgrade --install --namespace powerpi -f __OVERRIDE__ powerpi powerpi/powerpi
 ```
 
 ### Add Secrets


### PR DESCRIPTION
- Kubernetes deploy documentation has namespace and repo arguments switched.
- Release pipeline can fail if there is no change to the helm chart, so tag first just in case.