### PR TITLE
#144 Add support for conditions to schedules

### DIFF
--- a/common/python/powerpi_common/condition/__init__.py
+++ b/common/python/powerpi_common/condition/__init__.py
@@ -1,3 +1,4 @@
+from .container import ConditionContainer
 from .errors import InvalidArgumentException, InvalidIdentifierException, ParseException, \
     UnexpectedTokenException
 from .parser import ConditionParser, Expression

--- a/common/python/powerpi_common/condition/container.py
+++ b/common/python/powerpi_common/condition/container.py
@@ -1,6 +1,5 @@
 from dependency_injector import containers, providers
 
-from .dates import BankHolidayService
 from .parser import ConditionParser
 
 

--- a/common/python/powerpi_common/condition/container.py
+++ b/common/python/powerpi_common/condition/container.py
@@ -1,0 +1,19 @@
+from dependency_injector import containers, providers
+
+from .dates import BankHolidayService
+from .parser import ConditionParser
+
+
+class ConditionContainer(containers.DeclarativeContainer):
+    __self__ = providers.Self()
+
+    config = providers.Dependency()
+
+    logger = providers.Dependency()
+
+    variable_manager = providers.Dependency()
+
+    condition_parser = providers.Factory(
+        ConditionParser,
+        variable_manager=variable_manager
+    )

--- a/common/python/powerpi_common/container.py
+++ b/common/python/powerpi_common/container.py
@@ -1,5 +1,6 @@
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from dependency_injector import containers, providers
+from powerpi_common.condition import ConditionContainer
 from powerpi_common.config import Config
 from powerpi_common.config.config_retriever import ConfigRetriever
 from powerpi_common.controller import Controller

--- a/common/python/powerpi_common/container.py
+++ b/common/python/powerpi_common/container.py
@@ -65,6 +65,13 @@ class Container(containers.DeclarativeContainer):
         device_manager=device.device_manager
     )
 
+    condition = providers.Container(
+        ConditionContainer,
+        config=config,
+        logger=logger,
+        variable_manager=variable.variable_manager
+    )
+
     event_manager = providers.Singleton(
         EventManager,
         config=config,

--- a/common/python/pyproject.toml
+++ b/common/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "powerpi-common"
-version = "0.3.0"
+version = "0.3.1"
 description = "PowerPi Common Python Library"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: powerpi
 description: A Helm chart for deploying the PowerPi home automation stack
 type: application
-version: 0.1.14
-appVersion: 0.1.12
+version: 0.1.15
+appVersion: 0.1.13
 dependencies:
   # services
   - name: babel-fish
@@ -29,7 +29,7 @@ dependencies:
     version: 0.1.2
     condition: global.persistence
   - name: scheduler
-    version: 0.2.1
+    version: 0.2.2
     condition: global.scheduler
   - name: smarter-device-manager
     version: 0.1.1

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -10,7 +10,7 @@ dependencies:
     version: 0.1.1
     condition: global.voiceAssistant
   - name: clacks-config
-    version: 0.1.3
+    version: 0.1.4
     condition: global.config
   - name: database
     version: 0.1.3

--- a/kubernetes/charts/clacks-config/Chart.yaml
+++ b/kubernetes/charts/clacks-config/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: clacks-config
 description: A Helm chart for the PowerPi clacks-config configuration service
 type: application
-version: 0.1.3
-appVersion: 0.3.2
+version: 0.1.4
+appVersion: 0.3.3

--- a/kubernetes/charts/scheduler/Chart.yaml
+++ b/kubernetes/charts/scheduler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: scheduler
 description: A Helm chart for the PowerPi scheduler service
 type: application
-version: 0.2.1
-appVersion: 1.1.0
+version: 0.2.2
+appVersion: 1.2.0

--- a/services/clacks-config/package.json
+++ b/services/clacks-config/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@powerpi/clacks-config",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "description": "PowerPi config retrieval from GitHub pushing to message queue",
     "private": true,
     "license": "GPL-3.0-only",

--- a/services/clacks-config/src/schema/config/schedules.schema.json
+++ b/services/clacks-config/src/schema/config/schedules.schema.json
@@ -49,6 +49,10 @@
                         "type": "integer",
                         "minimum": 0
                     },
