### PR TITLE
#237 Convert harmony-controller and energenie-controller tests to fixtures

### DIFF
--- a/common/pytest/poetry.lock
+++ b/common/pytest/poetry.lock
@@ -2,14 +2,14 @@
 
 [[package]]
 name = "astroid"
-version = "2.15.0"
+version = "2.15.5"
 description = "An abstract syntax tree for Python with inference support."
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "astroid-2.15.0-py3-none-any.whl", hash = "sha256:e3e4d0ffc2d15d954065579689c36aac57a339a4679a679579af6401db4d3fdb"},
-    {file = "astroid-2.15.0.tar.gz", hash = "sha256:525f126d5dc1b8b0b6ee398b33159105615d92dc4a17f2cd064125d57f6186fa"},
+    {file = "astroid-2.15.5-py3-none-any.whl", hash = "sha256:078e5212f9885fa85fbb0cf0101978a336190aadea6e13305409d099f71b2324"},
+    {file = "astroid-2.15.5.tar.gz", hash = "sha256:1039262575027b441137ab4a62a793a9b43defb42c32d5670f38686207cd780f"},
 ]
 
 [package.dependencies]
@@ -19,24 +19,6 @@ wrapt = [
     {version = ">=1.11,<2", markers = "python_version < \"3.11\""},
     {version = ">=1.14,<2", markers = "python_version >= \"3.11\""},
 ]
-
-[[package]]
-name = "attrs"
-version = "22.1.0"
-description = "Classes Without Boilerplate"
-category = "main"
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
-    {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
-]
-
-[package.extras]
-dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
-docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
-tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
-tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "autopep8"
@@ -312,18 +294,18 @@ files = [
 
 [[package]]
 name = "pylint"
-version = "2.17.1"
+version = "2.17.4"
 description = "python code static checker"
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "pylint-2.17.1-py3-none-any.whl", hash = "sha256:8660a54e3f696243d644fca98f79013a959c03f979992c1ab59c24d3f4ec2700"},
-    {file = "pylint-2.17.1.tar.gz", hash = "sha256:d4d009b0116e16845533bc2163493d6681846ac725eab8ca8014afb520178ddd"},
+    {file = "pylint-2.17.4-py3-none-any.whl", hash = "sha256:7a1145fb08c251bdb5cca11739722ce64a63db479283d10ce718b2460e54123c"},
+    {file = "pylint-2.17.4.tar.gz", hash = "sha256:5dcf1d9e19f41f38e4e85d10f511e5b9c35e1aa74251bf95cdd8cb23584e2db1"},
 ]
 
 [package.dependencies]
-astroid = ">=2.15.0,<=2.17.0-dev0"
+astroid = ">=2.15.4,<=2.17.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
     {version = ">=0.2", markers = "python_version < \"3.11\""},
@@ -357,18 +339,17 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
-version = "7.2.2"
+version = "7.3.1"
 description = "pytest: simple powerful testing with Python"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.2.2-py3-none-any.whl", hash = "sha256:130328f552dcfac0b1cec75c12e3f005619dc5f874f0a06e8ff7263f0ee6225e"},
-    {file = "pytest-7.2.2.tar.gz", hash = "sha256:c99ab0c73aceb050f68929bc93af19ab6db0558791c6a0715723abe9d0ade9d4"},
+    {file = "pytest-7.3.1-py3-none-any.whl", hash = "sha256:3799fa815351fea3a5e96ac7e503a96fa51cc9942c3753cda7651b93c1cfa362"},
+    {file = "pytest-7.3.1.tar.gz", hash = "sha256:434afafd78b1d78ed0addf160ad2b77a30d35d4bdf8af234fe621919d9ed15e3"},
 ]
 
 [package.dependencies]
-attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
@@ -377,7 +358,7 @@ pluggy = ">=0.12,<2.0"
 tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
-testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
 name = "pytest-asyncio"
@@ -400,14 +381,14 @@ testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy 
 
 [[package]]
 name = "pytest-cov"
-version = "4.0.0"
+version = "4.1.0"
 description = "Pytest plugin for measuring coverage."
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "pytest-cov-4.0.0.tar.gz", hash = "sha256:996b79efde6433cdbd0088872dbc5fb3ed7fe1578b68cdbba634f14bb8dd0470"},
-    {file = "pytest_cov-4.0.0-py3-none-any.whl", hash = "sha256:2feb1b751d66a8bd934e5edfa2e961d11309dc37b73b0eabe73b5945fee20f6b"},
+    {file = "pytest-cov-4.1.0.tar.gz", hash = "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6"},
+    {file = "pytest_cov-4.1.0-py3-none-any.whl", hash = "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a"},
 ]
 
 [package.dependencies]
@@ -548,4 +529,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "00d2c05bc768edce0cf7f4c55a00be1186096b0ace47e1163a601cf698833666"
+content-hash = "6f365d11828486e9e8488bd992d1820da4f5176b012fb3c309aeb753bf40c2d5"

--- a/common/pytest/powerpi_common_test/fixture/__init__.py
+++ b/common/pytest/powerpi_common_test/fixture/__init__.py
@@ -1,4 +1,5 @@
 from .common import (powerpi_config, powerpi_logger, powerpi_scheduler,
                      powerpi_service_provider)
+from .device import powerpi_device_manager
 from .mqtt import powerpi_mqtt_client, powerpi_mqtt_producer
 from .variable import powerpi_variable_manager

--- a/common/pytest/powerpi_common_test/fixture/device.py
+++ b/common/pytest/powerpi_common_test/fixture/device.py
@@ -1,0 +1,10 @@
+from pytest_mock import MockerFixture
+
+import pytest
+
+
+@pytest.fixture
+def powerpi_device_manager(mocker: MockerFixture):
+    manager = mocker.MagicMock()
+
+    return manager

--- a/common/pytest/pyproject.toml
+++ b/common/pytest/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "powerpi-common-test"
-version = "0.3.1"
+version = "0.4.0"
 description = "PowerPi Common Python Test Library"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]
@@ -8,14 +8,14 @@ repository = "https://github.com/TWilkin/powerpi.git"
 
 [tool.poetry.dependencies]
 python = "^3.9"
