### PR TITLE
#341/#285/#297 Perform ping when turning on computer device

### DIFF
--- a/PowerPi.code-workspace
+++ b/PowerPi.code-workspace
@@ -136,7 +136,8 @@
                 "type": "shell",
                 "presentation": {
                     "reveal": "always"
-                }
+                },
+                "problemMatcher": []
             }
         ],
         "inputs": [

--- a/common/python/powerpi_common/device/device.py
+++ b/common/python/powerpi_common/device/device.py
@@ -147,7 +147,7 @@ class Device(BaseDevice, DeviceChangeEventConsumer):
                 if success is not False:
                     self.state = new_status
                 else:
-                    self.log_info(f'Failed to {new_status} device {self}')
+                    self.log_info(f'Failed to turn {new_status} device {self}')
         except Exception as ex:
             self.log_exception(ex)
             self.state = DeviceStatus.UNKNOWN

--- a/common/python/pyproject.toml
+++ b/common/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "powerpi-common"
-version = "0.3.2"
+version = "0.3.3"
 description = "PowerPi Common Python Library"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/common/python/tests/event/test_consumer.py
+++ b/common/python/tests/event/test_consumer.py
@@ -1,10 +1,8 @@
-from datetime import datetime
-
 import pytest
+from powerpi_common_test.base import BaseTest
 from pytest_mock import MockerFixture
 
 from powerpi_common.event.consumer import EventConsumer
-from powerpi_common_test.base import BaseTest
 
 
 class EventHandlerImpl:
@@ -40,7 +38,7 @@ class TestEventConsumer(BaseTest):
         )
 
     @pytest.mark.parametrize('timestamp,expected', [
-        (datetime.now().timestamp() * 1000, 2),
+        (1685910908 * 1000, 2),
         (None, 2),
         (0, 0)
     ])

--- a/controllers/network/network_controller/device/computer.py
+++ b/controllers/network/network_controller/device/computer.py
@@ -24,6 +24,7 @@ class ComputerDevice(Device, PollableMixin):
         mac: str,
         ip: str = None,
         hostname: str = None,
+        delay: int = 1,
         **kwargs
     ):
         # pylint: disable=too-many-arguments
@@ -32,6 +33,7 @@ class ComputerDevice(Device, PollableMixin):
 
         self.__mac_address = mac
         self.__network_address = ip if ip is not None else hostname
+        self.__delay = delay
 
     @property
     def mac_address(self):
@@ -53,7 +55,7 @@ class ComputerDevice(Device, PollableMixin):
         for _ in range(0, 4):
             send_magic_packet(self.__mac_address)
 
-            await sleep(1)
+            await sleep(self.__delay)
 
             if await self.__is_alive():
                 return True

--- a/controllers/network/network_controller/device/computer.py
+++ b/controllers/network/network_controller/device/computer.py
@@ -42,9 +42,9 @@ class ComputerDevice(Device, PollableMixin):
         return self.__network_address
 
     async def poll(self):
-        result = await async_ping(self.__network_address, count=4, interval=0.2, timeout=2)
+        is_alive = await self.__is_alive(4)
 
-        new_state = DeviceStatus.ON if result.is_alive else DeviceStatus.OFF
+        new_state = DeviceStatus.ON if is_alive else DeviceStatus.OFF
 
         if new_state != self.state:
             self.state = new_state
@@ -53,8 +53,18 @@ class ComputerDevice(Device, PollableMixin):
         for _ in range(0, 4):
             send_magic_packet(self.__mac_address)
 
-            await sleep(0.2)
+            await sleep(1)
+
+            if await self.__is_alive():
+                return True
+
+        return False
 
     async def _turn_off(self):
         # do nothing as this will be handled by the shutdown service running on that computer
         return False
+
+    async def __is_alive(self, count=1):
+        result = await async_ping(self.__network_address, count=count, interval=0.2, timeout=2)
+
+        return result.is_alive