+                    "condition": {
+                        "description": "The condition to test if this schedule should be executed",
+                        "$ref": "https://github.com/TWilkin/powerpi/tree/master/services/clacks-config/src/schema/common/Condition.schema.json"
+                    },
                     "hue": {
                         "description": "The start and end hue values this schedule applies",
                         "type": "array",

--- a/services/clacks-config/test/services/validator/SchedulesConfigFile.test.ts
+++ b/services/clacks-config/test/services/validator/SchedulesConfigFile.test.ts
@@ -6,7 +6,7 @@ import {
     setupValidator,
 } from "./setupValidator";
 
-describe("Users", () => {
+describe("Schedules", () => {
     let subject: ValidatorService | undefined;
 
     const testValid = (file: object) => _testValid(subject, ConfigFileType.Schedules, file);
@@ -40,6 +40,9 @@ describe("Users", () => {
                     devices: ["BedroomLight", "HallwayLight"],
                     between: ["01:00:00", "01:59:59"],
                     interval: 60,
+                    condition: {
+                        when: [{ equals: [{ var: "device.OfficeLight.state" }, "on"] }],
+                    },
                     brightness: [0, 1000],
                     temperature: [2000, 4000],
                 },

--- a/services/scheduler/poetry.lock
+++ b/services/scheduler/poetry.lock
@@ -459,7 +459,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "powerpi-common"
-version = "0.2.14"
+version = "0.3.1"
 description = "PowerPi Common Python Library"
 category = "dev"
 optional = false
@@ -480,7 +480,7 @@ url = "../../common/python"
 
 [[package]]
 name = "powerpi-common-test"
-version = "0.2.7"
+version = "0.3.1"
 description = "PowerPi Common Python Test Library"
 category = "dev"
 optional = false

--- a/services/scheduler/pyproject.toml
+++ b/services/scheduler/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scheduler"
-version = "1.1.0"
+version = "1.2.0"
 description = "PowerPi Scheduler Service"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/services/scheduler/scheduler/container.py
+++ b/services/scheduler/scheduler/container.py
@@ -30,7 +30,8 @@ class ApplicationContainer(containers.DeclarativeContainer):
         logger=common.logger,
         mqtt_client=common.mqtt_client,
         scheduler=common.scheduler,
-        variable_manager=common.variable.variable_manager
+        variable_manager=common.variable.variable_manager,
+        condition_parser_factory=common.condition.condition_parser.provider
     )
 
     device_scheduler = providers.Factory(

--- a/services/scheduler/scheduler/container.py
+++ b/services/scheduler/scheduler/container.py
@@ -38,7 +38,7 @@ class ApplicationContainer(containers.DeclarativeContainer):
         DeviceScheduler,
         config=config,
         logger=common.logger,
-        service_provider=service_provider
+        device_schedule_factory=device_schedule.provider
     )
 
     application = providers.Singleton(

--- a/services/scheduler/scheduler/services/device_schedule.py
+++ b/services/scheduler/scheduler/services/device_schedule.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Union
 import pytz
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
+from dependency_injector import providers
 from powerpi_common.condition import (ConditionParser, Expression,
                                       ParseException)
 from powerpi_common.device import DeviceStatus
@@ -48,6 +49,7 @@ class DeviceSchedule(LogMixin):
         mqtt_client: MQTTClient,
         scheduler: AsyncIOScheduler,
         variable_manager: VariableManager,
+        condition_parser_factory: providers.Factory,
         device: str,
         device_schedule: Dict[str, Any]
     ):
@@ -57,6 +59,7 @@ class DeviceSchedule(LogMixin):
         self._logger = logger
         self.__scheduler = scheduler
         self.__variable_manager = variable_manager
+        self.__condition_parser_factory = condition_parser_factory
 
         self.__producer = mqtt_client.add_producer()
 
@@ -152,7 +155,7 @@ class DeviceSchedule(LogMixin):
 
     def __check_condition(self):
         if self.__condition is not None:
-            parser = ConditionParser(self.__variable_manager)
+            parser: ConditionParser = self.__condition_parser_factory()
             return parser.conditional_expression(self.__condition)
 
         return True

--- a/services/scheduler/scheduler/services/device_schedule.py
+++ b/services/scheduler/scheduler/services/device_schedule.py
@@ -271,6 +271,9 @@ class DeviceSchedule(LogMixin):
         else:
             builder += ' every day'
 
+        if self.__condition:
+            builder += ', if the condition is true,'
+
         builder += f' adjust {self.__device}'
 
         for device_type, delta in self.__delta.items():

--- a/services/scheduler/scheduler/services/device_schedule.py
+++ b/services/scheduler/scheduler/services/device_schedule.py
@@ -6,7 +6,8 @@ from typing import Any, Dict, List, Union
 import pytz
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
-from powerpi_common.condition import ConditionParser, Expression
+from powerpi_common.condition import (ConditionParser, Expression,
+                                      ParseException)
 from powerpi_common.device import DeviceStatus
 from powerpi_common.logger import Logger, LogMixin
 from powerpi_common.mqtt import MQTTClient
@@ -67,6 +68,17 @@ class DeviceSchedule(LogMixin):
 
         # retrieve this variable to register the listener
         self.__variable_manager.get_device(self.__device)
+
+        # evaluate the condition if there is one
+        try:
+            self.__check_condition()
+        except ParseException as ex:
+            self.log_error(
+                'Failed to schedule job for %s due to bad condition',
+                self.__device
+            )
+            self.log_exception(ex)
+            return
 
         self.__start_schedule()
 

--- a/services/scheduler/scheduler/services/device_scheduler.py
+++ b/services/scheduler/scheduler/services/device_scheduler.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from dependency_injector import providers
 from powerpi_common.device import DeviceConfigType, DeviceNotFoundException
 from powerpi_common.logger import Logger, LogMixin
 from scheduler.config import SchedulerConfig
@@ -15,11 +16,11 @@ class DeviceScheduler(LogMixin):
         self,
         config: SchedulerConfig,
         logger: Logger,
-        service_provider
+        device_schedule_factory: providers.Factory
     ):
         self.__config = config
         self._logger = logger
-        self.__service_provider = service_provider
+        self.__device_schedule_factory = device_schedule_factory
 
     def start(self):
         device_config = self.__config.devices
@@ -33,8 +34,6 @@ class DeviceScheduler(LogMixin):
         self.__config.timezone = schedule_config['timezone']
         self.log_info('Using timezone %s', self.__config.timezone)
 
-        factory = self.__service_provider.device_schedule
-
         schedules = schedule_config['schedules']
         for schedule in schedules:
             schedule_devices = [schedule['device']] if 'device' in schedule \
@@ -42,7 +41,7 @@ class DeviceScheduler(LogMixin):
 
             for schedule_device in schedule_devices:
                 if schedule_device in devices:
-                    device_schedule: DeviceSchedule = factory(
+                    device_schedule: DeviceSchedule = self.__device_schedule_factory(
                         device=schedule_device,
                         device_schedule=schedule
                     )

--- a/services/scheduler/tests/services/test_device_scheduler.py
+++ b/services/scheduler/tests/services/test_device_scheduler.py
@@ -127,14 +127,16 @@ class TestDeviceScheduler:
         self,
         scheduler_config,
         powerpi_logger,
-        powerpi_service_provider
+        device_schedule_factory
     ):
         return DeviceScheduler(
             scheduler_config,
             powerpi_logger,
-            powerpi_service_provider
+            device_schedule_factory
         )
 
     @pytest.fixture
-    def device_schedule_factory(self, powerpi_service_provider):
-        return powerpi_service_provider.device_schedule
+    def device_schedule_factory(self, mocker: MockerFixture):
+        factory = mocker.MagicMock()
+
+        return factory


### PR DESCRIPTION
Resolves #144 
- Add support for conditions in `schedules.json`.
- Use `condition` property when deciding whether to execute the schedule or not on every execution.
- Remove use of service provider when can inject the `provider.Factory` instead, will use this pattern from now on.
  - For `device_schedule` in `DeviceScheduler`.
  - For `conditional_parser` in `DeviceSchedule`.