### PR TITLE
#91 Fix pipeline after new service

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -5,14 +5,14 @@ version_str=`grep "^version:\s*.*$" "${GITHUB_WORKSPACE}/kubernetes/Chart.yaml" 
 version_regex="version:\s*(.*)"
 if [[ $version_str =~ $version_regex ]]
 then 
-    version="${BASH_REMATCH[1]}"
-    echo "Found v$version of PowerPi helm chart"
+    version="v${BASH_REMATCH[1]}"
+    echo "Found $version of PowerPi helm chart"
 else 
     version=-1
 fi
 
 # if the tag already exists, don't release
-tag_exists=`git tag | grep $version | wc -l`
+tag_exists=`git tag | grep ^$version$ | wc -l`
 if [ $tag_exists -ne "0" ]
 then
     echo "Skipping release as tag already exists"

--- a/.github/scripts/tag.sh
+++ b/.github/scripts/tag.sh
@@ -113,6 +113,7 @@ tag_service "controllers/energenie" "energenie-controller"
 tag_service "controllers/harmony" "harmony-controller"
 tag_service "controllers/lifx" "lifx-controller"
 tag_service "controllers/macro" "macro-controller"
+tag_service "controllers/network" "network-controller"
 tag_service "controllers/node" "node-controller"
 tag_service "controllers/zigbee" "zigbee-controller"
 


### PR DESCRIPTION
Resolves #91 
- Add new service `network-controller` to tag script.
- Fix bug caused by #330 where it would find tags for services rather than PowerPi itself.