--- a/controllers/network/network_controller/device/computer.py
+++ b/controllers/network/network_controller/device/computer.py
@@ -24,7 +24,7 @@ class ComputerDevice(Device, PollableMixin):
         mac: str,
         ip: str = None,
         hostname: str = None,
-        delay: int = 1,
+        delay: int = 10,
         **kwargs
     ):
         # pylint: disable=too-many-arguments

--- a/controllers/network/pyproject.toml
+++ b/controllers/network/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "network_controller"
-version = "0.1.0"
+version = "0.1.1"
 description = "PowerPi Network Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/network/tests/device/test_computer.py
+++ b/controllers/network/tests/device/test_computer.py
@@ -57,7 +57,6 @@ class TestComputer(DeviceTestBaseNew, PollableMixinTestBaseNew):
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize('attempts,success', [(1, True), (3, True), (5, False)])
-    @pytest.mark.timeout(60)
     async def test_turn_on(
         self,
         subject: ComputerDevice,
@@ -141,6 +140,6 @@ class TestComputer(DeviceTestBaseNew, PollableMixinTestBaseNew):
     ):
         return ComputerDevice(
             powerpi_config, powerpi_logger, powerpi_mqtt_client,
-            mac='00:00:00:00:00', hostname='mycomputer.home',
+            mac='00:00:00:00:00', hostname='mycomputer.home', delay=0.1,
             name='computer', poll_frequency=120
         )

--- a/controllers/network/tests/device/test_computer.py
+++ b/controllers/network/tests/device/test_computer.py
@@ -56,22 +56,44 @@ class TestComputer(DeviceTestBaseNew, PollableMixinTestBaseNew):
         assert subject.state == state
 
     @pytest.mark.asyncio
-    async def test_turn_on(self, subject: ComputerDevice):
+    @pytest.mark.parametrize('attempts,success', [(1, True), (3, True), (5, False)])
+    @pytest.mark.timeout(60)
+    async def test_turn_on(
+        self,
+        subject: ComputerDevice,
+        mocker: MockerFixture,
+        attempts: int,
+        success: bool
+    ):
+        # pylint: disable=arguments-differ
+
         assert subject.state == DeviceStatus.UNKNOWN
+
+        is_alive = [i == attempts for i in range(1, attempts + 1)]
+
+        host = mocker.MagicMock()
+        type(host).is_alive = PropertyMock(side_effect=is_alive)
+
+        mocker.patch(
+            'network_controller.device.computer.async_ping',
+            return_value=host
+        )
 
         with patch('network_controller.device.computer.send_magic_packet') as wol:
             await subject.turn_on()
 
-            wol.assert_has_calls([
-                call('00:00:00:00:00'),
-                call('00:00:00:00:00'),
-                call('00:00:00:00:00'),
+            calls = [
                 call('00:00:00:00:00')
-            ])
+                for _ in range(0, min(4, attempts))
+            ]
+            wol.assert_has_calls(calls)
 
-        assert subject.state == DeviceStatus.ON
+        if success:
+            assert subject.state == DeviceStatus.ON
+        else:
+            assert subject.state == DeviceStatus.UNKNOWN
 
-    @pytest.mark.asyncio
+    @ pytest.mark.asyncio
     async def test_turn_off(self, subject: ComputerDevice):
         assert subject.state == DeviceStatus.UNKNOWN
 
@@ -79,7 +101,7 @@ class TestComputer(DeviceTestBaseNew, PollableMixinTestBaseNew):
 
         assert subject.state == DeviceStatus.UNKNOWN
 
