### PR TITLE
#237 Remove old python test bases and rename new test bases

### DIFF
--- a/.github/scripts/check_modified.sh
+++ b/.github/scripts/check_modified.sh
@@ -4,16 +4,9 @@ include_project() {
     local project=$1
     local type=$2
 
-    echo "Enabling tests for $project"
+    echo "Enabling tests for $type project $project"
     echo "$project=true" >> $GITHUB_OUTPUT
-
-    if [[ $type -eq "node" ]]
-    then
-        echo "node=true" >> $GITHUB_OUTPUT
-    elif [[ $type -eq "python" ]]
-    then
-        echo "python=true" >> $GITHUB_OUTPUT
-    fi
+    echo "$type=true" >> $GITHUB_OUTPUT
 }
 
 check_file() {
@@ -32,32 +25,33 @@ check_file() {
 git diff --name-only HEAD^ HEAD > files.txt
 while IFS= read -r file
 do
+    echo .
     echo $file
 
     # updating API requires testing everything using it
     if [[ $file == common/node/api/* ]]
     then
-        include_project "ui" "node"
-        include_project "voice-assistant" "node"
+        include_project "ui" "nodejs"
+        include_project "voice-assistant" "nodejs"
     fi
 
     # updating node common requires testing everything using it
     if [[ $file == common/node/common/* ]]
     then
-        include_project "node_common" "node"
+        include_project "node_common" "nodejs"
 
-        include_project "config-server" "node"
-        include_project "persistence" "node"
-        include_project "voice-assistant" "node"
+        include_project "config-server" "nodejs"
+        include_project "persistence" "nodejs"
+        include_project "voice-assistant" "nodejs"
     fi
 
     # updating node common-test requires testing everything using it
     if [[ $file == common/node/common-test/* ]]
     then
-        include_project "config-server" "node"
-        include_project "persistence" "node"
-        include_project "ui" "node"
-        include_project "voice-assistant" "node"
+        include_project "config-server" "nodejs"
+        include_project "persistence" "nodejs"
+        include_project "ui" "nodejs"
+        include_project "voice-assistant" "nodejs"
     fi
 
     # updating common python/pytest requires retesting everything using python
@@ -86,9 +80,9 @@ do
     check_file $file "controllers/zigbee" "zigbee_controller" "python"
 
     # check the services
-    check_file $file "services/config-server" "config_server" "node"
-    check_file $file "services/persistence" "persistence" "node"
+    check_file $file "services/config-server" "config_server" "nodejs"
+    check_file $file "services/persistence" "persistence" "nodejs"
     check_file $file "services/scheduler" "scheduler" "python"
-    check_file $file "services/ui" "ui" "node"
-    check_file $file "services/voice-assistant" "voice_assistant" "node"
+    check_file $file "services/ui" "ui" "nodejs"
+    check_file $file "services/voice-assistant" "voice_assistant" "nodejs"
 done < files.txt

--- a/.github/scripts/test_python.sh
+++ b/.github/scripts/test_python.sh
@@ -4,6 +4,9 @@ project=$1
 
 echo Testing $project
 
+# required to allow node-controller to build
+export PIJUICE_BUILD_BASE=1
+
 poetry install
 
 poetry run pytest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,16 +20,16 @@ jobs:
         shell: bash
         run: "${GITHUB_WORKSPACE}/.github/scripts/check_modified.sh"
 
-      # setup node
+      # setup node.js
       - name: Install Node.js
-        if: steps.check_modified.outputs.node
+        if: steps.check_modified.outputs.nodejs
         uses: actions/setup-node@v3
         with:
           node-version: 16.x
 
-      # install node dependencies
+      # install node.js dependencies
       - name: Install Node.js dependencies
-        if: steps.check_modified.outputs.node
+        if: steps.check_modified.outputs.nodejs
         run: |
           yarn install
           yarn build:lib

--- a/common/pytest/powerpi_common_test/base.py
+++ b/common/pytest/powerpi_common_test/base.py
@@ -1,9 +1,0 @@
-from abc import ABC, abstractmethod
-
-from pytest_mock import MockerFixture
-
-
-class BaseTest(ABC):
-    @abstractmethod
-    def create_subject(self, _: MockerFixture) -> object:
-        raise NotImplementedError

--- a/common/pytest/powerpi_common_test/device/__init__.py
+++ b/common/pytest/powerpi_common_test/device/__init__.py
@@ -1,3 +1,2 @@
-from .additional_state import (AdditionalStateDeviceTestBase,
-                               AdditionalStateDeviceTestBaseNew)
-from .device import DeviceTestBase, DeviceTestBaseNew
+from .additional_state import AdditionalStateDeviceTestBase
+from .device import DeviceTestBase

--- a/common/pytest/powerpi_common_test/device/additional_state.py
+++ b/common/pytest/powerpi_common_test/device/additional_state.py
@@ -2,120 +2,14 @@ from datetime import datetime
 from typing import Any, Dict
 from unittest.mock import MagicMock
 
-import pytest
 from powerpi_common.device import AdditionalStateDevice
-from pytest_mock import MockerFixture
 
-from .device import DeviceTestBase, DeviceTestBaseNew
+import pytest
+
+from .device import DeviceTestBase
 
 
 class AdditionalStateDeviceTestBase(DeviceTestBase):
-    async def test_on_additional_state_change_implemented(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        additional_state = await subject.on_additional_state_change({})
-        assert additional_state is not None
-
-    def test_additional_state_keys_implemented(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        keys = subject._additional_state_keys()
-
-        assert keys is not None
-        assert len(keys) > 0
-
-    async def test_change_additional_state_message(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        mocker.patch.object(self.config, 'message_age_cutoff', 120)
-
-        key = subject._additional_state_keys()[0]
-        message = {
-            'state': 'on',
-            'timestamp': int(datetime.utcnow().timestamp() * 1000),
-        }
-        message[key] = 1
-
-        assert subject.state == 'unknown'
-        assert subject.additional_state == {}
-
-        await subject.on_message(message, subject.name, 'change')
-
-        assert subject.state == 'on'
-        assert subject.additional_state.get(key, None) == 1
-
-    async def test_state_change_outputs_additional_state(self, mocker: MockerFixture):
-        # capture the published messages
-        self.messages = []
-
-        def mock_add_producer():
-            def add_producer():
-                def publish(_: str, message: Dict[str, Any]):
-                    self.messages.append(message)
-
-                return publish
-
-            self.mqtt_client.add_producer = add_producer
-
-        subject = self.create_subject(mocker, mock_add_producer)
-
-        mocker.patch.object(self.config, 'message_age_cutoff', 120)
-
-        assert subject.state == 'unknown'
-        assert subject.additional_state == {}
-
-        key = subject._additional_state_keys()[0]
-        additional_state = {}
-        additional_state[key] = 1
-        subject.additional_state = additional_state
-        assert subject.additional_state.get(key, None) == 1
-
-        # turn the device on, then off
-        for state in ['on', 'off']:
-            await subject.change_power(state)
-            assert subject.state == state
-            assert subject.additional_state.get(key, None) == 1
-
-        # ensure all message are present and contain the additional state
-        assert len(self.messages) == 3
-        assert all([key in message for message in self.messages])
-
-    async def test_initial_additional_state_message(self, mocker: MockerFixture):
-        self.initial_state_consumer = None
-
-        def mock_add_consumer():
-            def add_consumer(consumer):
-                if consumer.topic.endswith('status'):
-                    self.initial_state_consumer = consumer
-
-            self.mqtt_client.add_consumer = add_consumer
-
-        subject = self.create_subject(mocker, mock_add_consumer)
-
-        key = subject._additional_state_keys()[0]
-        message = {
-            'state': 'on',
-            'timestamp': 0,
-        }
-        message[key] = 1
-
-        assert subject.state == 'unknown'
-        assert subject.additional_state == {}
-
-        # first message should set the state
-        await self.initial_state_consumer.on_message(message, subject.name, 'status')
-        assert subject.state == 'on'
-        assert subject.additional_state.get(key, None) == 1
-
-        # subsequent messages should be ignored
-        message['state'] = 'off'
-        message['something'] = 'more'
-        await self.initial_state_consumer.on_message(message, subject.name, 'status')
-        assert subject.state == 'on'
-        assert subject.additional_state.get(key, None) == 1
-
-
-class AdditionalStateDeviceTestBaseNew(DeviceTestBaseNew):
     @pytest.mark.asyncio
     async def test_on_additional_state_change_implemented(self, subject: AdditionalStateDevice):
         additional_state = await subject.on_additional_state_change({})

--- a/common/pytest/powerpi_common_test/device/base.py
+++ b/common/pytest/powerpi_common_test/device/base.py
@@ -1,22 +1,9 @@
 from abc import ABC
 
 from powerpi_common.device.base import BaseDevice
-from pytest_mock import MockerFixture
 
 
 class BaseDeviceTestBase(ABC):
-    def test_name(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        assert subject.name is not None
-
-    def test_display_name(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        assert subject.display_name is not None
-
-
-class BaseDeviceTestBaseNew(ABC):
     def test_name(self, subject: BaseDevice):
         assert subject.name is not None
 

--- a/common/pytest/powerpi_common_test/device/device.py
+++ b/common/pytest/powerpi_common_test/device/device.py
@@ -1,156 +1,17 @@
-from abc import abstractmethod
 from datetime import datetime
-from typing import Callable, Union
+from typing import Union
 
-import pytest
 from powerpi_common.config.config import Config
 from powerpi_common.device import Device
 from powerpi_common.mqtt.client import MQTTClient
 from powerpi_common.mqtt.consumer import MQTTConsumer
-from powerpi_common_test.device.base import (BaseDeviceTestBase,
-                                             BaseDeviceTestBaseNew)
 from pytest_mock import MockerFixture
+
+import pytest
+from powerpi_common_test.device.base import BaseDeviceTestBase
 
 
 class DeviceTestBase(BaseDeviceTestBase):
-    pytestmark = pytest.mark.asyncio
-
-    def create_subject(self, mocker: MockerFixture, func: Callable[[], None] = None):
-        self.config = mocker.Mock()
-        self.logger = mocker.Mock()
-        self.mqtt_client = mocker.Mock()
-
-        # allow us to do extra mocking before setting up the subject
-        if func is not None:
-            func()
-
-        return self.get_subject(mocker)
-
-    @abstractmethod
-    def get_subject(self, mocker: MockerFixture):
-        raise NotImplementedError
-
-    async def test_turn_on(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        assert subject.state == 'unknown'
-        await subject.turn_on()
-        assert subject.state == 'on'
-
-    async def test_turn_off(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        assert subject.state == 'unknown'
-        await subject.turn_off()
-        assert subject.state == 'off'
-
-    @pytest.mark.parametrize('times', [1, 2])
-    async def test_change_message(self, mocker: MockerFixture, times: int):
-        subject = self.create_subject(mocker)
-
-        mocker.patch.object(self.config, 'message_age_cutoff', 120)
-
-        message = {
-            'state': 'on',
-            'timestamp': int(datetime.utcnow().timestamp() * 1000)
-        }
-
-        initial_state = 'unknown'
-        next_state = 'on'
-        for _ in range(1, times):
-            assert subject.state == initial_state
-            await subject.on_message(message, subject.name, 'change')
-            assert subject.state == next_state
-
-            initial_state = next_state
-            next_state = 'off' if initial_state == 'on' else 'on'
-            message['state'] = next_state
-
-    async def test_old_change_message(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        mocker.patch.object(self.config, 'message_age_cutoff', 120)
-
-        message = {
-            'state': 'on',
-            'timestamp': 0
-        }
-
-        assert subject.state == 'unknown'
-        await subject.on_message(message, subject.name, 'change')
-        assert subject.state == 'unknown'
-
-    async def test_wrong_change_message(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        mocker.patch.object(self.config, 'message_age_cutoff', 120)
-
-        message = {
-            'state': 'on',
-            'timestamp': int(datetime.utcnow().timestamp() * 1000)
-        }
-
-        assert subject.state == 'unknown'
-        await subject.on_message(message, 'other', 'change')
-        assert subject.state == 'unknown'
-
-    async def test_bad_state_change_message(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        mocker.patch.object(self.config, 'message_age_cutoff', 120)
-
-        message = {
-            'state': 'notastate',
-            'timestamp': int(datetime.utcnow().timestamp() * 1000)
-        }
-
-        assert subject.state == 'unknown'
-        await subject.on_message(message, subject.name, 'change')
-        assert subject.state == 'unknown'
-
-    async def test_missing_state_change_message(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        mocker.patch.object(self.config, 'message_age_cutoff', 120)
-
-        message = {
-            'timestamp': int(datetime.utcnow().timestamp() * 1000)
-        }
-
-        assert subject.state == 'unknown'
-        await subject.on_message(message, subject.name, 'change')
-        assert subject.state == 'unknown'
-
-    async def test_initial_state_message(self, mocker: MockerFixture):
-        self.initial_state_consumer = None
-
-        def mock_add_consumer():
-            def add_consumer(consumer):
-                if consumer.topic.endswith('status'):
-                    self.initial_state_consumer = consumer
-
-            self.mqtt_client.add_consumer = add_consumer
-
-        subject = self.create_subject(mocker, mock_add_consumer)
-
-        message = {
-            'state': 'on',
-            'timestamp': 0
-        }
-
-        assert subject.state == 'unknown'
-
-        # first message should set the state
-        await self.initial_state_consumer.on_message(message, subject.name, 'status')
-        assert subject.state == 'on'
-
-        # subsequent messages should be ignored
-        message['state'] = 'off'
-        await self.initial_state_consumer.on_message(message, subject.name, 'status')
-        assert subject.state == 'on'
-
-
-class DeviceTestBaseNew(BaseDeviceTestBaseNew):
     _initial_state_consumer: Union[MQTTConsumer, None] = None
 
     @pytest.mark.asyncio

--- a/common/pytest/powerpi_common_test/device/mixin/__init__.py
+++ b/common/pytest/powerpi_common_test/device/mixin/__init__.py
@@ -1,5 +1,3 @@
-from .initialisable import (InitialisableMixinTestBase,
-                            InitialisableMixinTestBaseNew)
-from .orchestrator import (DeviceOrchestratorMixinTestBase,
-                           DeviceOrchestratorMixinTestBaseNew)
-from .pollable import PollableMixinTestBase, PollableMixinTestBaseNew
+from .initialisable import InitialisableMixinTestBase
+from .orchestrator import DeviceOrchestratorMixinTestBase
+from .pollable import PollableMixinTestBase

--- a/common/pytest/powerpi_common_test/device/mixin/initialisable.py
+++ b/common/pytest/powerpi_common_test/device/mixin/initialisable.py
@@ -1,25 +1,11 @@
 from abc import ABC
 
-import pytest
 from powerpi_common.device.mixin import InitialisableMixin
-from pytest_mock import MockerFixture
+
+import pytest
 
 
 class InitialisableMixinTestBase(ABC):
-    pytestmark = pytest.mark.asyncio
-
-    async def test_initialise_implemented(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        await subject.initialise()
-
-    async def test_deinitialise_implemented(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        await subject.deinitialise()
-
-
-class InitialisableMixinTestBaseNew(ABC):
     @pytest.mark.asyncio
     async def test_initialise_implemented(self, subject: InitialisableMixin):
         await subject.initialise()

--- a/common/pytest/powerpi_common_test/device/mixin/orchestrator.py
+++ b/common/pytest/powerpi_common_test/device/mixin/orchestrator.py
@@ -1,27 +1,11 @@
 from abc import ABC
 
-import pytest
 from powerpi_common.device.mixin import DeviceOrchestratorMixin
-from pytest_mock import MockerFixture
+
+import pytest
 
 
 class DeviceOrchestratorMixinTestBase(ABC):
-    pytestmark = pytest.mark.asyncio
-
-    def test_devices(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        devices = subject.devices
-        assert devices is not None
-        assert len(devices) > 0
-
-    async def test_on_referenced_device_status_implemented(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        await subject.on_referenced_device_status('test_device', 'on')
-
-
-class DeviceOrchestratorMixinTestBaseNew(ABC):
     def test_devices(self, subject: DeviceOrchestratorMixin):
         devices = subject.devices
         assert devices is not None

--- a/common/pytest/powerpi_common_test/device/mixin/pollable.py
+++ b/common/pytest/powerpi_common_test/device/mixin/pollable.py
@@ -1,32 +1,13 @@
 from abc import ABC
 from unittest.mock import PropertyMock
 
-import pytest
 from powerpi_common.config import Config
 from powerpi_common.device.mixin import PollableMixin
-from pytest_mock import MockerFixture
+
+import pytest
 
 
 class PollableMixinTestBase(ABC):
-    pytestmark = pytest.mark.asyncio
-
-    async def test_poll_implemented(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        await subject.poll()
-
-    def test_polling_enabled(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        assert subject.polling_enabled is True
-
-    def test_poll_frequency(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        assert subject.poll_frequency >= 10
-
-
-class PollableMixinTestBaseNew(ABC):
     @pytest.mark.asyncio
     async def test_poll_implemented(self, subject: PollableMixin):
         await subject.poll()

--- a/common/pytest/powerpi_common_test/sensor/__init__.py
+++ b/common/pytest/powerpi_common_test/sensor/__init__.py
@@ -1,1 +1,1 @@
-from .sensor import SensorTestBase, SensorTestBaseNew
+from .sensor import SensorTestBase

--- a/common/pytest/powerpi_common_test/sensor/mixin/__init__.py
+++ b/common/pytest/powerpi_common_test/sensor/mixin/__init__.py
@@ -1,1 +1,1 @@
-from .battery import BatteryMixinTestBase, BatteryMixinTestBaseNew
+from .battery import BatteryMixinTestBase

--- a/common/pytest/powerpi_common_test/sensor/mixin/battery.py
+++ b/common/pytest/powerpi_common_test/sensor/mixin/battery.py
@@ -3,82 +3,9 @@ from typing import Any, Dict, Iterable
 from unittest.mock import MagicMock
 
 from powerpi_common.sensor.mixin import BatteryMixin
-from pytest_mock import MockerFixture
 
 
 class BatteryMixinTestBase(ABC):
-    def test_on_battery_message_level(self, mocker: MockerFixture):
-        # capture the published messages
-        self.messages = []
-
-        def mock_add_producer():
-            def add_producer():
-                def publish(_: str, message: Dict[str, Any]):
-                    self.messages.append(message)
-
-                return publish
-
-            self.mqtt_client.add_producer = add_producer
-
-        subject = self.create_subject(mocker, mock_add_producer)
-
-        levels = [13, 0, 100]
-        for level in levels:
-            subject.on_battery_change(level)
-
-        assert len(self.messages) == len(levels)
-
-        for level in levels:
-            assert any(
-                (message['value'] == level for message in self.messages)
-            )
-
-    def test_on_battery_message_charging(self, mocker: MockerFixture):
-        # capture the published messages
-        self.messages = []
-
-        def mock_add_producer():
-            def add_producer():
-                def publish(_: str, message: Dict[str, Any]):
-                    self.messages.append(message)
-
-                return publish
-
-            self.mqtt_client.add_producer = add_producer
-
-        subject = self.create_subject(mocker, mock_add_producer)
-
-        subject.on_battery_change(10, True)
-        # repeat won't generate new message
-        subject.on_battery_change(10, True)
-        subject.on_battery_change(11, False)
-        subject.on_battery_change(12, None)
-        subject.on_battery_change(13)
-
-        assert len(self.messages) == 4
-
-        assert once(
-            (message['value'] == 10 and message['charging']
-             is True for message in self.messages)
-        )
-
-        assert once(
-            (message['value'] == 11 and message['charging']
-             is False for message in self.messages)
-        )
-
-        assert once(
-            (message['value'] == 12 and not hasattr(message, 'charging')
-             for message in self.messages)
-        )
-
-        assert once(
-            (message['value'] == 13 and not hasattr(message, 'charging')
-             for message in self.messages)
-        )
-
-
-class BatteryMixinTestBaseNew(ABC):
     def test_on_battery_message_level(
         self,
         subject: BatteryMixin,

--- a/common/pytest/powerpi_common_test/sensor/sensor.py
+++ b/common/pytest/powerpi_common_test/sensor/sensor.py
@@ -1,31 +1,5 @@
-from abc import abstractmethod
-from typing import Callable
-
-from pytest_mock import MockerFixture
-
-import pytest
-from powerpi_common_test.device.base import (BaseDeviceTestBase,
-                                             BaseDeviceTestBaseNew)
+from powerpi_common_test.device.base import BaseDeviceTestBase
 
 
 class SensorTestBase(BaseDeviceTestBase):
-    pytestmark = pytest.mark.asyncio
-
-    def create_subject(self, mocker: MockerFixture, func: Callable[[], None] = None):
-        self.config = mocker.Mock()
-        self.logger = mocker.Mock()
-        self.mqtt_client = mocker.Mock()
-
-        # allow us to do extra mocking before setting up the subject
-        if func is not None:
-            func()
-
-        return self.get_subject(mocker)
-
-    @abstractmethod
-    def get_subject(self, mocker: MockerFixture):
-        raise NotImplementedError
-
-
-class SensorTestBaseNew(BaseDeviceTestBaseNew):
     pass

--- a/common/pytest/powerpi_common_test/variable/__init__.py
+++ b/common/pytest/powerpi_common_test/variable/__init__.py
@@ -1,1 +1,1 @@
-from .variable import VariableTestBase, VariableTestBaseNew
+from .variable import VariableTestBase

--- a/common/pytest/powerpi_common_test/variable/variable.py
+++ b/common/pytest/powerpi_common_test/variable/variable.py
@@ -1,37 +1,7 @@
 import re
 
-from pytest_mock import MockerFixture
 
-from powerpi_common_test.base import BaseTest
-
-
-class VariableTestBase(BaseTest):
-    def test_name(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        assert subject.name is not None
-
-    def test_variable_type(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        assert subject.variable_type is not None
-
-    def test_json(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        assert subject.json is not None
-        assert isinstance(subject.json, dict)
-
-    def test_str(self, mocker: MockerFixture):
-        subject = self.create_subject(mocker)
-
-        assert bool(re.match(
-            r'^var\.(device|sensor)\..*=\{.*\}$',
-            str(subject)
-        )) is True
-
-
-class VariableTestBaseNew:
+class VariableTestBase:
     def test_name(self, subject):
         assert subject.name is not None
 

--- a/common/python/tests/device/mixin/test_initialisable.py
+++ b/common/python/tests/device/mixin/test_initialisable.py
@@ -1,6 +1,6 @@
 import pytest
-from powerpi_common_test.device import DeviceTestBaseNew
-from powerpi_common_test.device.mixin import InitialisableMixinTestBaseNew
+from powerpi_common_test.device import DeviceTestBase
+from powerpi_common_test.device.mixin import InitialisableMixinTestBase
 
 from powerpi_common.device import Device
 from powerpi_common.device.mixin import InitialisableMixin
@@ -17,7 +17,7 @@ class DeviceImpl(Device, InitialisableMixin):
         pass
 
 
-class TestInitialisableMixin(DeviceTestBaseNew, InitialisableMixinTestBaseNew):
+class TestInitialisableMixin(DeviceTestBase, InitialisableMixinTestBase):
 
     @pytest.fixture
     def subject(self, powerpi_config, powerpi_logger, powerpi_mqtt_client):

--- a/common/python/tests/device/mixin/test_orchestrator.py
+++ b/common/python/tests/device/mixin/test_orchestrator.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Union
 
 import pytest
-from powerpi_common_test.device.mixin import DeviceOrchestratorMixinTestBaseNew
+from powerpi_common_test.device.mixin import DeviceOrchestratorMixinTestBase
 
 from powerpi_common.device import Device, DeviceStatus
 from powerpi_common.device.mixin import DeviceOrchestratorMixin
@@ -35,7 +35,7 @@ class DummyDevice:
         self.name = name
 
 
-class TestDeviceOrchestratorMixin(DeviceOrchestratorMixinTestBaseNew):
+class TestDeviceOrchestratorMixin(DeviceOrchestratorMixinTestBase):
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize('state', ['on', 'off', 'unknown'])

--- a/common/python/tests/device/mixin/test_pollable.py
+++ b/common/python/tests/device/mixin/test_pollable.py
@@ -1,6 +1,6 @@
 import pytest
-from powerpi_common_test.device import DeviceTestBaseNew
-from powerpi_common_test.device.mixin import PollableMixinTestBaseNew
+from powerpi_common_test.device import DeviceTestBase
+from powerpi_common_test.device.mixin import PollableMixinTestBase
 
 from powerpi_common.device import Device
 from powerpi_common.device.mixin import PollableMixin
@@ -24,7 +24,7 @@ class DeviceImpl(Device, PollableMixin):
         pass
 
 
-class TestPollableMixin(DeviceTestBaseNew, PollableMixinTestBaseNew):
+class TestPollableMixin(DeviceTestBase, PollableMixinTestBase):
 
     def test_poll_frequency_default(self, powerpi_config, powerpi_logger, powerpi_mqtt_client):
         device = DeviceImpl(

--- a/common/python/tests/device/test_additional_state.py
+++ b/common/python/tests/device/test_additional_state.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict
 
 import pytest
-from powerpi_common_test.device import AdditionalStateDeviceTestBaseNew
+from powerpi_common_test.device import AdditionalStateDeviceTestBase
 
 from powerpi_common.device import AdditionalStateDevice
 
@@ -27,7 +27,7 @@ class DeviceImpl(AdditionalStateDevice):
         return ['a', 'b', 'c']
 
 
-class TestAdditionalStateDevice(AdditionalStateDeviceTestBaseNew):
+class TestAdditionalStateDevice(AdditionalStateDeviceTestBase):
 
     @pytest.fixture
     def subject(self, powerpi_config, powerpi_logger, powerpi_mqtt_client):

--- a/common/python/tests/device/test_base.py
+++ b/common/python/tests/device/test_base.py
@@ -1,7 +1,7 @@
 from typing import Callable, Union
 
 import pytest
-from powerpi_common_test.device.base import BaseDeviceTestBaseNew
+from powerpi_common_test.device.base import BaseDeviceTestBase
 
 from powerpi_common.device.base import BaseDevice
 
@@ -13,7 +13,7 @@ class DeviceImpl(BaseDevice):
 SubjectBuilder = Callable[[Union[str, None]], BaseDevice]
 
 
-class TestBaseDevice(BaseDeviceTestBaseNew):
+class TestBaseDevice(BaseDeviceTestBase):
 
     def test_name(self, subject: BaseDevice):
         assert subject.name == 'TestDevice'

--- a/common/python/tests/device/test_device.py
+++ b/common/python/tests/device/test_device.py
@@ -1,5 +1,5 @@
 import pytest
-from powerpi_common_test.device import DeviceTestBaseNew
+from powerpi_common_test.device import DeviceTestBase
 
 from powerpi_common.device import Device, DeviceStatus
 
@@ -18,7 +18,7 @@ class DeviceImpl(Device):
         return True
 
 
-class TestDevice(DeviceTestBaseNew):
+class TestDevice(DeviceTestBase):
 
     @pytest.fixture
     def subject(self, powerpi_config, powerpi_logger, powerpi_mqtt_client):

--- a/common/python/tests/device/test_manager.py
+++ b/common/python/tests/device/test_manager.py
@@ -1,5 +1,5 @@
 import pytest
-from powerpi_common_test.device.mixin import InitialisableMixinTestBaseNew
+from powerpi_common_test.device.mixin import InitialisableMixinTestBase
 from pytest import raises
 from pytest_mock import MockerFixture
 
@@ -30,7 +30,7 @@ class InitialisationDummyDevice(DummyDevice, InitialisableMixin):
     pass
 
 
-class TestDeviceManager(InitialisableMixinTestBaseNew):
+class TestDeviceManager(InitialisableMixinTestBase):
 
     @pytest.mark.asyncio
     async def test_load_no_content(

--- a/common/python/tests/event/test_action.py
+++ b/common/python/tests/event/test_action.py
@@ -3,8 +3,6 @@ import pytest
 from powerpi_common.event.action import (device_additional_state_action,
                                          device_off_action, device_on_action)
 
-pytestmark = pytest.mark.asyncio
-
 
 class DeviceImpl:
     def __init__(self):
@@ -24,6 +22,7 @@ class DeviceImpl:
         self.additional_state = new_additional_state
 
 
+@pytest.mark.asyncio
 async def test_device_on_action():
     device = DeviceImpl()
 
@@ -34,6 +33,7 @@ async def test_device_on_action():
     assert device.state == 'on'
 
 
+@pytest.mark.asyncio
 async def test_device_off_action():
     device = DeviceImpl()
 
@@ -44,6 +44,7 @@ async def test_device_off_action():
     assert device.state == 'off'
 
 
+@pytest.mark.asyncio
 async def test_device_additional_state_action(powerpi_variable_manager):
     device = DeviceImpl()
 
@@ -72,6 +73,7 @@ async def test_device_additional_state_action(powerpi_variable_manager):
     assert device.additional_state['other'] == 'untouched'
 
 
+@pytest.mark.asyncio
 async def test_device_additional_state_action_with_variable(powerpi_variable_manager):
     device = DeviceImpl()
 

--- a/common/python/tests/sensor/mixin/test_battery.py
+++ b/common/python/tests/sensor/mixin/test_battery.py
@@ -1,6 +1,6 @@
 import pytest
-from powerpi_common_test.sensor import SensorTestBaseNew
-from powerpi_common_test.sensor.mixin import BatteryMixinTestBaseNew
+from powerpi_common_test.sensor import SensorTestBase
+from powerpi_common_test.sensor.mixin import BatteryMixinTestBase
 
 from powerpi_common.mqtt.client import MQTTClient
 from powerpi_common.sensor.mixin import BatteryMixin
@@ -17,7 +17,7 @@ class SensorImpl(Sensor, BatteryMixin):
         BatteryMixin.__init__(self)
 
 
-class TestBatteryMixin(SensorTestBaseNew, BatteryMixinTestBaseNew):
+class TestBatteryMixin(SensorTestBase, BatteryMixinTestBase):
 
     @pytest.fixture
     def subject(self, powerpi_mqtt_client):

--- a/common/python/tests/sensor/test_sensor.py
+++ b/common/python/tests/sensor/test_sensor.py
@@ -1,7 +1,7 @@
 from typing import Union
 
 import pytest
-from powerpi_common_test.sensor import SensorTestBaseNew
+from powerpi_common_test.sensor import SensorTestBase
 
 from powerpi_common.mqtt import MQTTClient
 from powerpi_common.sensor import Sensor
@@ -18,7 +18,7 @@ class SensorImpl(Sensor):
         Sensor.__init__(self, mqtt_client, entity, action, **kwargs)
 
 
-class TestSensor(SensorTestBaseNew):
+class TestSensor(SensorTestBase):
 
     def test_broadcast_entity(self, subject_builder, powerpi_mqtt_producer):
         self.__broadcast(

--- a/common/python/tests/variable/test_device.py
+++ b/common/python/tests/variable/test_device.py
@@ -1,10 +1,10 @@
 import pytest
-from powerpi_common_test.variable import VariableTestBaseNew
+from powerpi_common_test.variable import VariableTestBase
 
 from powerpi_common.variable.device import DeviceVariable
 
 
-class TestDeviceVariable(VariableTestBaseNew):
+class TestDeviceVariable(VariableTestBase):
 
     @pytest.fixture
     def subject(self, powerpi_config, powerpi_logger, powerpi_mqtt_client):

--- a/common/python/tests/variable/test_sensor.py
+++ b/common/python/tests/variable/test_sensor.py
@@ -1,10 +1,10 @@
 import pytest
-from powerpi_common_test.variable.variable import VariableTestBaseNew
+from powerpi_common_test.variable.variable import VariableTestBase
 
 from powerpi_common.variable.sensor import SensorVariable
 
 
-class TestSensorVariable(VariableTestBaseNew):
+class TestSensorVariable(VariableTestBase):
 
     def test_topic(self, subject: SensorVariable):
         assert subject.topic == 'event/TestSensor/detect'

--- a/common/python/tests/variable/test_variable.py
+++ b/common/python/tests/variable/test_variable.py
@@ -1,5 +1,5 @@
 import pytest
-from powerpi_common_test.variable import VariableTestBaseNew
+from powerpi_common_test.variable import VariableTestBase
 
 from powerpi_common.variable.types import VariableType
 from powerpi_common.variable.variable import Variable
@@ -19,7 +19,7 @@ class VariableImpl(Variable):
         return self._name
 
 
-class TestVariable(VariableTestBaseNew):
+class TestVariable(VariableTestBase):
 
     @pytest.fixture
     def subject(self):

--- a/controllers/energenie/tests/device/test_energenie_pairing.py
+++ b/controllers/energenie/tests/device/test_energenie_pairing.py
@@ -3,14 +3,14 @@ from asyncio import Future, sleep
 from unittest.mock import MagicMock, PropertyMock
 
 import pytest
-from powerpi_common_test.device import DeviceTestBaseNew
+from powerpi_common_test.device import DeviceTestBase
 from pytest_mock import MockerFixture
 
 from energenie_controller.device.energenie_pairing import \
     EnergeniePairingDevice
 
 
-class TestEnergeniePairingDevice(DeviceTestBaseNew):
+class TestEnergeniePairingDevice(DeviceTestBase):
 
     __timeout = 0.1
 

--- a/controllers/energenie/tests/device/test_socket.py
+++ b/controllers/energenie/tests/device/test_socket.py
@@ -1,11 +1,11 @@
 import pytest
-from powerpi_common_test.device import DeviceTestBaseNew
+from powerpi_common_test.device import DeviceTestBase
 from pytest_mock import MockerFixture
 
 from energenie_controller.device.socket import SocketDevice
 
 
-class TestSocketDevice(DeviceTestBaseNew):
+class TestSocketDevice(DeviceTestBase):
 
     @pytest.mark.asyncio
     async def test_run(self, subject: SocketDevice):

--- a/controllers/energenie/tests/device/test_socket_group.py
+++ b/controllers/energenie/tests/device/test_socket_group.py
@@ -3,8 +3,8 @@ from unittest.mock import MagicMock
 
 import pytest
 from powerpi_common.device import Device
-from powerpi_common_test.device import DeviceTestBaseNew
-from powerpi_common_test.device.mixin import DeviceOrchestratorMixinTestBaseNew
+from powerpi_common_test.device import DeviceTestBase
+from powerpi_common_test.device.mixin import DeviceOrchestratorMixinTestBase
 from pytest_mock import MockerFixture
 
 from energenie_controller.device.socket_group import SocketGroupDevice
@@ -21,7 +21,7 @@ class MockSocket(Device):
         pass
 
 
-class TestSocketGroupDevice(DeviceTestBaseNew, DeviceOrchestratorMixinTestBaseNew):
+class TestSocketGroupDevice(DeviceTestBase, DeviceOrchestratorMixinTestBase):
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize('state', ['on', 'off'])

--- a/controllers/harmony/tests/device/test_harmony_activity.py
+++ b/controllers/harmony/tests/device/test_harmony_activity.py
@@ -3,13 +3,13 @@ from unittest.mock import MagicMock
 
 import pytest
 from powerpi_common.device import DeviceManager
-from powerpi_common_test.device import DeviceTestBaseNew
+from powerpi_common_test.device import DeviceTestBase
 from pytest_mock import MockerFixture
 
 from harmony_controller.device.harmony_activity import HarmonyActivityDevice
 
 
-class TestHarmonyActivityDevice(DeviceTestBaseNew):
+class TestHarmonyActivityDevice(DeviceTestBase):
 
     @pytest.mark.asyncio
     async def test_turn_on_hub(self, subject: HarmonyActivityDevice, harmony_hub: MagicMock):

--- a/controllers/harmony/tests/device/test_harmony_client.py
+++ b/controllers/harmony/tests/device/test_harmony_client.py
@@ -7,9 +7,9 @@ from pytest_mock import MockerFixture
 from harmony_controller.device.harmony_client import HarmonyClient
 
 
-class TestHarmonyClient(object):
-    pytestmark = pytest.mark.asyncio
+class TestHarmonyClient:
 
+    @pytest.mark.asyncio
     async def test_get_config(self, subject: HarmonyClient, mock_api: MagicMock):
         await subject.get_config()
 
@@ -19,6 +19,7 @@ class TestHarmonyClient(object):
         # pylint: disable=protected-access
         mock_api.return_value._harmony_client.refresh_info_from_hub.assert_called_once()
 
+    @pytest.mark.asyncio
     @pytest.mark.skip(reason='the property mock isn\'t working')
     async def test_get_current_activity(self, subject: HarmonyClient, mock_api: MagicMock):
         type(mock_api).current_activity = PropertyMock(
@@ -34,6 +35,7 @@ class TestHarmonyClient(object):
 
         assert result == -1
 
+    @pytest.mark.asyncio
     async def test_start_activity(self, subject: HarmonyClient, mock_api: MagicMock):
         activity = 'Test Activity'
 
@@ -44,6 +46,7 @@ class TestHarmonyClient(object):
         mock_api.assert_called_once_with(subject.address)
         mock_api.return_value.start_activity.assert_called_once_with(activity)
 
+    @pytest.mark.asyncio
     async def test_power_off(self, subject: HarmonyClient, mock_api: MagicMock):
         mock_api.return_value.power_off = AsyncMock()
 
@@ -52,6 +55,7 @@ class TestHarmonyClient(object):
         mock_api.assert_called_once_with(subject.address)
         mock_api.return_value.power_off.assert_called_once()
 
+    @pytest.mark.asyncio
     async def test_reconnect(
         self,
         subject: HarmonyClient,

--- a/controllers/harmony/tests/device/test_harmony_hub.py
+++ b/controllers/harmony/tests/device/test_harmony_hub.py
@@ -1,18 +1,18 @@
 from asyncio import Future
-from typing import List, Tuple
+from typing import List
 from unittest.mock import MagicMock
 
 import pytest
 from powerpi_common.device import DeviceManager
-from powerpi_common_test.device import DeviceTestBaseNew
-from powerpi_common_test.device.mixin import PollableMixinTestBaseNew
+from powerpi_common_test.device import DeviceTestBase
+from powerpi_common_test.device.mixin import PollableMixinTestBase
 from pytest_mock import MockerFixture
 
 from harmony_controller.device.harmony_activity import HarmonyActivityDevice
 from harmony_controller.device.harmony_hub import HarmonyHubDevice
 
 
-class TestHarmonyHubDevice(DeviceTestBaseNew, PollableMixinTestBaseNew):
+class TestHarmonyHubDevice(DeviceTestBase, PollableMixinTestBase):
 
     __hub_name = 'TestHub'
 

--- a/controllers/lifx/poetry.lock
+++ b/controllers/lifx/poetry.lock
@@ -67,24 +67,6 @@ wrapt = [
 ]
 
 [[package]]
-name = "attrs"
-version = "22.1.0"
-description = "Classes Without Boilerplate"
-category = "dev"
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
-    {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
-]
-
-[package.extras]
-dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
-docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
-tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
-tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
-
-[[package]]
 name = "autopep8"
 version = "2.0.2"
 description = "A tool that automatically formats Python code to conform to the PEP 8 style guide"
@@ -502,7 +484,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "powerpi-common"
-version = "0.3.2"
+version = "0.3.3"
 description = "PowerPi Common Python Library"
 category = "dev"
 optional = false
@@ -523,7 +505,7 @@ url = "../../common/python"
 
 [[package]]
 name = "powerpi-common-test"
-version = "0.3.1"
+version = "0.4.0"
 description = "PowerPi Common Python Test Library"
 category = "dev"
 optional = false
@@ -532,9 +514,9 @@ files = []
 develop = true
 
 [package.dependencies]
-pytest = "~=7.2.2"
+pytest = "~=7.3.1"
 pytest-asyncio = "~=0.21.0"
-pytest-cov = "~=4.0.0"
+pytest-cov = "~=4.1.0"
 pytest-mock = "~=3.10.0"
 
 [package.source]
@@ -600,18 +582,17 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
-version = "7.2.2"
+version = "7.3.2"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.2.2-py3-none-any.whl", hash = "sha256:130328f552dcfac0b1cec75c12e3f005619dc5f874f0a06e8ff7263f0ee6225e"},
-    {file = "pytest-7.2.2.tar.gz", hash = "sha256:c99ab0c73aceb050f68929bc93af19ab6db0558791c6a0715723abe9d0ade9d4"},
+    {file = "pytest-7.3.2-py3-none-any.whl", hash = "sha256:cdcbd012c9312258922f8cd3f1b62a6580fdced17db6014896053d47cddf9295"},
+    {file = "pytest-7.3.2.tar.gz", hash = "sha256:ee990a3cc55ba808b80795a79944756f315c67c12b56abd3ac993a7b8c17030b"},
 ]
 
 [package.dependencies]
-attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
@@ -620,7 +601,7 @@ pluggy = ">=0.12,<2.0"
 tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
-testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "pytest-asyncio"
@@ -643,14 +624,14 @@ testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy 
 
 [[package]]
 name = "pytest-cov"
-version = "4.0.0"
+version = "4.1.0"
 description = "Pytest plugin for measuring coverage."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "pytest-cov-4.0.0.tar.gz", hash = "sha256:996b79efde6433cdbd0088872dbc5fb3ed7fe1578b68cdbba634f14bb8dd0470"},
-    {file = "pytest_cov-4.0.0-py3-none-any.whl", hash = "sha256:2feb1b751d66a8bd934e5edfa2e961d11309dc37b73b0eabe73b5945fee20f6b"},
+    {file = "pytest-cov-4.1.0.tar.gz", hash = "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6"},
+    {file = "pytest_cov-4.1.0-py3-none-any.whl", hash = "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a"},
 ]
 
 [package.dependencies]

--- a/controllers/lifx/tests/device/test_lifx_client.py
+++ b/controllers/lifx/tests/device/test_lifx_client.py
@@ -3,10 +3,11 @@ from typing import Callable, Tuple
 from unittest.mock import MagicMock, PropertyMock
 
 import pytest
-from lifx_controller.device.lifx_client import LIFXClient
-from lifx_controller.device.lifx_colour import LIFXColour
 from powerpi_common.logger import Logger
 from pytest_mock import MockerFixture
+
+from lifx_controller.device.lifx_client import LIFXClient
+from lifx_controller.device.lifx_colour import LIFXColour
 
 
 class TestLIFXClient:

--- a/controllers/lifx/tests/device/test_lifx_colour.py
+++ b/controllers/lifx/tests/device/test_lifx_colour.py
@@ -1,7 +1,8 @@
 import pytest
-from lifx_controller.device.lifx_colour import LIFXColour
 from powerpi_common.util.data import DataType
 from pytest import raises
+
+from lifx_controller.device.lifx_colour import LIFXColour
 
 
 class TestLIFXColour:

--- a/controllers/lifx/tests/device/test_lifx_light.py
+++ b/controllers/lifx/tests/device/test_lifx_light.py
@@ -3,20 +3,21 @@ from typing import Tuple, Union
 from unittest.mock import MagicMock, PropertyMock
 
 import pytest
+from powerpi_common.util.data import Range
+from powerpi_common_test.device import AdditionalStateDeviceTestBase
+from powerpi_common_test.device.mixin import (InitialisableMixinTestBase,
+                                              PollableMixinTestBase)
+from pytest_mock import MockerFixture
+
 from lifx_controller.device.lifx_client import LIFXClient
 from lifx_controller.device.lifx_colour import LIFXColour
 from lifx_controller.device.lifx_light import LIFXLightDevice
-from powerpi_common.util.data import Range
-from powerpi_common_test.device import AdditionalStateDeviceTestBaseNew
-from powerpi_common_test.device.mixin import (InitialisableMixinTestBaseNew,
-                                              PollableMixinTestBaseNew)
-from pytest_mock import MockerFixture
 
 
 class TestLIFXLightDevice(
-    AdditionalStateDeviceTestBaseNew,
-    PollableMixinTestBaseNew,
-    InitialisableMixinTestBaseNew
+    AdditionalStateDeviceTestBase,
+    PollableMixinTestBase,
+    InitialisableMixinTestBase
 ):
     @pytest.mark.asyncio
     @pytest.mark.parametrize('supports_colour', [None, True, False])

--- a/controllers/macro/poetry.lock
+++ b/controllers/macro/poetry.lock
@@ -51,24 +51,6 @@ wrapt = [
 ]
 
 [[package]]
-name = "attrs"
-version = "22.1.0"
-description = "Classes Without Boilerplate"
-category = "dev"
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
-    {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
-]
-
-[package.extras]
-dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
-docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
-tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
-tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
-
-[[package]]
 name = "autopep8"
 version = "2.0.2"
 description = "A tool that automatically formats Python code to conform to the PEP 8 style guide"
@@ -250,21 +232,6 @@ aiohttp = ["aiohttp"]
 flask = ["flask"]
 pydantic = ["pydantic"]
 yaml = ["pyyaml"]
-
-[[package]]
-name = "dill"
-version = "0.3.5.1"
-description = "serialize all of python"
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*"
-files = [
-    {file = "dill-0.3.5.1-py2.py3-none-any.whl", hash = "sha256:33501d03270bbe410c72639b350e941882a8b0fd55357580fbc873fba0c59302"},
-    {file = "dill-0.3.5.1.tar.gz", hash = "sha256:d75e41f3eff1eee599d738e76ba8f4ad98ea229db8b085318aa2b3333a208c86"},
-]
-
-[package.extras]
-graph = ["objgraph (>=1.7.2)"]
 
 [[package]]
 name = "dill"
@@ -476,7 +443,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "powerpi-common"
-version = "0.2.14"
+version = "0.3.3"
 description = "PowerPi Common Python Library"
 category = "dev"
 optional = false
@@ -497,7 +464,7 @@ url = "../../common/python"
 
 [[package]]
 name = "powerpi-common-test"
-version = "0.2.7"
+version = "0.4.0"
 description = "PowerPi Common Python Test Library"
 category = "dev"
 optional = false
@@ -506,9 +473,9 @@ files = []
 develop = true
 
 [package.dependencies]
-pytest = "~=7.2.2"
+pytest = "~=7.3.1"
 pytest-asyncio = "~=0.21.0"
-pytest-cov = "~=4.0.0"
+pytest-cov = "~=4.1.0"
 pytest-mock = "~=3.10.0"
 
 [package.source]
@@ -574,18 +541,17 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
-version = "7.2.2"
+version = "7.3.2"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.2.2-py3-none-any.whl", hash = "sha256:130328f552dcfac0b1cec75c12e3f005619dc5f874f0a06e8ff7263f0ee6225e"},
-    {file = "pytest-7.2.2.tar.gz", hash = "sha256:c99ab0c73aceb050f68929bc93af19ab6db0558791c6a0715723abe9d0ade9d4"},
+    {file = "pytest-7.3.2-py3-none-any.whl", hash = "sha256:cdcbd012c9312258922f8cd3f1b62a6580fdced17db6014896053d47cddf9295"},
+    {file = "pytest-7.3.2.tar.gz", hash = "sha256:ee990a3cc55ba808b80795a79944756f315c67c12b56abd3ac993a7b8c17030b"},
 ]
 
 [package.dependencies]
-attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
@@ -594,7 +560,7 @@ pluggy = ">=0.12,<2.0"
 tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
-testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "pytest-asyncio"
@@ -617,14 +583,14 @@ testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy 
 
 [[package]]
 name = "pytest-cov"
-version = "4.0.0"
+version = "4.1.0"
 description = "Pytest plugin for measuring coverage."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "pytest-cov-4.0.0.tar.gz", hash = "sha256:996b79efde6433cdbd0088872dbc5fb3ed7fe1578b68cdbba634f14bb8dd0470"},
-    {file = "pytest_cov-4.0.0-py3-none-any.whl", hash = "sha256:2feb1b751d66a8bd934e5edfa2e961d11309dc37b73b0eabe73b5945fee20f6b"},
+    {file = "pytest-cov-4.1.0.tar.gz", hash = "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6"},
+    {file = "pytest_cov-4.1.0-py3-none-any.whl", hash = "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a"},
 ]
 
 [package.dependencies]

--- a/controllers/macro/tests/device/test_composite.py
+++ b/controllers/macro/tests/device/test_composite.py
@@ -3,17 +3,18 @@ from typing import Dict, List, Tuple
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
-from macro_controller.device import CompositeDevice
-from powerpi_common_test.device import AdditionalStateDeviceTestBaseNew
-from powerpi_common_test.device.mixin import (
-    DeviceOrchestratorMixinTestBaseNew, PollableMixinTestBaseNew)
+from powerpi_common_test.device import AdditionalStateDeviceTestBase
+from powerpi_common_test.device.mixin import (DeviceOrchestratorMixinTestBase,
+                                              PollableMixinTestBase)
 from pytest_mock import MockerFixture
+
+from macro_controller.device import CompositeDevice
 
 
 class TestCompositeDevice(
-    AdditionalStateDeviceTestBaseNew,
-    DeviceOrchestratorMixinTestBaseNew,
-    PollableMixinTestBaseNew
+    AdditionalStateDeviceTestBase,
+    DeviceOrchestratorMixinTestBase,
+    PollableMixinTestBase
 ):
 
     @pytest.mark.asyncio

--- a/controllers/macro/tests/device/test_condition.py
+++ b/controllers/macro/tests/device/test_condition.py
@@ -2,18 +2,19 @@ from asyncio import Future
 from unittest.mock import MagicMock, Mock, PropertyMock
 
 import pytest
-from macro_controller.device.condition import ConditionDevice
 from powerpi_common.device import DeviceStatus
-from powerpi_common_test.device import DeviceTestBaseNew
-from powerpi_common_test.device.mixin import (
-    DeviceOrchestratorMixinTestBaseNew, PollableMixinTestBaseNew)
+from powerpi_common_test.device import DeviceTestBase
+from powerpi_common_test.device.mixin import (DeviceOrchestratorMixinTestBase,
+                                              PollableMixinTestBase)
 from pytest_mock import MockerFixture
+
+from macro_controller.device.condition import ConditionDevice
 
 
 class TestCondition(
-    DeviceTestBaseNew,
-    DeviceOrchestratorMixinTestBaseNew,
-    PollableMixinTestBaseNew
+    DeviceTestBase,
+    DeviceOrchestratorMixinTestBase,
+    PollableMixinTestBase
 ):
 
     @pytest.mark.asyncio
@@ -89,7 +90,7 @@ class TestCondition(
         mocker: MockerFixture,
         state: DeviceStatus
     ):
-        #pylint: disable=too-many-arguments
+        # pylint: disable=too-many-arguments
         opposite = DeviceStatus.OFF if state == DeviceStatus.ON else DeviceStatus.ON
 
         device_variable = mocker.Mock()
@@ -125,7 +126,7 @@ class TestCondition(
         mocker: MockerFixture,
         state: DeviceStatus
     ):
-        #pylint: disable=too-many-arguments
+        # pylint: disable=too-many-arguments
         opposite = DeviceStatus.OFF if state == DeviceStatus.ON else DeviceStatus.ON
 
         device_variable = mocker.Mock()
@@ -185,7 +186,7 @@ class TestCondition(
         device_manager,
         variable_manager
     ):
-        #pylint: disable=too-many-arguments
+        # pylint: disable=too-many-arguments
         return ConditionDevice(
             powerpi_config, powerpi_logger, powerpi_mqtt_client, device_manager, variable_manager,
             name='condition',
@@ -210,7 +211,7 @@ class TestCondition(
         device_manager,
         variable_manager
     ):
-        #pylint: disable=too-many-arguments
+        # pylint: disable=too-many-arguments
         return ConditionDevice(
             powerpi_config, powerpi_logger, powerpi_mqtt_client, device_manager, variable_manager,
             name='condition',

--- a/controllers/macro/tests/device/test_delay.py
+++ b/controllers/macro/tests/device/test_delay.py
@@ -1,9 +1,10 @@
 import pytest
+from powerpi_common_test.device import DeviceTestBase
+
 from macro_controller.device import DelayDevice
-from powerpi_common_test.device import DeviceTestBaseNew
 
 
-class TestDelayDevice(DeviceTestBaseNew):
+class TestDelayDevice(DeviceTestBase):
     @pytest.fixture
     def subject(
         self,

--- a/controllers/macro/tests/device/test_log.py
+++ b/controllers/macro/tests/device/test_log.py
@@ -1,9 +1,10 @@
 import pytest
+from powerpi_common_test.device import DeviceTestBase
+
 from macro_controller.device import LogDevice
-from powerpi_common_test.device import DeviceTestBaseNew
 
 
-class TestLogDevice(DeviceTestBaseNew):
+class TestLogDevice(DeviceTestBase):
     @pytest.fixture
     def subject(
         self,

--- a/controllers/macro/tests/device/test_mutex.py
+++ b/controllers/macro/tests/device/test_mutex.py
@@ -3,17 +3,18 @@ from typing import List, Tuple
 from unittest.mock import MagicMock, PropertyMock
 
 import pytest
-from macro_controller.device import MutexDevice
-from powerpi_common_test.device import DeviceTestBaseNew
-from powerpi_common_test.device.mixin import (
-    DeviceOrchestratorMixinTestBaseNew, PollableMixinTestBaseNew)
+from powerpi_common_test.device import DeviceTestBase
+from powerpi_common_test.device.mixin import (DeviceOrchestratorMixinTestBase,
+                                              PollableMixinTestBase)
 from pytest_mock import MockerFixture
+
+from macro_controller.device import MutexDevice
 
 
 class TestMutexDevice(
-    DeviceTestBaseNew,
-    DeviceOrchestratorMixinTestBaseNew,
-    PollableMixinTestBaseNew
+    DeviceTestBase,
+    DeviceOrchestratorMixinTestBase,
+    PollableMixinTestBase
 ):
     @pytest.mark.asyncio
     async def test_all_on(self, subject: MutexDevice, devices: List[MagicMock]):

--- a/controllers/macro/tests/device/test_variable.py
+++ b/controllers/macro/tests/device/test_variable.py
@@ -1,9 +1,10 @@
 import pytest
+from powerpi_common_test.device import DeviceTestBase
+
 from macro_controller.device import VariableDevice
-from powerpi_common_test.device import DeviceTestBaseNew
 
 
-class TestVariableDevice(DeviceTestBaseNew):
+class TestVariableDevice(DeviceTestBase):
     @pytest.fixture
     def subject(
         self,

--- a/controllers/network/poetry.lock
+++ b/controllers/network/poetry.lock
@@ -51,25 +51,6 @@ wrapt = [
 ]
 
 [[package]]
-name = "attrs"
-version = "23.1.0"
-description = "Classes Without Boilerplate"
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "attrs-23.1.0-py3-none-any.whl", hash = "sha256:1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04"},
-    {file = "attrs-23.1.0.tar.gz", hash = "sha256:6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"},
-]
-
-[package.extras]
-cov = ["attrs[tests]", "coverage[toml] (>=5.3)"]
-dev = ["attrs[docs,tests]", "pre-commit"]
-docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier", "zope-interface"]
-tests = ["attrs[tests-no-zope]", "zope-interface"]
-tests-no-zope = ["cloudpickle", "hypothesis", "mypy (>=1.1.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
-
-[[package]]
 name = "autopep8"
 version = "2.0.2"
 description = "A tool that automatically formats Python code to conform to the PEP 8 style guide"
@@ -480,7 +461,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "powerpi-common"
-version = "0.3.2"
+version = "0.3.3"
 description = "PowerPi Common Python Library"
 category = "dev"
 optional = false
@@ -501,7 +482,7 @@ url = "../../common/python"
 
 [[package]]
 name = "powerpi-common-test"
-version = "0.3.1"
+version = "0.4.0"
 description = "PowerPi Common Python Test Library"
 category = "dev"
 optional = false
@@ -510,9 +491,9 @@ files = []
 develop = true
 
 [package.dependencies]
-pytest = "~=7.2.2"
+pytest = "~=7.3.1"
 pytest-asyncio = "~=0.21.0"
-pytest-cov = "~=4.0.0"
+pytest-cov = "~=4.1.0"
 pytest-mock = "~=3.10.0"
 
 [package.source]
@@ -563,18 +544,17 @@ testutils = ["gitpython (>3)"]
 
 [[package]]
 name = "pytest"
-version = "7.2.2"
+version = "7.3.2"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.2.2-py3-none-any.whl", hash = "sha256:130328f552dcfac0b1cec75c12e3f005619dc5f874f0a06e8ff7263f0ee6225e"},
-    {file = "pytest-7.2.2.tar.gz", hash = "sha256:c99ab0c73aceb050f68929bc93af19ab6db0558791c6a0715723abe9d0ade9d4"},
+    {file = "pytest-7.3.2-py3-none-any.whl", hash = "sha256:cdcbd012c9312258922f8cd3f1b62a6580fdced17db6014896053d47cddf9295"},
+    {file = "pytest-7.3.2.tar.gz", hash = "sha256:ee990a3cc55ba808b80795a79944756f315c67c12b56abd3ac993a7b8c17030b"},
 ]
 
 [package.dependencies]
-attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
@@ -583,7 +563,7 @@ pluggy = ">=0.12,<2.0"
 tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
-testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "pytest-asyncio"
@@ -606,14 +586,14 @@ testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy 
 
 [[package]]
 name = "pytest-cov"
-version = "4.0.0"
+version = "4.1.0"
 description = "Pytest plugin for measuring coverage."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "pytest-cov-4.0.0.tar.gz", hash = "sha256:996b79efde6433cdbd0088872dbc5fb3ed7fe1578b68cdbba634f14bb8dd0470"},
-    {file = "pytest_cov-4.0.0-py3-none-any.whl", hash = "sha256:2feb1b751d66a8bd934e5edfa2e961d11309dc37b73b0eabe73b5945fee20f6b"},
+    {file = "pytest-cov-4.1.0.tar.gz", hash = "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6"},
+    {file = "pytest_cov-4.1.0-py3-none-any.whl", hash = "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a"},
 ]
 
 [package.dependencies]

--- a/controllers/network/tests/device/test_computer.py
+++ b/controllers/network/tests/device/test_computer.py
@@ -3,14 +3,14 @@ from unittest.mock import PropertyMock, call, patch
 
 import pytest
 from powerpi_common.device import DeviceStatus
-from powerpi_common_test.device import DeviceTestBaseNew
-from powerpi_common_test.device.mixin import PollableMixinTestBaseNew
+from powerpi_common_test.device import DeviceTestBase
+from powerpi_common_test.device.mixin import PollableMixinTestBase
 from pytest_mock import MockerFixture
 
 from network_controller.device.computer import ComputerDevice
 
 
-class TestComputer(DeviceTestBaseNew, PollableMixinTestBaseNew):
+class TestComputer(DeviceTestBase, PollableMixinTestBase):
     def test_setup(self, subject: ComputerDevice):
         assert subject.mac_address == '00:00:00:00:00'
         assert subject.network_address == 'mycomputer.home'
@@ -104,14 +104,11 @@ class TestComputer(DeviceTestBaseNew, PollableMixinTestBaseNew):
     async def test_change_message(
         self,
         subject: ComputerDevice,
-        powerpi_config,
         mocker: MockerFixture
     ):
-        # pylint: disable=arguments-differ
+        # pylint: disable=arguments-renamed
 
         assert subject.state == DeviceStatus.UNKNOWN
-
-        mocker.patch.object(powerpi_config, 'message_age_cutoff', 120)
 
         host = mocker.Mock()
         type(host).is_alive = PropertyMock(return_value=True)

--- a/controllers/node/poetry.lock
+++ b/controllers/node/poetry.lock
@@ -63,24 +63,6 @@ wrapt = [
 ]
 
 [[package]]
-name = "attrs"
-version = "22.1.0"
-description = "Classes Without Boilerplate"
-category = "dev"
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
-    {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
-]
-
-[package.extras]
-dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
-docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
-tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
-tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
-
-[[package]]
 name = "autopep8"
 version = "2.0.2"
 description = "A tool that automatically formats Python code to conform to the PEP 8 style guide"
@@ -502,7 +484,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "powerpi-common"
-version = "0.2.14"
+version = "0.3.3"
 description = "PowerPi Common Python Library"
 category = "dev"
 optional = false
@@ -523,7 +505,7 @@ url = "../../common/python"
 
 [[package]]
 name = "powerpi-common-test"
-version = "0.2.7"
+version = "0.4.0"
 description = "PowerPi Common Python Test Library"
 category = "dev"
 optional = false
@@ -532,9 +514,9 @@ files = []
 develop = true
 
 [package.dependencies]
-pytest = "~=7.2.2"
+pytest = "~=7.3.1"
 pytest-asyncio = "~=0.21.0"
-pytest-cov = "~=4.0.0"
+pytest-cov = "~=4.1.0"
 pytest-mock = "~=3.10.0"
 
 [package.source]
@@ -600,18 +582,17 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
-version = "7.2.2"
+version = "7.3.2"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.2.2-py3-none-any.whl", hash = "sha256:130328f552dcfac0b1cec75c12e3f005619dc5f874f0a06e8ff7263f0ee6225e"},
-    {file = "pytest-7.2.2.tar.gz", hash = "sha256:c99ab0c73aceb050f68929bc93af19ab6db0558791c6a0715723abe9d0ade9d4"},
+    {file = "pytest-7.3.2-py3-none-any.whl", hash = "sha256:cdcbd012c9312258922f8cd3f1b62a6580fdced17db6014896053d47cddf9295"},
+    {file = "pytest-7.3.2.tar.gz", hash = "sha256:ee990a3cc55ba808b80795a79944756f315c67c12b56abd3ac993a7b8c17030b"},
 ]
 
 [package.dependencies]
-attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
@@ -620,7 +601,7 @@ pluggy = ">=0.12,<2.0"
 tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
-testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "pytest-asyncio"
@@ -643,14 +624,14 @@ testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy 
 
 [[package]]
 name = "pytest-cov"
-version = "4.0.0"
+version = "4.1.0"
 description = "Pytest plugin for measuring coverage."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "pytest-cov-4.0.0.tar.gz", hash = "sha256:996b79efde6433cdbd0088872dbc5fb3ed7fe1578b68cdbba634f14bb8dd0470"},
-    {file = "pytest_cov-4.0.0-py3-none-any.whl", hash = "sha256:2feb1b751d66a8bd934e5edfa2e961d11309dc37b73b0eabe73b5945fee20f6b"},
+    {file = "pytest-cov-4.1.0.tar.gz", hash = "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6"},
+    {file = "pytest_cov-4.1.0-py3-none-any.whl", hash = "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a"},
 ]
 
 [package.dependencies]

--- a/controllers/node/tests/device/test_local_node.py
+++ b/controllers/node/tests/device/test_local_node.py
@@ -4,10 +4,10 @@ from unittest.mock import PropertyMock, call
 
 import pytest
 from powerpi_common.device import DeviceStatus
-from powerpi_common_test.device import DeviceTestBaseNew
-from powerpi_common_test.device.mixin import (InitialisableMixinTestBaseNew,
-                                              PollableMixinTestBaseNew)
-from powerpi_common_test.sensor.mixin import BatteryMixinTestBaseNew
+from powerpi_common_test.device import DeviceTestBase
+from powerpi_common_test.device.mixin import (InitialisableMixinTestBase,
+                                              PollableMixinTestBase)
+from powerpi_common_test.sensor.mixin import BatteryMixinTestBase
 from pytest_mock import MockerFixture
 
 from node_controller.device.local_node import LocalNodeDevice
@@ -19,10 +19,10 @@ SubjectBuilder = Callable[
 
 
 class TestLocalNode(
-    DeviceTestBaseNew,
-    InitialisableMixinTestBaseNew,
-    PollableMixinTestBaseNew,
-    BatteryMixinTestBaseNew
+    DeviceTestBase,
+    InitialisableMixinTestBase,
+    PollableMixinTestBase,
+    BatteryMixinTestBase
 ):
 
     @pytest.mark.asyncio

--- a/controllers/node/tests/device/test_remote_node.py
+++ b/controllers/node/tests/device/test_remote_node.py
@@ -3,14 +3,14 @@ from unittest.mock import PropertyMock
 
 import pytest
 from powerpi_common.device import DeviceStatus
-from powerpi_common_test.device import DeviceTestBaseNew
-from powerpi_common_test.device.mixin import PollableMixinTestBaseNew
+from powerpi_common_test.device import DeviceTestBase
+from powerpi_common_test.device.mixin import PollableMixinTestBase
 from pytest_mock import MockerFixture
 
 from node_controller.device.remote_node import RemoteNodeDevice
 
 
-class TestRemoteNodeDevice(DeviceTestBaseNew, PollableMixinTestBaseNew):
+class TestRemoteNodeDevice(DeviceTestBase, PollableMixinTestBase):
     @pytest.mark.asyncio
     async def test_poll_implemented(self, subject: RemoteNodeDevice, mocker: MockerFixture):
         # pylint: disable=arguments-differ
@@ -72,15 +72,11 @@ class TestRemoteNodeDevice(DeviceTestBaseNew, PollableMixinTestBaseNew):
     async def test_change_message(
         self,
         subject: RemoteNodeDevice,
-        powerpi_config,
-        mocker: MockerFixture,
         times: int
     ):
         # pylint: disable=arguments-differ
 
         assert subject.state == DeviceStatus.UNKNOWN
-
-        mocker.patch.object(powerpi_config, 'message_age_cutoff', 120)
 
         message = {
             'state': 'on',

--- a/controllers/zigbee/poetry.lock
+++ b/controllers/zigbee/poetry.lock
@@ -950,7 +950,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "powerpi-common"
-version = "0.3.2"
+version = "0.3.3"
 description = "PowerPi Common Python Library"
 category = "dev"
 optional = false
@@ -971,7 +971,7 @@ url = "../../common/python"
 
 [[package]]
 name = "powerpi-common-test"
-version = "0.3.1"
+version = "0.4.0"
 description = "PowerPi Common Python Test Library"
 category = "dev"
 optional = false
@@ -980,9 +980,9 @@ files = []
 develop = true
 
 [package.dependencies]
-pytest = "~=7.2.2"
+pytest = "~=7.3.1"
 pytest-asyncio = "~=0.21.0"
-pytest-cov = "~=4.0.0"
+pytest-cov = "~=4.1.0"
 pytest-mock = "~=3.10.0"
 
 [package.source]
@@ -1133,18 +1133,17 @@ pyserial = "*"
 
 [[package]]
 name = "pytest"
-version = "7.2.2"
+version = "7.3.2"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.2.2-py3-none-any.whl", hash = "sha256:130328f552dcfac0b1cec75c12e3f005619dc5f874f0a06e8ff7263f0ee6225e"},
-    {file = "pytest-7.2.2.tar.gz", hash = "sha256:c99ab0c73aceb050f68929bc93af19ab6db0558791c6a0715723abe9d0ade9d4"},
+    {file = "pytest-7.3.2-py3-none-any.whl", hash = "sha256:cdcbd012c9312258922f8cd3f1b62a6580fdced17db6014896053d47cddf9295"},
+    {file = "pytest-7.3.2.tar.gz", hash = "sha256:ee990a3cc55ba808b80795a79944756f315c67c12b56abd3ac993a7b8c17030b"},
 ]
 
 [package.dependencies]
-attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
@@ -1153,7 +1152,7 @@ pluggy = ">=0.12,<2.0"
 tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
-testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "pytest-asyncio"
@@ -1176,14 +1175,14 @@ testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy 
 
 [[package]]
 name = "pytest-cov"
-version = "4.0.0"
+version = "4.1.0"
 description = "Pytest plugin for measuring coverage."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "pytest-cov-4.0.0.tar.gz", hash = "sha256:996b79efde6433cdbd0088872dbc5fb3ed7fe1578b68cdbba634f14bb8dd0470"},
-    {file = "pytest_cov-4.0.0-py3-none-any.whl", hash = "sha256:2feb1b751d66a8bd934e5edfa2e961d11309dc37b73b0eabe73b5945fee20f6b"},
+    {file = "pytest-cov-4.1.0.tar.gz", hash = "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6"},
+    {file = "pytest_cov-4.1.0-py3-none-any.whl", hash = "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a"},
 ]
 
 [package.dependencies]

--- a/controllers/zigbee/tests/device/test_zigbee_light.py
+++ b/controllers/zigbee/tests/device/test_zigbee_light.py
@@ -4,20 +4,21 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock, call
 
 import pytest
 from powerpi_common.device.mixin import AdditionalState
-from powerpi_common_test.device import AdditionalStateDeviceTestBaseNew
-from powerpi_common_test.device.mixin import (InitialisableMixinTestBaseNew,
-                                              PollableMixinTestBaseNew)
+from powerpi_common_test.device import AdditionalStateDeviceTestBase
+from powerpi_common_test.device.mixin import (InitialisableMixinTestBase,
+                                              PollableMixinTestBase)
 from pytest_mock import MockerFixture
-from zigbee_controller.device.zigbee_light import ZigbeeLight
 from zigpy.exceptions import DeliveryError
 from zigpy.zcl import Cluster
 from zigpy.zcl.foundation import Status
 
+from zigbee_controller.device.zigbee_light import ZigbeeLight
+
 
 class TestZigbeeeLight(
-    AdditionalStateDeviceTestBaseNew,
-    InitialisableMixinTestBaseNew,
-    PollableMixinTestBaseNew
+    AdditionalStateDeviceTestBase,
+    InitialisableMixinTestBase,
+    PollableMixinTestBase
 ):
     def test_duration(self, subject: ZigbeeLight):
         assert subject.duration == 13

--- a/controllers/zigbee/tests/device/test_zigbee_pairing.py
+++ b/controllers/zigbee/tests/device/test_zigbee_pairing.py
@@ -2,13 +2,14 @@ from asyncio import Future
 from unittest.mock import MagicMock, PropertyMock
 
 import pytest
-from powerpi_common_test.device import DeviceTestBaseNew
+from powerpi_common_test.device import DeviceTestBase
 from pytest_mock import MockerFixture
-from zigbee_controller.device.zigbee_pairing import ZigbeePairingDevice
 from zigpy.typing import DeviceType
 
+from zigbee_controller.device.zigbee_pairing import ZigbeePairingDevice
 
-class TestZigbeePairingDevice(DeviceTestBaseNew):
+
+class TestZigbeePairingDevice(DeviceTestBase):
     @pytest.mark.asyncio
     async def test_pair(self, subject: ZigbeePairingDevice, zigbee_controller: MagicMock):
         assert subject.state == 'unknown'

--- a/controllers/zigbee/tests/sensor/aqara/test_door_window_sensor.py
+++ b/controllers/zigbee/tests/sensor/aqara/test_door_window_sensor.py
@@ -2,15 +2,15 @@ from typing import Tuple, Union
 from unittest.mock import MagicMock
 
 import pytest
-from powerpi_common_test.device.base import BaseDeviceTestBase
 from powerpi_common_test.device.mixin import InitialisableMixinTestBase
+from powerpi_common_test.sensor import SensorTestBase
 from powerpi_common_test.sensor.mixin import BatteryMixinTestBase
 
 from zigbee_controller.sensor.aqara.door_window_sensor import \
     AqaraDoorWindowSensor
 
 
-class TestAqaraDoorWindowSensor(BaseDeviceTestBase, InitialisableMixinTestBase, BatteryMixinTestBase):
+class TestAqaraDoorWindowSensor(SensorTestBase, InitialisableMixinTestBase, BatteryMixinTestBase):
     @pytest.mark.parametrize(
         'values', [(0, 'close'), (1, 'open'), (False, 'close'), (True, 'open')]
     )

--- a/controllers/zigbee/tests/sensor/aqara/test_door_window_sensor.py
+++ b/controllers/zigbee/tests/sensor/aqara/test_door_window_sensor.py
@@ -2,14 +2,15 @@ from typing import Tuple, Union
 from unittest.mock import MagicMock
 
 import pytest
-from powerpi_common_test.device.base import BaseDeviceTestBaseNew
-from powerpi_common_test.device.mixin import InitialisableMixinTestBaseNew
-from powerpi_common_test.sensor.mixin import BatteryMixinTestBaseNew
+from powerpi_common_test.device.base import BaseDeviceTestBase
+from powerpi_common_test.device.mixin import InitialisableMixinTestBase
+from powerpi_common_test.sensor.mixin import BatteryMixinTestBase
+
 from zigbee_controller.sensor.aqara.door_window_sensor import \
     AqaraDoorWindowSensor
 
 
-class TestAqaraDoorWindowSensor(BaseDeviceTestBaseNew, InitialisableMixinTestBaseNew, BatteryMixinTestBaseNew):
+class TestAqaraDoorWindowSensor(BaseDeviceTestBase, InitialisableMixinTestBase, BatteryMixinTestBase):
     @pytest.mark.parametrize(
         'values', [(0, 'close'), (1, 'open'), (False, 'close'), (True, 'open')]
     )

--- a/controllers/zigbee/tests/sensor/osram/test_switch_mini.py
+++ b/controllers/zigbee/tests/sensor/osram/test_switch_mini.py
@@ -3,17 +3,18 @@ from typing import List, Tuple
 from unittest.mock import MagicMock, PropertyMock
 
 import pytest
-from powerpi_common_test.device.base import BaseDeviceTestBaseNew
-from powerpi_common_test.device.mixin import InitialisableMixinTestBaseNew
-from powerpi_common_test.sensor.mixin import BatteryMixinTestBaseNew
+from powerpi_common_test.device.base import BaseDeviceTestBase
+from powerpi_common_test.device.mixin import InitialisableMixinTestBase
+from powerpi_common_test.sensor.mixin import BatteryMixinTestBase
 from pytest_mock import MockerFixture
+from zigpy.zcl import Cluster
+
 from zigbee_controller.sensor.osram.switch_mini import (Button,
                                                         OsramSwitchMiniSensor,
                                                         PressType)
-from zigpy.zcl import Cluster
 
 
-class TestOsramSwitchMiniSensor(BaseDeviceTestBaseNew, InitialisableMixinTestBaseNew, BatteryMixinTestBaseNew):
+class TestOsramSwitchMiniSensor(BaseDeviceTestBase, InitialisableMixinTestBase, BatteryMixinTestBase):
     @pytest.mark.parametrize('button', [Button.UP, Button.MIDDLE, Button.DOWN])
     def test_single_press_handler(
         self,
@@ -85,7 +86,7 @@ class TestOsramSwitchMiniSensor(BaseDeviceTestBaseNew, InitialisableMixinTestBas
         mocker: MockerFixture,
         values: Tuple[int, int]
     ):
-        #pylint: disable=too-many-arguments
+        # pylint: disable=too-many-arguments
         (data, percent) = values
 
         attribute = mocker.MagicMock()
@@ -105,7 +106,7 @@ class TestOsramSwitchMiniSensor(BaseDeviceTestBaseNew, InitialisableMixinTestBas
         powerpi_mqtt_producer: MagicMock,
         mocker: MockerFixture
     ):
-        #pylint: disable=too-many-arguments
+        # pylint: disable=too-many-arguments
         attribute = mocker.MagicMock()
         type(attribute).id = PropertyMock(return_value=0x0021)
         zigbee_in_cluster.find_attribute.return_value = attribute

--- a/controllers/zigbee/tests/sensor/osram/test_switch_mini.py
+++ b/controllers/zigbee/tests/sensor/osram/test_switch_mini.py
@@ -3,8 +3,8 @@ from typing import List, Tuple
 from unittest.mock import MagicMock, PropertyMock
 
 import pytest
-from powerpi_common_test.device.base import BaseDeviceTestBase
 from powerpi_common_test.device.mixin import InitialisableMixinTestBase
+from powerpi_common_test.sensor import SensorTestBase
 from powerpi_common_test.sensor.mixin import BatteryMixinTestBase
 from pytest_mock import MockerFixture
 from zigpy.zcl import Cluster
@@ -14,7 +14,7 @@ from zigbee_controller.sensor.osram.switch_mini import (Button,
                                                         PressType)
 
 
-class TestOsramSwitchMiniSensor(BaseDeviceTestBase, InitialisableMixinTestBase, BatteryMixinTestBase):
+class TestOsramSwitchMiniSensor(SensorTestBase, InitialisableMixinTestBase, BatteryMixinTestBase):
     @pytest.mark.parametrize('button', [Button.UP, Button.MIDDLE, Button.DOWN])
     def test_single_press_handler(
         self,


### PR DESCRIPTION
Resolves #237:
- Remove old python test bases.
- Rename new python test bases from `XNew` to `X`.
- Update all controllers to use renamed test bases.
- Fix for test pipeline to allow dependencies for `node-controller` to install.