-pytest = "~=7.2.2"
+pytest = "~=7.3.1"
 pytest-asyncio = "~=0.21.0"
-pytest-cov = "~=4.0.0"
+pytest-cov = "~=4.1.0"
 pytest-mock = "~=3.10.0"
 
 [tool.poetry.group.dev.dependencies]
 autopep8 = "~=2.0.2"
-pylint = "~=2.17.1"
+pylint = "~=2.17.4"
 
 [build-system]
 requires = ["poetry-core>=1.1.0"]

--- a/controllers/energenie/poetry.lock
+++ b/controllers/energenie/poetry.lock
@@ -51,24 +51,6 @@ wrapt = [
 ]
 
 [[package]]
-name = "attrs"
-version = "22.1.0"
-description = "Classes Without Boilerplate"
-category = "dev"
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
-    {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
-]
-
-[package.extras]
-dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
-docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
-tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
-tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
-
-[[package]]
 name = "autopep8"
 version = "2.0.2"
 description = "A tool that automatically formats Python code to conform to the PEP 8 style guide"
@@ -250,21 +232,6 @@ aiohttp = ["aiohttp"]
 flask = ["flask"]
 pydantic = ["pydantic"]
 yaml = ["pyyaml"]
-
-[[package]]
-name = "dill"
-version = "0.3.5.1"
-description = "serialize all of python"
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*"
-files = [
-    {file = "dill-0.3.5.1-py2.py3-none-any.whl", hash = "sha256:33501d03270bbe410c72639b350e941882a8b0fd55357580fbc873fba0c59302"},
-    {file = "dill-0.3.5.1.tar.gz", hash = "sha256:d75e41f3eff1eee599d738e76ba8f4ad98ea229db8b085318aa2b3333a208c86"},
-]
-
-[package.extras]
-graph = ["objgraph (>=1.7.2)"]
 
 [[package]]
 name = "dill"
@@ -502,7 +469,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "powerpi-common"
-version = "0.2.14"
+version = "0.3.3"
 description = "PowerPi Common Python Library"
 category = "dev"
 optional = false
@@ -523,7 +490,7 @@ url = "../../common/python"
 
 [[package]]
 name = "powerpi-common-test"
-version = "0.2.7"
+version = "0.4.0"
 description = "PowerPi Common Python Test Library"
 category = "dev"
 optional = false
@@ -532,9 +499,9 @@ files = []
 develop = true
 
 [package.dependencies]
-pytest = "~=7.2.2"
+pytest = "~=7.3.1"
 pytest-asyncio = "~=0.21.0"
-pytest-cov = "~=4.0.0"
+pytest-cov = "~=4.1.0"
 pytest-mock = "~=3.10.0"
 
 [package.source]
@@ -620,18 +587,17 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
-version = "7.2.2"
+version = "7.3.1"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.2.2-py3-none-any.whl", hash = "sha256:130328f552dcfac0b1cec75c12e3f005619dc5f874f0a06e8ff7263f0ee6225e"},
-    {file = "pytest-7.2.2.tar.gz", hash = "sha256:c99ab0c73aceb050f68929bc93af19ab6db0558791c6a0715723abe9d0ade9d4"},
+    {file = "pytest-7.3.1-py3-none-any.whl", hash = "sha256:3799fa815351fea3a5e96ac7e503a96fa51cc9942c3753cda7651b93c1cfa362"},
+    {file = "pytest-7.3.1.tar.gz", hash = "sha256:434afafd78b1d78ed0addf160ad2b77a30d35d4bdf8af234fe621919d9ed15e3"},
 ]
 
 [package.dependencies]
-attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
@@ -640,7 +606,7 @@ pluggy = ">=0.12,<2.0"
 tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
-testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
 name = "pytest-asyncio"
@@ -663,14 +629,14 @@ testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy 
 
 [[package]]
 name = "pytest-cov"
-version = "4.0.0"
+version = "4.1.0"
 description = "Pytest plugin for measuring coverage."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "pytest-cov-4.0.0.tar.gz", hash = "sha256:996b79efde6433cdbd0088872dbc5fb3ed7fe1578b68cdbba634f14bb8dd0470"},
-    {file = "pytest_cov-4.0.0-py3-none-any.whl", hash = "sha256:2feb1b751d66a8bd934e5edfa2e961d11309dc37b73b0eabe73b5945fee20f6b"},
+    {file = "pytest-cov-4.1.0.tar.gz", hash = "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6"},
+    {file = "pytest_cov-4.1.0-py3-none-any.whl", hash = "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a"},
 ]
 
 [package.dependencies]

--- a/controllers/energenie/tests/conftest.py
+++ b/controllers/energenie/tests/conftest.py
@@ -1,0 +1,7 @@
+# pylint: disable=unused-import
+
+import pytest
+from powerpi_common_test.fixture import (powerpi_config,
+                                         powerpi_device_manager,
+                                         powerpi_logger, powerpi_mqtt_client,
+                                         powerpi_mqtt_producer)

--- a/controllers/energenie/tests/device/test_energenie_pairing.py
+++ b/controllers/energenie/tests/device/test_energenie_pairing.py
@@ -1,45 +1,36 @@
 import asyncio
-
 from asyncio import Future, sleep
-from unittest.mock import PropertyMock
+from unittest.mock import MagicMock, PropertyMock
+
+import pytest
+from powerpi_common_test.device import DeviceTestBaseNew
 from pytest_mock import MockerFixture
 
-from energenie_controller.device.energenie_pairing import EnergeniePairingDevice
-from powerpi_common_test.device import DeviceTestBase
-from powerpi_common_test.mqtt import mock_producer
+from energenie_controller.device.energenie_pairing import \
+    EnergeniePairingDevice
 
 
-class TestEnergeniePairingDevice(DeviceTestBase):
-    def get_subject(self, mocker: MockerFixture):
-        self.energenie = mocker.Mock()
+class TestEnergeniePairingDevice(DeviceTestBaseNew):
 
-        self.timeout = 0.1
+    __timeout = 0.1
 
