### PR TITLE
#196 Use current value when executing light schedules

### DIFF
--- a/common/pytest/powerpi_common_test/fixture/__init__.py
+++ b/common/pytest/powerpi_common_test/fixture/__init__.py
@@ -1,3 +1,4 @@
 from .common import (powerpi_config, powerpi_logger, powerpi_scheduler,
                      powerpi_service_provider)
 from .mqtt import powerpi_mqtt_client, powerpi_mqtt_producer
+from .variable import powerpi_variable_manager

--- a/common/pytest/powerpi_common_test/fixture/variable.py
+++ b/common/pytest/powerpi_common_test/fixture/variable.py
@@ -1,0 +1,9 @@
+import pytest
+from pytest_mock import MockerFixture
+
+
+@pytest.fixture
+def powerpi_variable_manager(mocker: MockerFixture):
+    manager = mocker.MagicMock()
+
+    return manager

--- a/common/pytest/pyproject.toml
+++ b/common/pytest/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "powerpi-common-test"
-version = "0.3.0"
+version = "0.3.1"
 description = "PowerPi Common Python Test Library"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -10,7 +10,7 @@ dependencies:
     version: 0.1.1
     condition: global.voiceAssistant
   - name: clacks-config
-    version: 0.1.2
+    version: 0.1.3
     condition: global.config
   - name: database
     version: 0.1.3

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: powerpi
 description: A Helm chart for deploying the PowerPi home automation stack
 type: application
-version: 0.1.13
-appVersion: 0.1.11
+version: 0.1.14
+appVersion: 0.1.12
 dependencies:
   # services
   - name: babel-fish
@@ -29,7 +29,7 @@ dependencies:
     version: 0.1.2
     condition: global.persistence
   - name: scheduler
-    version: 0.2.0
+    version: 0.2.1
     condition: global.scheduler
   - name: smarter-device-manager
     version: 0.1.1

--- a/kubernetes/charts/clacks-config/Chart.yaml
+++ b/kubernetes/charts/clacks-config/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: clacks-config
 description: A Helm chart for the PowerPi clacks-config configuration service
 type: application
-version: 0.1.2
-appVersion: 0.3.1
+version: 0.1.3
+appVersion: 0.3.2

--- a/kubernetes/charts/scheduler/Chart.yaml
+++ b/kubernetes/charts/scheduler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: scheduler
 description: A Helm chart for the PowerPi scheduler service
 type: application
-version: 0.2.0
-appVersion: 1.0.0
+version: 0.2.1
+appVersion: 1.1.0

--- a/services/clacks-config/package.json
+++ b/services/clacks-config/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@powerpi/clacks-config",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "description": "PowerPi config retrieval from GitHub pushing to message queue",
     "private": true,
     "license": "GPL-3.0-only",

--- a/services/clacks-config/src/schema/config/schedules.schema.json
+++ b/services/clacks-config/src/schema/config/schedules.schema.json
@@ -19,6 +19,14 @@
                         "description": "The device to control",
                         "$ref": "https://github.com/TWilkin/powerpi/tree/master/services/clacks-config/src/schema/common/Identifier.schema.json"
                     },
+                    "devices": {
+                        "description": "The devices to control",
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                            "$ref": "https://github.com/TWilkin/powerpi/tree/master/services/clacks-config/src/schema/common/Identifier.schema.json"
+                        }
+                    },
                     "days": {
                         "description": "The days this schedule applies to",
                         "type": "array",
@@ -90,7 +98,8 @@
                         "type": "boolean"
                     }
                 },
-                "required": ["device", "between", "interval"],
+                "required": ["between", "interval"],
+                "oneOf": [{ "required": ["device"] }, { "required": ["devices"] }],
                 "additionalProperties": false
             }
         }