-    @pytest.mark.asyncio
+    @ pytest.mark.asyncio
     async def test_change_message(
         self,
         subject: ComputerDevice,
@@ -91,6 +113,14 @@ class TestComputer(DeviceTestBaseNew, PollableMixinTestBaseNew):
         assert subject.state == DeviceStatus.UNKNOWN
 
         mocker.patch.object(powerpi_config, 'message_age_cutoff', 120)
+
+        host = mocker.Mock()
+        type(host).is_alive = PropertyMock(return_value=True)
+
+        mocker.patch(
+            'network_controller.device.computer.async_ping',
+            return_value=host
+        )
 
         message = {
             'state': 'on',

--- a/controllers/node/Dockerfile
+++ b/controllers/node/Dockerfile
@@ -31,8 +31,14 @@ RUN ln -s ../../common/python/.venv .venv \
 FROM python:3.9.16-slim AS run-image
 LABEL description="PowerPi Node Controller"
 
+RUN apt-get update \
+    && apt-get install -y libcap2-bin
+
 ENV PATH="/usr/src/app/venv/bin:$PATH"
 ENV TZ="UTC"
+
+# ensure the controller can run ping
+RUN setcap cap_net_raw+ep /usr/local/bin/python3.9
 
 RUN groupadd -g 997 gpio \
     && groupadd -g 998 i2c \

--- a/controllers/node/node_controller/device/container.py
+++ b/controllers/node/node_controller/device/container.py
@@ -1,4 +1,5 @@
 from dependency_injector import providers
+
 from node_controller.config import NodeConfig
 from node_controller.pijuice import PiJuiceImpl
 from node_controller.pwm_fan import PWMFanController
@@ -54,7 +55,8 @@ def add_devices(container):
             config=container.common.config,
             logger=container.common.logger,
             mqtt_client=container.common.mqtt_client,
-            service_provider=container.common.device.service_provider,
+            pijuice_interface_factory=device_container.pijuice_interface.provider,
+            pwm_fan_controller_factory=device_container.pwm_fan_controller.provider,
             shutdown=container.shutdown
         )
     )

--- a/controllers/node/node_controller/device/remote_node.py
+++ b/controllers/node/node_controller/device/remote_node.py
@@ -22,7 +22,7 @@ class RemoteNodeDevice(Device, PollableMixin):
         self.__ip = ip
 
     async def poll(self):
-        result = await async_ping(self.__ip, count=4, interval=0.2, timeout=2, privileged=False)
+        result = await async_ping(self.__ip, count=4, interval=0.2, timeout=2)
 
         new_state = DeviceStatus.ON if result.is_alive else DeviceStatus.OFF
 

--- a/controllers/node/pyproject.toml
+++ b/controllers/node/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "node_controller"
-version = "0.1.1"
+version = "0.1.2"
 description = "PowerPi Node Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/node/tests/conftest.py
+++ b/controllers/node/tests/conftest.py
@@ -1,0 +1,6 @@
+# pylint: disable=unused-import
+
+import pytest
+from powerpi_common_test.fixture import (powerpi_config, powerpi_logger,
+                                         powerpi_mqtt_client,
+                                         powerpi_mqtt_producer)

--- a/controllers/node/tests/device/test_factory.py
+++ b/controllers/node/tests/device/test_factory.py
@@ -1,9 +1,10 @@
 from unittest.mock import MagicMock, PropertyMock
 
 import pytest
-from node_controller.device.factory import NodeDeviceFactory
 from powerpi_common.device.types import DeviceConfigType
 from pytest_mock import MockerFixture
+
+from node_controller.device.factory import NodeDeviceFactory
 
 
 class TestNodeDeviceFactory:
@@ -37,12 +38,11 @@ class TestNodeDeviceFactory:
         assert result == 'sensor'
 
     @pytest.fixture
-    def mock_config(self, mocker: MockerFixture):
-        config = mocker.Mock()
+    def mock_config(self, powerpi_config):
+        type(powerpi_config).node_hostname = PropertyMock(
+            return_value='NODE123')
 
-        type(config).node_hostname = PropertyMock(return_value='NODE123')
-
-        return config
+        return powerpi_config
 
     @pytest.fixture
     def mock_service_provider(self, mocker: MockerFixture):

--- a/controllers/node/tests/device/test_local_node.py
+++ b/controllers/node/tests/device/test_local_node.py
@@ -1,5 +1,5 @@
 from asyncio import Future