-        self.publish = mock_producer(mocker, self.mqtt_client)
-
-        future = Future()
-        future.set_result(None)
-        mocker.patch.object(
-            self.energenie,
-            'start_pair',
-            return_value=future
+    @pytest.mark.asyncio
+    async def test_pair(
+        self,
+        subject: EnergeniePairingDevice,
+        powerpi_config,
+        powerpi_mqtt_producer: MagicMock,
+        energenie: MagicMock
+    ):
+        type(powerpi_config).devices = PropertyMock(
+            return_value={'devices': []}
         )
-
-        return EnergeniePairingDevice(
-            self.config, self.logger, self.mqtt_client, self.energenie,
-            self.timeout, name='EnergeniePairing'
-        )
-
-    async def test_pair(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        type(self.config).devices = PropertyMock(return_value={'devices': []})
 
         assert subject.state == 'unknown'
 
         await subject.pair()
 
-        self.energenie.start_pair.assert_called_once_with(self.timeout)
+        energenie.start_pair.assert_called_once_with(self.__timeout)
 
         assert subject.state == 'off'
 
@@ -47,12 +38,16 @@ class TestEnergeniePairingDevice(DeviceTestBase):
         message = {
             'home_id': 0
         }
-        self.publish.assert_any_call(topic, message)
+        powerpi_mqtt_producer.assert_any_call(topic, message)
 
-    async def test_pair_no_free_home_id(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        type(self.config).devices = PropertyMock(return_value={
+    @pytest.mark.asyncio
+    async def test_pair_no_free_home_id(
+        self,
+        subject: EnergeniePairingDevice,
+        powerpi_config,
+        energenie: MagicMock
+    ):
+        type(powerpi_config).devices = PropertyMock(return_value={
             'devices': [{'type': 'energenie_socket', 'home_id': i} for i in range(0, 17)]
         })
 
@@ -62,19 +57,25 @@ class TestEnergeniePairingDevice(DeviceTestBase):
 
         assert subject.state == 'off'
 
-        self.energenie.start_pair.assert_not_called()
+        energenie.start_pair.assert_not_called()
 
-    async def test_pair_stop(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
+    @pytest.mark.asyncio
+    async def test_pair_stop(
+        self,
+        subject: EnergeniePairingDevice,
+        powerpi_config,
+        energenie: MagicMock,
+        mocker: MockerFixture
+    ):
         sleeper = asyncio.get_event_loop().create_task(sleep(0.2))
         mocker.patch.object(
-            self.energenie,
+            energenie,
             'start_pair',
             return_value=sleeper
         )
 
-        type(self.config).devices = PropertyMock(return_value={'devices': []})
+        type(powerpi_config).devices = PropertyMock(
+            return_value={'devices': []})
 
         assert subject.state == 'unknown'
 
@@ -85,18 +86,21 @@ class TestEnergeniePairingDevice(DeviceTestBase):
         await subject.turn_off()
         await sleeper
 
-        self.energenie.start_pair.assert_called_once_with(self.timeout)
+        energenie.start_pair.assert_called_once_with(self.__timeout)
 
-        self.energenie.stop_pair.assert_called_once_with()
+        energenie.stop_pair.assert_called_once_with()
 
         assert subject.state == 'off'
 
-    async def test_find_free_home_id_ener314(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
+    @pytest.mark.asyncio
+    async def test_find_free_home_id_ener314(
+        self,
+        subject: EnergeniePairingDevice,
+        powerpi_config,
+    ):
+        type(powerpi_config).is_ener314_rt = PropertyMock(return_value=False)
 
-        type(self.config).is_ener314_rt = PropertyMock(return_value=False)
-
-        type(self.config).devices = PropertyMock(return_value={
+        type(powerpi_config).devices = PropertyMock(return_value={
             'devices': [{'type': 'energenie_socket', 'home_id': 0}]
         })
 
@@ -104,12 +108,15 @@ class TestEnergeniePairingDevice(DeviceTestBase):
 
         assert home_id == 0
 
-    async def test_find_free_home_id_ener314_rt(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
+    @pytest.mark.asyncio
+    async def test_find_free_home_id_ener314_rt(
+        self,
+        subject: EnergeniePairingDevice,
+        powerpi_config,
+    ):
+        type(powerpi_config).is_ener314_rt = PropertyMock(return_value=True)
 
-        type(self.config).is_ener314_rt = PropertyMock(return_value=True)
-
-        type(self.config).devices = PropertyMock(return_value={
+        type(powerpi_config).devices = PropertyMock(return_value={
             'devices': [
                 {'type': 'energenie_socket', 'home_id': 10},
                 {'type': 'energenie_socket_group', 'home_id': 0},
@@ -123,15 +130,49 @@ class TestEnergeniePairingDevice(DeviceTestBase):
 
         assert home_id == 2
 
-    async def test_find_free_home_id_ener314_rt_no_free_home_id(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
+    @pytest.mark.asyncio
+    async def test_find_free_home_id_ener314_rt_no_free_home_id(
+        self,
+        subject: EnergeniePairingDevice,
+        powerpi_config,
+    ):
+        type(powerpi_config).is_ener314_rt = PropertyMock(return_value=True)
 
-        type(self.config).is_ener314_rt = PropertyMock(return_value=True)
-
-        type(self.config).devices = PropertyMock(return_value={
+        type(powerpi_config).devices = PropertyMock(return_value={
             'devices': [{'type': 'energenie_socket', 'home_id': i} for i in range(0, 17)]
         })
 
         home_id = subject.find_free_home_id()
 
         assert home_id is None
+
+    @pytest.fixture
+    def subject(
+        self,
+        powerpi_config,
+        powerpi_logger,
+        powerpi_mqtt_client,
+        energenie
+    ):
+        return EnergeniePairingDevice(
+            powerpi_config,
+            powerpi_logger,
+            powerpi_mqtt_client,
+            energenie,
+            self.__timeout,
+            name='EnergeniePairing'
+        )
+
+    @pytest.fixture
+    def energenie(self, mocker: MockerFixture):
+        energenie = mocker.MagicMock()
+
+        future = Future()
+        future.set_result(None)
+        mocker.patch.object(
+            energenie,
+            'start_pair',
+            return_value=future
+        )
+
+        return energenie

--- a/controllers/energenie/tests/device/test_socket.py
+++ b/controllers/energenie/tests/device/test_socket.py
@@ -1,26 +1,39 @@
+import pytest
+from powerpi_common_test.device import DeviceTestBaseNew
 from pytest_mock import MockerFixture
 
 from energenie_controller.device.socket import SocketDevice
-from powerpi_common_test.device import DeviceTestBase
 
 
-class TestSocketDevice(DeviceTestBase):
-    def get_subject(self, mocker: MockerFixture):
-        self.energenie = mocker.Mock()
+class TestSocketDevice(DeviceTestBaseNew):
 
-        return SocketDevice(
-            self.config, self.logger, self.mqtt_client, self.energenie,
-            name='test', retries=2, delay=0
-        )
-
-    async def test_run(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        self.counter = 0
+    @pytest.mark.asyncio
+    async def test_run(self, subject: SocketDevice):
+        counter = 0
 
         def func():
-            self.counter += 1
+            nonlocal counter
+            counter += 1
 
+        # pylint: disable=protected-access
         await subject._run(func)
 
-        assert self.counter == 2
+        assert counter == 2
+
+    @pytest.fixture
+    def subject(
+        self,
+        powerpi_config,
+        powerpi_logger,
+        powerpi_mqtt_client,
+        mocker: MockerFixture
+    ):
+        energenie = mocker.MagicMock()
+
+        return SocketDevice(
+            powerpi_config,
+            powerpi_logger,
+            powerpi_mqtt_client,
+            energenie,
+            name='test', retries=2, delay=0
+        )

--- a/controllers/harmony/poetry.lock
+++ b/controllers/harmony/poetry.lock
@@ -524,21 +524,6 @@ yaml = ["pyyaml"]
 
 [[package]]
 name = "dill"
-version = "0.3.5.1"
-description = "serialize all of python"
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*"
-files = [
-    {file = "dill-0.3.5.1-py2.py3-none-any.whl", hash = "sha256:33501d03270bbe410c72639b350e941882a8b0fd55357580fbc873fba0c59302"},
-    {file = "dill-0.3.5.1.tar.gz", hash = "sha256:d75e41f3eff1eee599d738e76ba8f4ad98ea229db8b085318aa2b3333a208c86"},
-]
-
-[package.extras]
-graph = ["objgraph (>=1.7.2)"]
-
-[[package]]
-name = "dill"
 version = "0.3.6"
 description = "serialize all of python"
 category = "dev"
@@ -912,7 +897,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "powerpi-common"
-version = "0.2.14"
+version = "0.3.3"
 description = "PowerPi Common Python Library"
 category = "dev"
 optional = false
@@ -933,7 +918,7 @@ url = "../../common/python"
 
 [[package]]
 name = "powerpi-common-test"
-version = "0.2.7"
+version = "0.4.0"
 description = "PowerPi Common Python Test Library"
 category = "dev"
 optional = false
@@ -942,9 +927,9 @@ files = []
 develop = true
 
 [package.dependencies]
-pytest = "~=7.2.2"
+pytest = "~=7.3.1"
 pytest-asyncio = "~=0.21.0"
-pytest-cov = "~=4.0.0"
+pytest-cov = "~=4.1.0"
 pytest-mock = "~=3.10.0"
 
 [package.source]
@@ -1114,18 +1099,17 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
-version = "7.2.2"
+version = "7.3.1"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.2.2-py3-none-any.whl", hash = "sha256:130328f552dcfac0b1cec75c12e3f005619dc5f874f0a06e8ff7263f0ee6225e"},
-    {file = "pytest-7.2.2.tar.gz", hash = "sha256:c99ab0c73aceb050f68929bc93af19ab6db0558791c6a0715723abe9d0ade9d4"},
+    {file = "pytest-7.3.1-py3-none-any.whl", hash = "sha256:3799fa815351fea3a5e96ac7e503a96fa51cc9942c3753cda7651b93c1cfa362"},
+    {file = "pytest-7.3.1.tar.gz", hash = "sha256:434afafd78b1d78ed0addf160ad2b77a30d35d4bdf8af234fe621919d9ed15e3"},
 ]
 
 [package.dependencies]
-attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
@@ -1134,7 +1118,7 @@ pluggy = ">=0.12,<2.0"
 tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
-testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
 name = "pytest-asyncio"
@@ -1157,14 +1141,14 @@ testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy 
 
 [[package]]
 name = "pytest-cov"
-version = "4.0.0"
+version = "4.1.0"
 description = "Pytest plugin for measuring coverage."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "pytest-cov-4.0.0.tar.gz", hash = "sha256:996b79efde6433cdbd0088872dbc5fb3ed7fe1578b68cdbba634f14bb8dd0470"},
-    {file = "pytest_cov-4.0.0-py3-none-any.whl", hash = "sha256:2feb1b751d66a8bd934e5edfa2e961d11309dc37b73b0eabe73b5945fee20f6b"},
+    {file = "pytest-cov-4.1.0.tar.gz", hash = "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6"},
+    {file = "pytest_cov-4.1.0-py3-none-any.whl", hash = "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a"},
 ]
 
 [package.dependencies]

--- a/controllers/harmony/pyproject.toml
+++ b/controllers/harmony/pyproject.toml
@@ -26,6 +26,7 @@ powerpi-common-test = {path = "../../common/pytest", develop = true}
 
 [tool.pytest.ini_options]
 addopts = "-v --cov=harmony_controller"
+markers = ["first"]
 
 [build-system]
 requires = ["poetry-core>=1.1.0"]

--- a/controllers/harmony/tests/conftest.py
+++ b/controllers/harmony/tests/conftest.py
@@ -1,6 +1,9 @@
 # pylint: disable=unused-import
 
 import pytest
-from powerpi_common_test.fixture import (powerpi_config, powerpi_logger,
-                                         powerpi_mqtt_client,
+from powerpi_common_test.fixture import (powerpi_config,
+                                         powerpi_device_manager,
+                                         powerpi_logger, powerpi_mqtt_client,
                                          powerpi_mqtt_producer)
+
+from .fixtures import harmony_client

--- a/controllers/harmony/tests/conftest.py
+++ b/controllers/harmony/tests/conftest.py
@@ -1,0 +1,6 @@
+# pylint: disable=unused-import
+
+import pytest
+from powerpi_common_test.fixture import (powerpi_config, powerpi_logger,
+                                         powerpi_mqtt_client,
+                                         powerpi_mqtt_producer)

--- a/controllers/harmony/tests/device/test_harmony_activity.py
+++ b/controllers/harmony/tests/device/test_harmony_activity.py
@@ -1,53 +1,31 @@
 from asyncio import Future
+from unittest.mock import MagicMock
 
+import pytest
+from powerpi_common.device import DeviceManager
+from powerpi_common_test.device import DeviceTestBaseNew
 from pytest_mock import MockerFixture
 
 from harmony_controller.device.harmony_activity import HarmonyActivityDevice
-from powerpi_common_test.device import DeviceTestBase
 
 
-class TestHarmonyActivityDevice(DeviceTestBase):
-    def get_subject(self, mocker: MockerFixture):
-        self.device_manager = mocker.Mock()
-        self.harmony_hub = mocker.Mock()
+class TestHarmonyActivityDevice(DeviceTestBaseNew):
 
-        mocker.patch.object(
-            self.device_manager,
-            'get_device',
-            return_value=self.harmony_hub
-        )
-
-        future = Future()
-        future.set_result(None)
-        for method in ['start_activity', 'turn_on', 'turn_off']:
-            mocker.patch.object(
-                self.harmony_hub,
-                method,
-                return_value=future
-            )
-
-        return HarmonyActivityDevice(
-            self.config, self.logger, self.mqtt_client, self.device_manager, 'hub', 'my activity',
-            name='testactivity'
-        )
-
-    async def test_turn_on_hub(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
+    @pytest.mark.asyncio
+    async def test_turn_on_hub(self, subject: HarmonyActivityDevice, harmony_hub: MagicMock):
         assert subject.state == 'unknown'
 
         await subject.turn_on()
 
         assert subject.state == 'on'
 
-        self.harmony_hub.start_activity.assert_called_once_with('my activity')
+        harmony_hub.start_activity.assert_called_once_with('my activity')
 
-    async def test_turn_on_hub_error(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
+    @pytest.mark.asyncio
+    async def test_turn_on_hub_error(self, subject: HarmonyActivityDevice, harmony_hub: MagicMock):
         async def start_activity(_: str):
-            raise Exception('error')
-        self.harmony_hub.start_activity = start_activity
+            raise KeyError('error')
+        harmony_hub.start_activity = start_activity
 
         assert subject.state == 'unknown'
 
@@ -55,26 +33,66 @@ class TestHarmonyActivityDevice(DeviceTestBase):
 
         assert subject.state == 'unknown'
 
-    async def test_turn_off_hub(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
+    @pytest.mark.asyncio
+    async def test_turn_off_hub(self, subject: HarmonyActivityDevice, harmony_hub: MagicMock):
         assert subject.state == 'unknown'
 
         await subject.turn_off()
 
         assert subject.state == 'off'
 
-        self.harmony_hub.turn_off.assert_called_once()
+        harmony_hub.turn_off.assert_called_once()
 
-    async def test_turn_off_hub_error(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
+    @pytest.mark.asyncio
+    async def test_turn_off_hub_error(self, subject: HarmonyActivityDevice, harmony_hub: MagicMock):
         async def turn_off(_: str):
-            raise Exception('error')
-        self.harmony_hub.turn_off = turn_off
+            raise KeyError('error')
+        harmony_hub.turn_off = turn_off
 
         assert subject.state == 'unknown'
 
         await subject.turn_off()
 
         assert subject.state == 'unknown'
+
+    @pytest.fixture
+    def subject(
+        self,
+        powerpi_config,
+        powerpi_logger,
+        powerpi_mqtt_client,
+        powerpi_device_manager: DeviceManager,
+        harmony_hub,
+        mocker: MockerFixture
+    ):
+        # pylint: disable=too-many-arguments
+        mocker.patch.object(
+            powerpi_device_manager,
+            'get_device',
+            return_value=harmony_hub
+        )
+
+        return HarmonyActivityDevice(
+            powerpi_config,
+            powerpi_logger,
+            powerpi_mqtt_client,
+            powerpi_device_manager,
+            'hub',
+            'my activity',
+            name='testactivity'
+        )
+
+    @pytest.fixture
+    def harmony_hub(self, mocker: MockerFixture):
+        hub = mocker.MagicMock()
+
+        future = Future()
+        future.set_result(None)
+        for method in ['start_activity', 'turn_on', 'turn_off']:
+            mocker.patch.object(
+                hub,
+                method,
+                return_value=future
+            )
+
+        return hub

--- a/controllers/harmony/tests/device/test_harmony_client.py
+++ b/controllers/harmony/tests/device/test_harmony_client.py
@@ -1,9 +1,10 @@
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock
 
 import pytest
-from harmony_controller.device.harmony_client import HarmonyClient
 from pytest import raises
 from pytest_mock import MockerFixture
+
+from harmony_controller.device.harmony_client import HarmonyClient
 
 
 class TestHarmonyClient(object):
@@ -14,6 +15,8 @@ class TestHarmonyClient(object):
 
         mock_api.assert_called_once_with(subject.address)
         mock_api.return_value.connect.assert_called_once()
+
+        # pylint: disable=protected-access
         mock_api.return_value._harmony_client.refresh_info_from_hub.assert_called_once()
 
     @pytest.mark.skip(reason='the property mock isn\'t working')
@@ -25,6 +28,8 @@ class TestHarmonyClient(object):
         result = await subject.get_current_activity()
 
         mock_api.assert_called_once_with(subject.address)
+
+        # pylint: disable=protected-access
         mock_api.return_value._harmony_client.refresh_info_from_hub.assert_called_once()
 
         assert result == -1
@@ -47,7 +52,12 @@ class TestHarmonyClient(object):
         mock_api.assert_called_once_with(subject.address)
         mock_api.return_value.power_off.assert_called_once()
 
-    async def test_reconnect(self, subject: HarmonyClient, mock_api: MagicMock, mocker: MockerFixture):
+    async def test_reconnect(
+        self,
+        subject: HarmonyClient,
+        mock_api: MagicMock,
+        mocker: MockerFixture
+    ):
         mock_connect = AsyncMock()
         mock_connect.return_value = False
         mock_api.return_value.connect = mock_connect
@@ -58,10 +68,8 @@ class TestHarmonyClient(object):
         mock_api.assert_has_calls([mocker.call(subject.address)])
 
     @pytest.fixture
-    def subject(self, mocker: MockerFixture):
-        self.logger = mocker.Mock()
-
-        client = HarmonyClient(self.logger)
+    def subject(self, powerpi_logger):
+        client = HarmonyClient(powerpi_logger)
         client.address = 'my.harmony.address'
 
         return client
@@ -78,6 +86,8 @@ class TestHarmonyClient(object):
 
         mock_client = MagicMock()
         mock_client.refresh_info_from_hub = AsyncMock()
+
+        # pylint: disable=protected-access
         mock_api.return_value._harmony_client = mock_client
 
         return mock_api

--- a/controllers/harmony/tests/device/test_harmony_hub.py
+++ b/controllers/harmony/tests/device/test_harmony_hub.py
@@ -1,37 +1,258 @@
 from asyncio import Future
-from typing import Tuple
+from typing import List, Tuple
+from unittest.mock import MagicMock
 
 import pytest
-from harmony_controller.device.harmony_activity import HarmonyActivityDevice
-from harmony_controller.device.harmony_hub import HarmonyHubDevice
-from powerpi_common_test.device import DeviceTestBase
-from powerpi_common_test.device.mixin import PollableMixinTestBase
+from powerpi_common.device import DeviceManager
+from powerpi_common_test.device import DeviceTestBaseNew
+from powerpi_common_test.device.mixin import PollableMixinTestBaseNew
 from pytest_mock import MockerFixture
 
+from harmony_controller.device.harmony_activity import HarmonyActivityDevice
+from harmony_controller.device.harmony_hub import HarmonyHubDevice
 
-class TestHarmonyHubDevice(DeviceTestBase, PollableMixinTestBase):
-    def get_subject(self, mocker: MockerFixture):
-        self.device_manager = mocker.Mock()
-        self.harmony_client = mocker.Mock()
 
-        self.__hub_name = 'TestHub'
+class TestHarmonyHubDevice(DeviceTestBaseNew, PollableMixinTestBaseNew):
 
-        self.activities = [HarmonyActivityDevice(
-            self.config, self.logger, self.mqtt_client, self.device_manager,
-            name=f'activity{i}',
-            activity_name=f'Test Activity {i}',
-            hub=self.__hub_name
-        ) for i in range(2)]
+    __hub_name = 'TestHub'
 
-        # add an activity from a different hub
-        self.unmatched_activity = HarmonyActivityDevice(
-            self.config, self.logger, self.mqtt_client, self.device_manager,
-            name='wronghubactivity',
-            activity_name=f'Test Activity 0',
-            hub='WrongHub'
+    @pytest.mark.asyncio
+    @pytest.mark.first
+    async def test_config_cache(self, subject: HarmonyHubDevice):
+        # this test has to run first because the cache is not reset
+
+        # will hit client once
+        await subject.start_activity('')
+        await subject.start_activity('')
+
+    def test_activities(self, subject: HarmonyHubDevice):
+        activities = subject.activities
+        assert len(activities) == 2
+        assert all(
+            (activity.hub_name == self.__hub_name for activity in activities)
         )
 
-        self.config_data = {
+    @pytest.mark.asyncio
+    async def test_power_off(
+        self,
+        subject: HarmonyHubDevice,
+        harmony_client: MagicMock,
+        activities: List[HarmonyActivityDevice],
+        unmatched_activity: HarmonyActivityDevice
+    ):
+        assert subject.state == 'unknown'
+        assert activities[0].state == 'unknown'
+        assert activities[1].state == 'unknown'
+        assert unmatched_activity.state == 'unknown'
+
+        await subject.turn_off()
+
+        harmony_client.power_off.assert_called_once()
+
+        assert subject.state == 'off'
+        assert activities[0].state == 'off'
+        assert activities[1].state == 'off'
+        assert unmatched_activity.state == 'unknown'
+
+    @pytest.mark.asyncio
+    async def test_power_off_error(
+        self,
+        subject: HarmonyHubDevice,
+        harmony_client: MagicMock,
+        activities: List[HarmonyActivityDevice],
+        unmatched_activity: HarmonyActivityDevice
+    ):
+        async def power_off():
+            raise KeyError('error')
+
+        harmony_client.power_off = power_off
+
+        assert subject.state == 'unknown'
+        assert activities[0].state == 'unknown'
+        assert activities[1].state == 'unknown'
+        assert unmatched_activity.state == 'unknown'
+
+        await subject.turn_off()
+
+        assert subject.state == 'unknown'
+        assert activities[0].state == 'unknown'
+        assert activities[1].state == 'unknown'
+        assert unmatched_activity.state == 'unknown'
+
+    @pytest.mark.asyncio
+    async def test_start_activity(
+        self,
+        subject: HarmonyHubDevice,
+        harmony_client: MagicMock,
+        activities: List[HarmonyActivityDevice],
+        unmatched_activity: HarmonyActivityDevice,
+        harmony_config
+    ):
+        # pylint: disable=too-many-arguments
+
+        assert subject.state == 'unknown'
+        assert activities[0].state == 'unknown'
+        assert activities[1].state == 'unknown'
+        assert unmatched_activity.state == 'unknown'
+
+        # will be called
+        await subject.start_activity(harmony_config['activity'][1]['label'])
+
+        # will not be called
+        await subject.start_activity('Not An Activity')
+
+        harmony_client.start_activity.assert_called_once_with(
+            harmony_config['activity'][1]['id']
+        )
+
+        # update state of other activities, but not the one we're starting
+        assert subject.state == 'on'
+        assert activities[0].state == 'unknown'
+        assert activities[1].state == 'off'
+        assert unmatched_activity.state == 'unknown'
+
+    @pytest.mark.asyncio
+    async def test_start_activity_error(
+        self,
+        subject: HarmonyHubDevice,
+        harmony_client: MagicMock,
+        activities: List[HarmonyActivityDevice],
+        unmatched_activity: HarmonyActivityDevice,
+        harmony_config
+    ):
+        # pylint: disable=too-many-arguments
+
+        async def start_activity(_: str):
+            raise KeyError('error')
+        harmony_client.start_activity = start_activity
+
+        assert subject.state == 'unknown'
+        assert activities[0].state == 'unknown'
+        assert activities[1].state == 'unknown'
+        assert unmatched_activity.state == 'unknown'
+
+        error = None
+        # pylint: disable=broad-except
+        try:
+            await subject.start_activity(harmony_config['activity'][1]['label'])
+        except KeyError as ex:
+            # we're expecting this
+            error = ex
+        assert error is not None
+
+        assert subject.state == 'unknown'
+        assert activities[0].state == 'unknown'
+        assert activities[1].state == 'unknown'
+        assert unmatched_activity.state == 'unknown'
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('current_state,hub_state,activity1_state,activity2_state', [
+        (-1, 'off', 'off', 'off'),
+        (1000, 'on', 'on', 'off'),
+        (13, 'on', 'off', 'on')
+    ])
+    async def test_poll(
+        self,
+        subject: HarmonyHubDevice,
+        harmony_client: MagicMock,
+        activities: List[HarmonyActivityDevice],
+        unmatched_activity: HarmonyActivityDevice,
+        mocker: MockerFixture,
+        current_state: int,
+        hub_state: str,
+        activity1_state: str,
+        activity2_state: str
+    ):
+        # pylint: disable=too-many-arguments
+
+        current_activity = Future()
+        current_activity.set_result(current_state)
+        mocker.patch.object(
+            harmony_client,
+            'get_current_activity',
+            return_value=current_activity
+        )
+
+        assert subject.state == 'unknown'
+        assert activities[0].state == 'unknown'
+        assert activities[1].state == 'unknown'
+        assert unmatched_activity.state == 'unknown'
+
+        await subject.poll()
+
+        assert subject.state == hub_state
+        assert activities[0].state == activity1_state
+        assert activities[1].state == activity2_state
+        assert unmatched_activity.state == 'unknown'
+
+    @pytest.mark.asyncio
+    async def test_poll_error(
+        self,
+        subject: HarmonyHubDevice,
+        harmony_client: MagicMock,
+        activities: List[HarmonyActivityDevice],
+        unmatched_activity: HarmonyActivityDevice,
+    ):
+        async def get_current_activity():
+            raise KeyError('error')
+        harmony_client.get_current_activity = get_current_activity
+
+        assert subject.state == 'unknown'
+        assert activities[0].state == 'unknown'
+        assert activities[1].state == 'unknown'
+        assert unmatched_activity.state == 'unknown'
+
+        await subject.poll()
+
+        assert subject.state == 'unknown'
+        assert activities[0].state == 'unknown'
+        assert activities[1].state == 'unknown'
+        assert unmatched_activity.state == 'unknown'
+
+    @pytest.fixture
+    def subject(
+        self,
+        powerpi_config,
+        powerpi_logger,
+        powerpi_mqtt_client,
+        powerpi_device_manager: DeviceManager,
+        harmony_client,
+        harmony_config,
+        activities: List[HarmonyActivityDevice],
+        unmatched_activity: HarmonyActivityDevice,
+        mocker: MockerFixture
+    ):
+        # pylint: disable=too-many-arguments
+
+        hub = HarmonyHubDevice(
+            powerpi_config,
+            powerpi_logger,
+            powerpi_mqtt_client,
+            powerpi_device_manager,
+            harmony_client,
+            name=self.__hub_name,
+            poll_frequency=120
+        )
+
+        devices = activities.copy()
+        devices.extend([hub, unmatched_activity])
+        powerpi_device_manager.devices = {
+            device.name: device for device in devices
+        }
+
+        config_result = Future()
+        config_result.set_result(harmony_config)
+        mocker.patch.object(
+            harmony_client,
+            'get_config',
+            return_value=config_result
+        )
+
+        return hub
+
+    @pytest.fixture
+    def harmony_config(self):
+        return {
             'activity': [
                 {'label': 'PowerOff', 'id': -1},
                 {'label': 'Test Activity 0', 'id': 1000},
@@ -39,180 +260,39 @@ class TestHarmonyHubDevice(DeviceTestBase, PollableMixinTestBase):
                 {'label': 'Test Activity 1', 'id': 13}
             ]
         }
-        config_result = Future()
-        config_result.set_result(self.config_data)
-        mocker.patch.object(
-            self.harmony_client,
-            'get_config',
-            return_value=config_result
+
+    @pytest.fixture
+    def activities(
+        self,
+        powerpi_config,
+        powerpi_logger,
+        powerpi_mqtt_client,
+        powerpi_device_manager
+    ):
+        return [HarmonyActivityDevice(
+            powerpi_config,
+            powerpi_logger,
+            powerpi_mqtt_client,
+            powerpi_device_manager,
+            name=f'activity{i}',
+            activity_name=f'Test Activity {i}',
+            hub=self.__hub_name
+        ) for i in range(2)]
+
+    @pytest.fixture
+    def unmatched_activity(
+        self,
+        powerpi_config,
+        powerpi_logger,
+        powerpi_mqtt_client,
+        powerpi_device_manager
+    ):
+        return HarmonyActivityDevice(
+            powerpi_config,
+            powerpi_logger,
+            powerpi_mqtt_client,
+            powerpi_device_manager,
+            name='wronghubactivity',
+            activity_name='Test Activity 0',
+            hub='WrongHub'
         )
-
-        future = Future()
-        future.set_result(None)
-        for method in ['get_current_activity', 'start_activity', 'power_off']:
-            mocker.patch.object(
-                self.harmony_client,
-                method,
-                return_value=future
-            )
-
-        hub = HarmonyHubDevice(
-            self.config, self.logger, self.mqtt_client, self.device_manager, self.harmony_client,
-            name=self.__hub_name, poll_frequency=120
-        )
-
-        # device manager will include other activities and the hub
-        devices = self.activities.copy()
-        devices.extend([hub, self.unmatched_activity])
-        self.device_manager.devices = {
-            device.name: device for device in devices
-        }
-
-        return hub
-
-    @pytest.mark.first
-    async def test_config_cache(self, mocker: MockerFixture):
-        # this test has to run first because the cache is not reset
-        subject = self.create_subject(mocker)
-
-        # will hit client once
-        await subject.start_activity('')
-        await subject.start_activity('')
-
-    def test_activities(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        activities = subject.activities
-        assert len(activities) == 2
-        assert all(
-            (activity.hub_name == self.__hub_name for activity in activities)
-        )
-
-    async def test_power_off(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        assert subject.state == 'unknown'
-        assert self.activities[0].state == 'unknown'
-        assert self.activities[1].state == 'unknown'
-        assert self.unmatched_activity.state == 'unknown'
-
-        await subject.turn_off()
-
-        self.harmony_client.power_off.assert_called_once()
-
-        assert subject.state == 'off'
-        assert self.activities[0].state == 'off'
-        assert self.activities[1].state == 'off'
-        assert self.unmatched_activity.state == 'unknown'
-
-    async def test_power_off_error(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        async def power_off():
-            raise Exception('error')
-        self.harmony_client.power_off = power_off
-
-        assert subject.state == 'unknown'
-        assert self.activities[0].state == 'unknown'
-        assert self.activities[1].state == 'unknown'
-        assert self.unmatched_activity.state == 'unknown'
-
-        await subject.turn_off()
-
-        assert subject.state == 'unknown'
-        assert self.activities[0].state == 'unknown'
-        assert self.activities[1].state == 'unknown'
-        assert self.unmatched_activity.state == 'unknown'
-
-    async def test_start_activity(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        assert subject.state == 'unknown'
-        assert self.activities[0].state == 'unknown'
-        assert self.activities[1].state == 'unknown'
-        assert self.unmatched_activity.state == 'unknown'
-
-        # will be called
-        await subject.start_activity(self.config_data['activity'][1]['label'])
-
-        # will not be called
-        await subject.start_activity('Not An Activity')
-
-        self.harmony_client.start_activity.assert_called_once_with(
-            self.config_data['activity'][1]['id']
-        )
-
-        # update state of other activities, but not the one we're starting
-        assert subject.state == 'on'
-        assert self.activities[0].state == 'unknown'
-        assert self.activities[1].state == 'off'
-        assert self.unmatched_activity.state == 'unknown'
-
-    async def test_start_activity_error(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        async def start_activity(_: str):
-            raise Exception('error')
-        self.harmony_client.start_activity = start_activity
-
-        assert subject.state == 'unknown'
-        assert self.activities[0].state == 'unknown'
-        assert self.activities[1].state == 'unknown'
-        assert self.unmatched_activity.state == 'unknown'
-
-        error = None
-        # pylint: disable=broad-except
-        try:
-            await subject.start_activity(self.config_data['activity'][1]['label'])
-        except Exception as e:
-            # we're expecting this
-            error = e
-        assert error is not None
-
-        assert subject.state == 'unknown'
-        assert self.activities[0].state == 'unknown'
-        assert self.activities[1].state == 'unknown'
-        assert self.unmatched_activity.state == 'unknown'
-
-    @pytest.mark.parametrize('test_state', [(-1, 'off', 'off', 'off'), (1000, 'on', 'on', 'off'), (13, 'on', 'off', 'on')])
-    async def test_poll(self, mocker: MockerFixture, test_state: Tuple[int, str, str, str]):
-        subject = self.create_subject(mocker)
-
-        current_activity = Future()
-        current_activity.set_result(test_state[0])
-        mocker.patch.object(
-            self.harmony_client,
-            'get_current_activity',
-            return_value=current_activity
-        )
-
-        assert subject.state == 'unknown'
-        assert self.activities[0].state == 'unknown'
-        assert self.activities[1].state == 'unknown'
-        assert self.unmatched_activity.state == 'unknown'
-
-        await subject.poll()
-
-        assert subject.state == test_state[1]
-        assert self.activities[0].state == test_state[2]
-        assert self.activities[1].state == test_state[3]
-        assert self.unmatched_activity.state == 'unknown'
-
-    async def test_poll_error(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        async def get_current_activity():
-            raise Exception('error')
-        self.harmony_client.get_current_activity = get_current_activity
-
-        assert subject.state == 'unknown'
-        assert self.activities[0].state == 'unknown'
-        assert self.activities[1].state == 'unknown'
-        assert self.unmatched_activity.state == 'unknown'
-
-        await subject.poll()
-
-        assert subject.state == 'unknown'
-        assert self.activities[0].state == 'unknown'
-        assert self.activities[1].state == 'unknown'
-        assert self.unmatched_activity.state == 'unknown'

--- a/controllers/harmony/tests/fixtures/__init__.py
+++ b/controllers/harmony/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+from .harmony_client import harmony_client

--- a/controllers/harmony/tests/fixtures/harmony_client.py
+++ b/controllers/harmony/tests/fixtures/harmony_client.py
@@ -1,0 +1,20 @@
+from asyncio import Future
+
+import pytest
+from pytest_mock import MockerFixture
+
+
+@pytest.fixture
+def harmony_client(mocker: MockerFixture):
+    client = mocker.MagicMock()
+
+    future = Future()
+    future.set_result(None)
+    for method in ['get_current_activity', 'start_activity', 'power_off']:
+        mocker.patch.object(
+            client,
+            method,
+            return_value=future
+        )
+
+    return client


### PR DESCRIPTION
- Convert `harmony-controller` tests to fixtures
- Convert `energenie-controller` tests to fixtures
- Update python test libraries.