--- a/services/clacks-config/test/services/validator/SchedulesConfigFile.test.ts
+++ b/services/clacks-config/test/services/validator/SchedulesConfigFile.test.ts
@@ -1,9 +1,9 @@
 import { ConfigFileType, ISchedule } from "@powerpi/common";
 import ValidatorService from "../../../src/services/ValidatorService";
 import {
-    setupValidator,
     testInvalid as _testInvalid,
     testValid as _testValid,
+    setupValidator,
 } from "./setupValidator";
 
 describe("Users", () => {
@@ -35,6 +35,13 @@ describe("Users", () => {
                     hue: [0, 100],
                     saturation: [1000, 10000],
                     power: true,
+                },
+                {
+                    devices: ["BedroomLight", "HallwayLight"],
+                    between: ["01:00:00", "01:59:59"],
+                    interval: 60,
+                    brightness: [0, 1000],
+                    temperature: [2000, 4000],
                 },
             ],
         }));
@@ -84,6 +91,19 @@ describe("Users", () => {
                     ],
                 }));
         });
+
+        test("duplicate device(s)", () =>
+            testInvalid({
+                timezone: "Europe/London",
+                schedules: [
+                    {
+                        device: "BedroomLight",
+                        devices: ["BedroomLight", "HallwayLight"],
+                        between: ["01:00:00", "01:59:59"],
+                        interval: 60,
+                    },
+                ],
+            }));
 
         test("Other properties", () =>
             testInvalid({

--- a/services/scheduler/pyproject.toml
+++ b/services/scheduler/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scheduler"
-version = "1.0.0"
+version = "1.1.0"
 description = "PowerPi Scheduler Service"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/services/scheduler/scheduler/container.py
+++ b/services/scheduler/scheduler/container.py
@@ -29,7 +29,8 @@ class ApplicationContainer(containers.DeclarativeContainer):
         config=config,
         logger=common.logger,
         mqtt_client=common.mqtt_client,
-        scheduler=common.scheduler
+        scheduler=common.scheduler,
+        variable_manager=common.variable.variable_manager
     )
 
     device_scheduler = providers.Factory(

--- a/services/scheduler/scheduler/services/device_schedule.py
+++ b/services/scheduler/scheduler/services/device_schedule.py
@@ -44,6 +44,7 @@ class DeviceSchedule(LogMixin):
         logger: Logger,
         mqtt_client: MQTTClient,
         scheduler: AsyncIOScheduler,
+        device: str,
         device_schedule: Dict[str, Any]
     ):
         # pylint: disable=too-many-arguments
@@ -54,6 +55,7 @@ class DeviceSchedule(LogMixin):
 
         self.__producer = mqtt_client.add_producer()
 
+        self.__device = device
         self.__parse(device_schedule)
 
     def start(self):
@@ -92,7 +94,6 @@ class DeviceSchedule(LogMixin):
             self.__producer(topic, message)
 
     def __parse(self, device_schedule: Dict[str, Any]):
-        self.__device: str = device_schedule['device']
         self.__between: List[str] = device_schedule['between']
         self.__interval = int(device_schedule['interval'])
 

--- a/services/scheduler/scheduler/services/device_schedule.py
+++ b/services/scheduler/scheduler/services/device_schedule.py
@@ -9,6 +9,7 @@ from apscheduler.triggers.interval import IntervalTrigger
 from powerpi_common.device import DeviceStatus
 from powerpi_common.logger import Logger, LogMixin
 from powerpi_common.mqtt import MQTTClient
+from powerpi_common.variable import VariableManager
 from scheduler.config import SchedulerConfig
 
 
@@ -29,7 +30,7 @@ class DayOfWeek(IntEnum):
     SUNDAY = 6
 
 
-Delta = namedtuple('Delta', 'start end delta')
+DeltaRange = namedtuple('DeltaRange', 'type start end')
 
 
 class DeviceSchedule(LogMixin):
@@ -44,6 +45,7 @@ class DeviceSchedule(LogMixin):
         logger: Logger,
         mqtt_client: MQTTClient,
         scheduler: AsyncIOScheduler,
+        variable_manager: VariableManager,
         device: str,
         device_schedule: Dict[str, Any]
     ):
@@ -52,6 +54,7 @@ class DeviceSchedule(LogMixin):
         self.__config = config
         self._logger = logger
         self.__scheduler = scheduler
+        self.__variable_manager = variable_manager
 
         self.__producer = mqtt_client.add_producer()
 
@@ -60,6 +63,9 @@ class DeviceSchedule(LogMixin):
 
     def start(self):
         self.log_info(self)
+
+        # retrieve this variable to register the listener
+        self.__variable_manager.get_device(self.__device)
 
         self.__start_schedule()
 
@@ -70,17 +76,17 @@ class DeviceSchedule(LogMixin):
 
         message = {}
 
-        for delta_type, delta in self.__delta.items():
-            new_value = self.__calculate_new_value(start_date, delta)
+        for _, delta_range in self.__delta.items():
+            new_value = self.__calculate_new_value(start_date, delta_range)
 
             self.log_info(
                 'Setting %s %s to %d',
-                delta_type,
+                delta_range.type,
                 self.__device,
                 new_value
             )
 
-            message[delta_type] = new_value
+            message[delta_range.type] = new_value
 
         if self.__power is not None:
             new_state = DeviceStatus.ON if self.__power else DeviceStatus.OFF
@@ -100,18 +106,20 @@ class DeviceSchedule(LogMixin):
         self.__days = device_schedule['days'] if 'days' in device_schedule \
             else None
 
-        self.__delta: Dict[DeltaType, Delta] = {}
+        self.__delta: Dict[DeltaType, DeltaRange] = {}
 
         for delta_type in [DeltaType.BRIGHTNESS, DeltaType.TEMPERATURE]:
             if delta_type in device_schedule:
-                self.__delta[delta_type] = self.__calculate_delta(
+                self.__delta[delta_type] = DeltaRange(
+                    delta_type,
                     int(device_schedule[delta_type][0]),
                     int(device_schedule[delta_type][1])
                 )
 
         for delta_type in [DeltaType.HUE, DeltaType.SATURATION]:
             if delta_type in device_schedule:
-                self.__delta[delta_type] = self.__calculate_delta(
+                self.__delta[delta_type] = DeltaRange(
+                    delta_type,
                     float(device_schedule[delta_type][0]),
                     float(device_schedule[delta_type][1])
                 )
@@ -196,7 +204,7 @@ class DeviceSchedule(LogMixin):
 
         return (start_date, end_date)
 
-    def __calculate_delta(self, start: float, end: float):
+    def __calculate_delta(self, delta_range: DeltaRange):
         (start_date, end_date) = self.__calculate_dates()
 
         # how many seconds between the dates
@@ -205,25 +213,34 @@ class DeviceSchedule(LogMixin):
         # how many intervals will there be
         intervals = seconds / self.__interval
 
+        # do we want to overwrite start with the current value from the device
+        device = self.__variable_manager.get_device(self.__device)
+        if delta_range.type in device.additional_state:
+            start = device.additional_state[delta_range.type]
+        else:
+            start = delta_range.start
+
         # what is the delta
-        delta = (end - start) / intervals
+        delta = (delta_range.end - start) / intervals
 
-        return Delta(start, end, delta)
+        return (DeltaRange(delta_range.type, start, delta_range.end), delta)
 
-    def __calculate_new_value(self, start_date: datetime, delta: Delta):
+    def __calculate_new_value(self, start_date: datetime, delta_range: DeltaRange):
+        (delta_range, delta) = self.__calculate_delta(delta_range)
+
         # calculate how much time has elapsed
         diff = datetime.now(pytz.UTC).timestamp() - start_date.timestamp()
 
         # how many intervals is that
         intervals = diff / self.__interval
 
-        new_value = delta.start + delta.delta * intervals
+        new_value = delta_range.start + delta * intervals
 
         new_value = round(new_value)
-        if delta.delta > 0:
-            new_value = min(max(new_value, delta.start), delta.end)
+        if delta > 0:
+            new_value = min(max(new_value, delta_range.start), delta_range.end)
         else:
-            new_value = max(min(new_value, delta.start), delta.end)
+            new_value = max(min(new_value, delta_range.start), delta_range.end)
 
         return new_value
 

--- a/services/scheduler/scheduler/services/device_scheduler.py
+++ b/services/scheduler/scheduler/services/device_scheduler.py
@@ -37,13 +37,18 @@ class DeviceScheduler(LogMixin):
 
         schedules = schedule_config['schedules']
         for schedule in schedules:
-            if schedule['device'] in devices:
-                device_schedule: DeviceSchedule = factory(
-                    device_schedule=schedule
-                )
+            schedule_devices = [schedule['device']] if 'device' in schedule \
+                else schedule['devices']
 
-                device_schedule.start()
-            else:
-                raise DeviceNotFoundException(
-                    DeviceConfigType.DEVICE, schedule['device']
-                )
+            for schedule_device in schedule_devices:
+                if schedule_device in devices:
+                    device_schedule: DeviceSchedule = factory(
+                        device=schedule_device,
+                        device_schedule=schedule
+                    )
+
+                    device_schedule.start()
+                else:
+                    raise DeviceNotFoundException(
+                        DeviceConfigType.DEVICE, schedule_device
+                    )

--- a/services/scheduler/tests/conftest.py
+++ b/services/scheduler/tests/conftest.py
@@ -5,6 +5,7 @@ from powerpi_common_test.fixture import (powerpi_config, powerpi_logger,
                                          powerpi_mqtt_client,
                                          powerpi_mqtt_producer,
                                          powerpi_scheduler,
-                                         powerpi_service_provider)
+                                         powerpi_service_provider,
+                                         powerpi_variable_manager)
 
 from .fixtures import scheduler_config

--- a/services/scheduler/tests/services/test_device_schedule.py
+++ b/services/scheduler/tests/services/test_device_schedule.py
@@ -240,6 +240,7 @@ class TestDeviceSchedule:
                 powerpi_logger,
                 powerpi_mqtt_client,
                 powerpi_scheduler,
+                schedule['device'],
                 schedule
             )
 

--- a/services/scheduler/tests/services/test_device_scheduler.py
+++ b/services/scheduler/tests/services/test_device_scheduler.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, PropertyMock
 
 import pytest
 from powerpi_common.device import DeviceNotFoundException
+from pytest_mock import MockerFixture
 from scheduler.config import SchedulerConfig
 from scheduler.services import DeviceScheduler
 
@@ -34,7 +35,48 @@ class TestDeviceScheduler:
         subject.start()
 
         device_schedule_factory.assert_called_once_with(
+            device='SomeDevice',
             device_schedule={'device': 'SomeDevice'}
+        )
+
+    def test_start_multiple_devices(
+        self,
+        subject: DeviceScheduler,
+        scheduler_config: SchedulerConfig,
+        device_schedule_factory: MagicMock,
+        mocker: MockerFixture
+    ):
+        devices = {
+            'devices': [
+                {'name': 'SomeDevice'},
+                {'name': 'OtherDevice'}
+            ]
+        }
+
+        schedules = {
+            'timezone': 'Europe/London',
+            'schedules': [
+                {
+                    'devices': ['SomeDevice', 'OtherDevice']
+                }
+            ]
+        }
+
+        type(scheduler_config).devices = PropertyMock(return_value=devices)
+        type(scheduler_config).schedules = PropertyMock(return_value=schedules)
+
+        subject.start()
+
+        assert device_schedule_factory.call_count == 2
+
+        assert device_schedule_factory.call_args_list[0] == mocker.call(
+            device='SomeDevice',
+            device_schedule={'devices': ['SomeDevice', 'OtherDevice']}
+        )
+
+        assert device_schedule_factory.call_args_list[1] == mocker.call(
+            device='OtherDevice',
+            device_schedule={'devices': ['SomeDevice', 'OtherDevice']}
         )
 
     def test_start_no_config(

--- a/yarn.lock
+++ b/yarn.lock
@@ -399,18 +399,18 @@
     eslint-visitor-keys "^3.3.0"
 
 "@eslint-community/regexpp@^4.4.0":
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.5.0.tgz#f6f729b02feee2c749f57e334b7a1b5f40a81724"
-  integrity sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.5.1.tgz#cdd35dce4fa1a89a4fd42b1599eb35b3af408884"
+  integrity sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==
 
-"@eslint/eslintrc@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-2.0.2.tgz#01575e38707add677cf73ca1589abba8da899a02"
-  integrity sha512-3W4f5tDUra+pA+FzgugqL2pRimUTDJWKr7BINqOpkZrC0uYI0NIc0/JFgBROCU07HR6GieA5m3/rsPIhDmCXTQ==
+"@eslint/eslintrc@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-2.0.3.tgz#4910db5505f4d503f27774bf356e3704818a0331"
+  integrity sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==
   dependencies:
     ajv "^6.12.4"
     debug "^4.3.2"
-    espree "^9.5.1"
+    espree "^9.5.2"
     globals "^13.19.0"
     ignore "^5.2.0"
     import-fresh "^3.2.1"
@@ -418,10 +418,10 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@eslint/js@8.39.0":
-  version "8.39.0"
-  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.39.0.tgz#58b536bcc843f4cd1e02a7e6171da5c040f4d44b"
-  integrity sha512-kf9RB0Fg7NZfap83B3QOqOGg9QmD9yBudqQXzzOtn3i4y7ZUXe5ONeW34Gwi+TxhH4mvj72R1Zc300KUMa9Bng==
+"@eslint/js@8.40.0":
+  version "8.40.0"
+  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.40.0.tgz#3ba73359e11f5a7bd3e407f70b3528abfae69cec"
+  integrity sha512-ElyB54bJIhXQYVKjDSvCkPO1iU1tSAeVQJbllWJq1XQSmmA4dgFk8CbiBGpiOPxleE48vDogxCtmMYku4HSVLA==
 
 "@fortawesome/fontawesome-common-types@6.4.0":
   version "6.4.0"
@@ -1754,7 +1754,12 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.15.5.tgz#3af577099a99c61479149b716183e70b5239324a"
   integrity sha512-Ark2WDjjZO7GmvsyFFf81MXuGTA/d6oP38anyxWOL6EREyBKAxKoFHwBhaZxCfLRLpO8JgVXwqOwSwa7jRcjew==
 
-"@types/node@^18.0.0", "@types/node@^18.6.4", "@types/node@^18.7.2":
+"@types/node@^18.0.0":
+  version "18.16.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.5.tgz#bf64e42719dc2e74da24709a2e1c0b50a966120a"
+  integrity sha512-seOA34WMo9KB+UA78qaJoCO20RJzZGVXQ5Sh6FWu0g/hfT44nKXnej3/tCQl7FL97idFpBhisLYCTB50S0EirA==
+
+"@types/node@^18.6.4", "@types/node@^18.7.2":
   version "18.16.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.2.tgz#2f610ea71034b3971c312192377f8a7178eb57f1"
   integrity sha512-GQW/JL/5Fz/0I8RpeBG9lKp0+aNcXEaVL71c0D2Q0QHDTFvlYKT7an0onCUXj85anv7b4/WesqdfchLc0jtsCg==
@@ -2065,14 +2070,14 @@
     "@types/yargs-parser" "*"
 
 "@typescript-eslint/eslint-plugin@^5.30.0":
-  version "5.59.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.1.tgz#9b09ee1541bff1d2cebdcb87e7ce4a4003acde08"
-  integrity sha512-AVi0uazY5quFB9hlp2Xv+ogpfpk77xzsgsIEWyVS7uK/c7MZ5tw7ZPbapa0SbfkqE0fsAMkz5UwtgMLVk2BQAg==
+  version "5.59.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.2.tgz#684a2ce7182f3b4dac342eef7caa1c2bae476abd"
+  integrity sha512-yVrXupeHjRxLDcPKL10sGQ/QlVrA8J5IYOEWVqk0lJaSZP7X5DfnP7Ns3cc74/blmbipQ1htFNVGsHX6wsYm0A==
   dependencies:
     "@eslint-community/regexpp" "^4.4.0"
-    "@typescript-eslint/scope-manager" "5.59.1"
-    "@typescript-eslint/type-utils" "5.59.1"
-    "@typescript-eslint/utils" "5.59.1"
+    "@typescript-eslint/scope-manager" "5.59.2"
+    "@typescript-eslint/type-utils" "5.59.2"
+    "@typescript-eslint/utils" "5.59.2"
     debug "^4.3.4"
     grapheme-splitter "^1.0.4"
     ignore "^5.2.0"
@@ -2081,71 +2086,71 @@
     tsutils "^3.21.0"
 
 "@typescript-eslint/parser@^5.30.0":
-  version "5.59.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.59.1.tgz#73c2c12127c5c1182d2e5b71a8fa2a85d215cbb4"
-  integrity sha512-nzjFAN8WEu6yPRDizIFyzAfgK7nybPodMNFGNH0M9tei2gYnYszRDqVA0xlnRjkl7Hkx2vYrEdb6fP2a21cG1g==
+  version "5.59.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.59.2.tgz#c2c443247901d95865b9f77332d9eee7c55655e8"
+  integrity sha512-uq0sKyw6ao1iFOZZGk9F8Nro/8+gfB5ezl1cA06SrqbgJAt0SRoFhb9pXaHvkrxUpZaoLxt8KlovHNk8Gp6/HQ==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.59.1"
-    "@typescript-eslint/types" "5.59.1"
-    "@typescript-eslint/typescript-estree" "5.59.1"
+    "@typescript-eslint/scope-manager" "5.59.2"
+    "@typescript-eslint/types" "5.59.2"
+    "@typescript-eslint/typescript-estree" "5.59.2"
     debug "^4.3.4"
 
-"@typescript-eslint/scope-manager@5.59.1":
-  version "5.59.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.59.1.tgz#8a20222719cebc5198618a5d44113705b51fd7fe"
-  integrity sha512-mau0waO5frJctPuAzcxiNWqJR5Z8V0190FTSqRw1Q4Euop6+zTwHAf8YIXNwDOT29tyUDrQ65jSg9aTU/H0omA==
+"@typescript-eslint/scope-manager@5.59.2":
+  version "5.59.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.59.2.tgz#f699fe936ee4e2c996d14f0fdd3a7da5ba7b9a4c"
+  integrity sha512-dB1v7ROySwQWKqQ8rEWcdbTsFjh2G0vn8KUyvTXdPoyzSL6lLGkiXEV5CvpJsEe9xIdKV+8Zqb7wif2issoOFA==
   dependencies:
-    "@typescript-eslint/types" "5.59.1"
-    "@typescript-eslint/visitor-keys" "5.59.1"
+    "@typescript-eslint/types" "5.59.2"
+    "@typescript-eslint/visitor-keys" "5.59.2"
 
-"@typescript-eslint/type-utils@5.59.1":
-  version "5.59.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.59.1.tgz#63981d61684fd24eda2f9f08c0a47ecb000a2111"
-  integrity sha512-ZMWQ+Oh82jWqWzvM3xU+9y5U7MEMVv6GLioM3R5NJk6uvP47kZ7YvlgSHJ7ERD6bOY7Q4uxWm25c76HKEwIjZw==
+"@typescript-eslint/type-utils@5.59.2":
+  version "5.59.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.59.2.tgz#0729c237503604cd9a7084b5af04c496c9a4cdcf"
+  integrity sha512-b1LS2phBOsEy/T381bxkkywfQXkV1dWda/z0PhnIy3bC5+rQWQDS7fk9CSpcXBccPY27Z6vBEuaPBCKCgYezyQ==
   dependencies:
-    "@typescript-eslint/typescript-estree" "5.59.1"
-    "@typescript-eslint/utils" "5.59.1"
+    "@typescript-eslint/typescript-estree" "5.59.2"
+    "@typescript-eslint/utils" "5.59.2"
     debug "^4.3.4"
     tsutils "^3.21.0"
 
-"@typescript-eslint/types@5.59.1":
-  version "5.59.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.59.1.tgz#03f3fedd1c044cb336ebc34cc7855f121991f41d"
-  integrity sha512-dg0ICB+RZwHlysIy/Dh1SP+gnXNzwd/KS0JprD3Lmgmdq+dJAJnUPe1gNG34p0U19HvRlGX733d/KqscrGC1Pg==
+"@typescript-eslint/types@5.59.2":
+  version "5.59.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.59.2.tgz#b511d2b9847fe277c5cb002a2318bd329ef4f655"
+  integrity sha512-LbJ/HqoVs2XTGq5shkiKaNTuVv5tTejdHgfdjqRUGdYhjW1crm/M7og2jhVskMt8/4wS3T1+PfFvL1K3wqYj4w==
 
-"@typescript-eslint/typescript-estree@5.59.1":
-  version "5.59.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.1.tgz#4aa546d27fd0d477c618f0ca00b483f0ec84c43c"
-  integrity sha512-lYLBBOCsFltFy7XVqzX0Ju+Lh3WPIAWxYpmH/Q7ZoqzbscLiCW00LeYCdsUnnfnj29/s1WovXKh2gwCoinHNGA==
+"@typescript-eslint/typescript-estree@5.59.2":
+  version "5.59.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.2.tgz#6e2fabd3ba01db5d69df44e0b654c0b051fe9936"
+  integrity sha512-+j4SmbwVmZsQ9jEyBMgpuBD0rKwi9RxRpjX71Brr73RsYnEr3Lt5QZ624Bxphp8HUkSKfqGnPJp1kA5nl0Sh7Q==
   dependencies:
-    "@typescript-eslint/types" "5.59.1"
-    "@typescript-eslint/visitor-keys" "5.59.1"
+    "@typescript-eslint/types" "5.59.2"
+    "@typescript-eslint/visitor-keys" "5.59.2"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.59.1":
-  version "5.59.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.59.1.tgz#d89fc758ad23d2157cfae53f0b429bdf15db9473"
-  integrity sha512-MkTe7FE+K1/GxZkP5gRj3rCztg45bEhsd8HYjczBuYm+qFHP5vtZmjx3B0yUCDotceQ4sHgTyz60Ycl225njmA==
+"@typescript-eslint/utils@5.59.2":
+  version "5.59.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.59.2.tgz#0c45178124d10cc986115885688db6abc37939f4"
+  integrity sha512-kSuF6/77TZzyGPhGO4uVp+f0SBoYxCDf+lW3GKhtKru/L8k/Hd7NFQxyWUeY7Z/KGB2C6Fe3yf2vVi4V9TsCSQ==
   dependencies:
     "@eslint-community/eslint-utils" "^4.2.0"
     "@types/json-schema" "^7.0.9"
     "@types/semver" "^7.3.12"
-    "@typescript-eslint/scope-manager" "5.59.1"
-    "@typescript-eslint/types" "5.59.1"
-    "@typescript-eslint/typescript-estree" "5.59.1"
+    "@typescript-eslint/scope-manager" "5.59.2"
+    "@typescript-eslint/types" "5.59.2"
+    "@typescript-eslint/typescript-estree" "5.59.2"
     eslint-scope "^5.1.1"
     semver "^7.3.7"
 
-"@typescript-eslint/visitor-keys@5.59.1":
-  version "5.59.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.1.tgz#0d96c36efb6560d7fb8eb85de10442c10d8f6058"
-  integrity sha512-6waEYwBTCWryx0VJmP7JaM4FpipLsFl9CvYf2foAE8Qh/Y0s+bxWysciwOs0LTBED4JCaNxTZ5rGadB14M6dwA==
+"@typescript-eslint/visitor-keys@5.59.2":
+  version "5.59.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.2.tgz#37a419dc2723a3eacbf722512b86d6caf7d3b750"
+  integrity sha512-EEpsO8m3RASrKAHI9jpavNv9NlEUebV4qmF1OWxSTtKSFBpC1NCmWazDQHFivRf0O1DV11BA645yrLEVQ0/Lig==
   dependencies:
-    "@typescript-eslint/types" "5.59.1"
+    "@typescript-eslint/types" "5.59.2"
     eslint-visitor-keys "^3.3.0"
 
 "@webassemblyjs/ast@1.11.5", "@webassemblyjs/ast@^1.11.5":
@@ -3986,20 +3991,20 @@ eslint-scope@^7.2.0:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
 
-eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz#c7f0f956124ce677047ddbc192a68f999454dedc"
-  integrity sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==
+eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz#c22c48f48942d08ca824cc526211ae400478a994"
+  integrity sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==
 
 eslint@^8.18.0:
-  version "8.39.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.39.0.tgz#7fd20a295ef92d43809e914b70c39fd5a23cf3f1"
-  integrity sha512-mwiok6cy7KTW7rBpo05k6+p4YVZByLNjAZ/ACB9DRCu4YDRwjXI01tWHp6KAUWelsBetTxKK/2sHB0vdS8Z2Og==
+  version "8.40.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.40.0.tgz#a564cd0099f38542c4e9a2f630fa45bf33bc42a4"
+  integrity sha512-bvR+TsP9EHL3TqNtj9sCNJVAFK3fBN8Q7g5waghxyRsPLIMwL73XSKnZFK0hk/O2ANC+iAoq6PWMQ+IfBAJIiQ==
   dependencies:
     "@eslint-community/eslint-utils" "^4.2.0"
     "@eslint-community/regexpp" "^4.4.0"
-    "@eslint/eslintrc" "^2.0.2"
-    "@eslint/js" "8.39.0"
+    "@eslint/eslintrc" "^2.0.3"
+    "@eslint/js" "8.40.0"
     "@humanwhocodes/config-array" "^0.11.8"
     "@humanwhocodes/module-importer" "^1.0.1"
     "@nodelib/fs.walk" "^1.2.8"
@@ -4010,8 +4015,8 @@ eslint@^8.18.0:
     doctrine "^3.0.0"
     escape-string-regexp "^4.0.0"
     eslint-scope "^7.2.0"
-    eslint-visitor-keys "^3.4.0"
-    espree "^9.5.1"
+    eslint-visitor-keys "^3.4.1"
+    espree "^9.5.2"
     esquery "^1.4.2"
     esutils "^2.0.2"
     fast-deep-equal "^3.1.3"
@@ -4037,14 +4042,14 @@ eslint@^8.18.0:
     strip-json-comments "^3.1.0"
     text-table "^0.2.0"
 
-espree@^9.5.1:
-  version "9.5.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-9.5.1.tgz#4f26a4d5f18905bf4f2e0bd99002aab807e96dd4"
-  integrity sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==
+espree@^9.5.2:
+  version "9.5.2"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.5.2.tgz#e994e7dc33a082a7a82dceaf12883a829353215b"
+  integrity sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==
   dependencies:
     acorn "^8.8.0"
     acorn-jsx "^5.3.2"
-    eslint-visitor-keys "^3.4.0"
+    eslint-visitor-keys "^3.4.1"
 
 esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
Resolves #196.
- Update `clacks-config` to support `device` or `devices` property in `schedules.json`.
- Update `clacks-config` dependencies.
- Update `DeviceScheduler` to support updated `schedules.json`.
- Use `VariableManager` to get current device additional state to use when calculating delta for schedule.