-from typing import Callable, Dict, List, Tuple, Union
+from typing import Any, Callable, Dict, List, Tuple, Union
 from unittest.mock import PropertyMock, call
 
 import pytest
@@ -7,14 +7,13 @@ from powerpi_common.device import DeviceStatus
 from powerpi_common_test.device import DeviceTestBaseNew
 from powerpi_common_test.device.mixin import (InitialisableMixinTestBaseNew,
                                               PollableMixinTestBaseNew)
-from powerpi_common_test.mqtt.mqtt import mock_producer
 from powerpi_common_test.sensor.mixin import BatteryMixinTestBaseNew
 from pytest_mock import MockerFixture
 
 from node_controller.device.local_node import LocalNodeDevice
 
 SubjectBuilder = Callable[
-    [Union[Dict, None], Union[Dict, None]],
+    [Union[Dict[str, Any], None], Union[Dict[str, Any], None]],
     LocalNodeDevice
 ]
 
@@ -326,7 +325,7 @@ class TestLocalNode(
     ):
         # pylint: disable=too-many-arguments
 
-        def build(pijuice: Union[Dict, None], pwm_fan: Union[Dict, None]):
+        def build(pijuice: Union[Dict[str, Any], None], pwm_fan: Union[Dict[str, Any], None]):
             return LocalNodeDevice(
                 powerpi_config,
                 powerpi_logger,

--- a/controllers/node/tests/device/test_remote_node.py
+++ b/controllers/node/tests/device/test_remote_node.py
@@ -1,37 +1,41 @@
 from datetime import datetime
-from typing import Tuple
 from unittest.mock import PropertyMock
 
 import pytest
-from node_controller.device.remote_node import RemoteNodeDevice
 from powerpi_common.device import DeviceStatus
-from powerpi_common_test.device import DeviceTestBase
-from powerpi_common_test.device.mixin import PollableMixinTestBase
+from powerpi_common_test.device import DeviceTestBaseNew
+from powerpi_common_test.device.mixin import PollableMixinTestBaseNew
 from pytest_mock import MockerFixture
 
+from node_controller.device.remote_node import RemoteNodeDevice
 
-class TestRemoteNodeDevice(DeviceTestBase, PollableMixinTestBase):
-    def get_subject(self, _: MockerFixture):
-        self.ip = '127.0.0.1'
 
-        return RemoteNodeDevice(
-            self.config,
-            self.logger,
-            self.mqtt_client,
-            self.ip,
-            name='remote',
-            poll_frequency=60
+class TestRemoteNodeDevice(DeviceTestBaseNew, PollableMixinTestBaseNew):
+    @pytest.mark.asyncio
+    async def test_poll_implemented(self, subject: RemoteNodeDevice, mocker: MockerFixture):
+        # pylint: disable=arguments-differ
+
+        host = mocker.MagicMock()
+        type(host).is_alive = PropertyMock(return_value=True)
+
+        mocker.patch(
+            'node_controller.device.remote_node.async_ping',
+            return_value=host
         )
 
-    @pytest.mark.parametrize('states', [
+        await subject.poll()
+
+    @pytest.mark.parametrize('is_alive,state', [
         (False, DeviceStatus.OFF),
         (True, DeviceStatus.ON)
     ])
-    async def test_poll_ping(self, mocker: MockerFixture, states: Tuple[bool, str]):
-        is_alive, state = states
-
-        subject = self.create_subject(mocker)
-
+    async def test_poll_ping(
+        self,
+        subject: RemoteNodeDevice,
+        mocker: MockerFixture,
+        is_alive: bool,
+        state: DeviceStatus
+    ):
         assert subject.state == DeviceStatus.UNKNOWN
 
         host = mocker.Mock()
@@ -47,9 +51,7 @@ class TestRemoteNodeDevice(DeviceTestBase, PollableMixinTestBase):
         assert subject.state == state
 
     @pytest.mark.asyncio
-    async def test_turn_on(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
+    async def test_turn_on(self, subject: RemoteNodeDevice):
         assert subject.state == DeviceStatus.UNKNOWN
 
         await subject.turn_on()
@@ -57,9 +59,7 @@ class TestRemoteNodeDevice(DeviceTestBase, PollableMixinTestBase):
         assert subject.state == DeviceStatus.UNKNOWN
 
     @pytest.mark.asyncio
-    async def test_turn_off(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
+    async def test_turn_off(self, subject: RemoteNodeDevice):
         assert subject.state == DeviceStatus.UNKNOWN
 
         await subject.turn_off()
@@ -68,12 +68,18 @@ class TestRemoteNodeDevice(DeviceTestBase, PollableMixinTestBase):
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize('times', [1, 2])
-    async def test_change_message(self, mocker: MockerFixture, times: int):
-        subject = self.create_subject(mocker)
+    async def test_change_message(
+        self,
+        subject: RemoteNodeDevice,
+        powerpi_config,
+        mocker: MockerFixture,
+        times: int
+    ):
+        # pylint: disable=arguments-differ
 
         assert subject.state == DeviceStatus.UNKNOWN
 
-        mocker.patch.object(self.config, 'message_age_cutoff', 120)
+        mocker.patch.object(powerpi_config, 'message_age_cutoff', 120)
 
         message = {
             'state': 'on',
@@ -84,3 +90,21 @@ class TestRemoteNodeDevice(DeviceTestBase, PollableMixinTestBase):
             await subject.on_message(message, subject.name, 'change')
 
             assert subject.state == DeviceStatus.UNKNOWN
+            assert subject.state == DeviceStatus.UNKNOWN
+            assert subject.state == DeviceStatus.UNKNOWN
+
+    @pytest.fixture
+    def subject(
+        self,
+        powerpi_config,
+        powerpi_logger,
+        powerpi_mqtt_client
+    ):
+        return RemoteNodeDevice(
+            powerpi_config,
+            powerpi_logger,
+            powerpi_mqtt_client,
+            '127.0.0.1',
+            name='remote',
+            poll_frequency=60
+        )

--- a/controllers/node/tests/device/test_remote_node.py
+++ b/controllers/node/tests/device/test_remote_node.py
@@ -25,6 +25,7 @@ class TestRemoteNodeDevice(DeviceTestBaseNew, PollableMixinTestBaseNew):
 
         await subject.poll()
 
+    @pytest.mark.asyncio
     @pytest.mark.parametrize('is_alive,state', [
         (False, DeviceStatus.OFF),
         (True, DeviceStatus.ON)

--- a/controllers/node/tests/pijuice/test_pijuice.py
+++ b/controllers/node/tests/pijuice/test_pijuice.py
@@ -1,9 +1,10 @@
 from unittest.mock import MagicMock, PropertyMock
 
 import pytest
+from pytest_mock import MockerFixture
+
 from node_controller.pijuice import PiJuiceImpl
 from node_controller.pijuice.dummy import DummyPiJuiceInterface
-from pytest_mock import MockerFixture
 
 
 class TestPijuiceImpl:
@@ -115,14 +116,12 @@ class TestPijuiceImpl:
         return PiJuiceImpl(mock_config, mocker.Mock())
 
     @pytest.fixture
-    def mock_config(self, mocker: MockerFixture):
-        config = mocker.Mock()
+    def mock_config(self, powerpi_config):
+        type(powerpi_config).device_fatal = PropertyMock(return_value=True)
+        type(powerpi_config).i2c_device = '/dev/i2c-2'
+        type(powerpi_config).i2c_address = 0x14
 
-        type(config).device_fatal = PropertyMock(return_value=True)
-        type(config).i2c_device = '/dev/i2c-2'
-        type(config).i2c_address = 0x14
-
-        return config
+        return powerpi_config
 
     @pytest.fixture
     def mock_pijuice(self, mocker: MockerFixture):

--- a/controllers/node/tests/pwm_fan/test_pwm_fan.py
+++ b/controllers/node/tests/pwm_fan/test_pwm_fan.py
@@ -2,20 +2,21 @@ from typing import List, Tuple
 from unittest.mock import AsyncMock, MagicMock, PropertyMock
 
 import pytest
+from pytest_mock import MockerFixture
+
 from node_controller.pwm_fan import PWMFanController
 from node_controller.pwm_fan.dummy import DummyPWMFanInterface
-from pytest_mock import MockerFixture
 
 
 class TestPWMFanController:
     def test_no_pwm_fan(
         self,
-        mock_config: MagicMock,
+        powerpi_config: MagicMock,
         mocker: MockerFixture
     ):
         with pytest.raises(RuntimeError):
             _ = PWMFanController(
-                mock_config,
+                powerpi_config,
                 mocker.Mock(),
                 mocker.Mock(),
                 None
@@ -23,13 +24,13 @@ class TestPWMFanController:
 
     def test_no_pwm_fan_gets_dummy(
         self,
-        mock_config: MagicMock,
+        powerpi_config: MagicMock,
         mocker: MockerFixture
     ):
-        type(mock_config).device_fatal = PropertyMock(return_value=False)
+        type(powerpi_config).device_fatal = PropertyMock(return_value=False)
 
         subject = PWMFanController(
-            mock_config,
+            powerpi_config,
             mocker.Mock(),
             mocker.Mock(),
             None
@@ -120,25 +121,17 @@ class TestPWMFanController:
     def subject(
         self,
         mock_rpi: MagicMock,
-        mock_config: MagicMock,
+        powerpi_config: MagicMock,
         mock_pijuice: MagicMock,
         mocker: MockerFixture
     ):
         # pylint: disable=unused-argument
         return PWMFanController(
-            mock_config,
+            powerpi_config,
             mocker.Mock(),
             mocker.Mock(),
             mock_pijuice
         )
-
-    @pytest.fixture
-    def mock_config(self, mocker: MockerFixture):
-        config = mocker.Mock()
-
-        type(config).device_fatal = PropertyMock(return_value=True)
-
-        return config
 
     @pytest.fixture
     def mock_pijuice(self, mocker: MockerFixture):

--- a/controllers/node/tests/services/test_shutdown.py
+++ b/controllers/node/tests/services/test_shutdown.py
@@ -1,16 +1,16 @@
 from unittest.mock import MagicMock, PropertyMock
 
 import pytest
-from node_controller.services.shutdown import ShutdownService
 from powerpi_common.device import DeviceStatus
-from powerpi_common_test.mqtt.mqtt import mock_producer
 from pytest_mock import MockerFixture
+
+from node_controller.services.shutdown import ShutdownService
 
 
 class TestShutdownService:
     def test_shutdown(
         self,
-        mock_mqtt_producer: MagicMock,
+        powerpi_mqtt_producer: MagicMock,
         subject: ShutdownService,
         mocker: MockerFixture
     ):
@@ -19,19 +19,11 @@ class TestShutdownService:
 
         subject.shutdown(device)
 
-        mock_mqtt_producer.assert_called_once_with(
+        powerpi_mqtt_producer.assert_called_once_with(
             'device/TestDevice/change',
             {'state': DeviceStatus.OFF}
         )
 
     @pytest.fixture
-    def subject(self, mock_mqtt_client: MagicMock, mocker: MockerFixture):
-        return ShutdownService(mocker.Mock(), mock_mqtt_client)
-
-    @pytest.fixture
-    def mock_mqtt_client(self, mocker: MockerFixture):
-        return mocker.Mock()
-
-    @pytest.fixture
-    def mock_mqtt_producer(self, mock_mqtt_client: MagicMock, mocker: MockerFixture):
-        return mock_producer(mocker, mock_mqtt_client)
+    def subject(self, powerpi_logger, powerpi_mqtt_client):
+        return ShutdownService(powerpi_logger, powerpi_mqtt_client)

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -51,7 +51,7 @@ dependencies:
     version: 0.1.0
     condition: global.network
   - name: node-controller
-    version: 0.1.2
+    version: 0.1.3
     condition: global.node
   - name: zigbee-controller
     version: 0.1.3

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: powerpi
 description: A Helm chart for deploying the PowerPi home automation stack
 type: application
-version: 0.2.0
-appVersion: 0.2.0
+version: 0.2.1
+appVersion: 0.2.1
 dependencies:
   # services
   - name: clacks-config

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -7,7 +7,7 @@ appVersion: 0.2.1
 dependencies:
   # services
   - name: clacks-config
-    version: 0.1.6
+    version: 0.1.7
     condition: global.config
   - name: database
     version: 0.1.3

--- a/kubernetes/charts/clacks-config/Chart.yaml
+++ b/kubernetes/charts/clacks-config/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: clacks-config
 description: A Helm chart for the PowerPi clacks-config configuration service
 type: application
-version: 0.1.6
-appVersion: 0.3.5
+version: 0.1.7
+appVersion: 0.3.6

--- a/kubernetes/charts/network-controller/Chart.yaml
+++ b/kubernetes/charts/network-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: network-controller
 description: A Helm chart for the PowerPi Network device controller
 type: application
-version: 0.1.0
-appVersion: 0.1.0
+version: 0.1.1
+appVersion: 0.1.1

--- a/kubernetes/charts/node-controller/Chart.yaml
+++ b/kubernetes/charts/node-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: node-controller
 description: A Helm chart for the PowerPi cluster node monitoring controller
 type: application
-version: 0.1.2
-appVersion: 0.1.1
+version: 0.1.3
+appVersion: 0.1.2

--- a/services/clacks-config/package.json
+++ b/services/clacks-config/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@powerpi/clacks-config",
-    "version": "0.3.5",
+    "version": "0.3.6",
     "description": "PowerPi config retrieval from GitHub pushing to message queue",
     "private": true,
     "license": "GPL-3.0-only",

--- a/services/clacks-config/src/schema/devices/network/Computer.schema.json
+++ b/services/clacks-config/src/schema/devices/network/Computer.schema.json
@@ -29,6 +29,12 @@
         "mac": {
             "description": "The MAC address where the Wake-On-LAN packet can be sent",
             "$ref": "https://github.com/TWilkin/powerpi/tree/master/services/clacks-config/src/schema/common/MACAddress.schema.json"
+        },
+        "delay": {
+            "description": "The amount of time (in seconds) to wait between WOL packets to check if the computer has booted",
+            "type": "number",
+            "minimum": 1,
+            "maximum": 60
         }
     },
     "required": ["mac"],

--- a/services/clacks-config/test/services/validator/devices/NetworkDevicesConfigFile.test.ts
+++ b/services/clacks-config/test/services/validator/devices/NetworkDevicesConfigFile.test.ts
@@ -9,6 +9,7 @@ describe("Network Devices", () => {
                     name: "Computer",
                     mac: "00:AA:BB:CC:DD:EE",
                     ip: "127.0.0.1",
+                    delay: 10,
                 },
             ],
         });
@@ -74,5 +75,20 @@ describe("Network Devices", () => {
                     },
                 ],
             }));
+
+        ["test", 0, 61].forEach((delay) =>
+            test(`Bad delay ${delay}`, () =>
+                testInvalid({
+                    devices: [
+                        {
+                            type: "computer",
+                            name: "Computer",
+                            mac: "00:AA:BB:CC:DD:EE",
+                            hostname: "computer.example.com",
+                            delay,
+                        },
+                    ],
+                }))
+        );
     });
 });


### PR DESCRIPTION
- Resolves #341
  - Add a ping step in `_turn_on` method of `ComputerDevice`.
  - Make delay between pings configurable.
 - Fix for ping issue in `node-controller` (#285) by applying same fix as `network-controller` used.
 - Upgrade `node-controller` tests to use fixtures (#297)
 - Fix bad log message in `powerpi-common` which will print when a device failed to turn on/off.