### PR TITLE
#318/#355 Ensure each python service defines own config with used_config populated

### DIFF
--- a/common/python/poetry.lock
+++ b/common/python/poetry.lock
@@ -475,14 +475,14 @@ files = [
 
 [[package]]
 name = "pylint"
-version = "2.17.3"
+version = "2.17.4"
 description = "python code static checker"
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "pylint-2.17.3-py3-none-any.whl", hash = "sha256:a6cbb4c6e96eab4a3c7de7c6383c512478f58f88d95764507d84c899d656a89a"},
-    {file = "pylint-2.17.3.tar.gz", hash = "sha256:761907349e699f8afdcd56c4fe02f3021ab5b3a0fc26d19a9bfdc66c7d0d5cd5"},
+    {file = "pylint-2.17.4-py3-none-any.whl", hash = "sha256:7a1145fb08c251bdb5cca11739722ce64a63db479283d10ce718b2460e54123c"},
+    {file = "pylint-2.17.4.tar.gz", hash = "sha256:5dcf1d9e19f41f38e4e85d10f511e5b9c35e1aa74251bf95cdd8cb23584e2db1"},
 ]
 
 [package.dependencies]
@@ -810,4 +810,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "6b74f1261a3312dd4df0c471b42c73305e6fa06858dd0c79588e215f7ca07c19"
+content-hash = "d0c6850b53f3bc4b3aa93848fdcabdf81e573b7bce98c15ddc29404ac15e2e45"

--- a/common/python/powerpi_common/application.py
+++ b/common/python/powerpi_common/application.py
@@ -3,6 +3,7 @@ from asyncio import (CancelledError, ensure_future, get_event_loop,
 from signal import SIGINT, SIGTERM
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
 from powerpi_common.config.config_retriever import ConfigRetriever
 from powerpi_common.health import HealthService
 from powerpi_common.logger import Logger, LogMixin
@@ -72,7 +73,7 @@ class Application(LogMixin):
             await self._app_start()
 
             # start the health check
-            self.__health.start()
+            await self.__health.start()
 
             # loop forever
             await get_running_loop().create_future()

--- a/common/python/powerpi_common/config/__init__.py
+++ b/common/python/powerpi_common/config/__init__.py
@@ -1,1 +1,2 @@
 from .config import Config, ConfigFileType
+from .controller_config import ControllerConfig

--- a/common/python/powerpi_common/config/config.py
+++ b/common/python/powerpi_common/config/config.py
@@ -13,7 +13,7 @@ class ConfigFileType(str, Enum):
 
 class Config(ABC):
     '''
-    Extend to define a service's configuration paramters.
+    Extend to define a service's configuration parameters.
     '''
 
     __configs: Dict[ConfigFileType, Dict[str, Any]]

--- a/common/python/powerpi_common/config/config.py
+++ b/common/python/powerpi_common/config/config.py
@@ -1,7 +1,8 @@
 import json
 import os
+from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 
 class ConfigFileType(str, Enum):
@@ -10,7 +11,11 @@ class ConfigFileType(str, Enum):
     SCHEDULES = 'schedules'
 
 
-class Config:
+class Config(ABC):
+    '''
+    Extend to define a service's configuration paramters.
+    '''
+
     __configs: Dict[ConfigFileType, Dict[str, Any]]
 
     def __init__(self):
@@ -83,8 +88,12 @@ class Config:
         return all((self.__configs.get(fileType) is not None for fileType in types))
 
     @property
-    def used_config(self):
-        return [fileType.value for fileType in ConfigFileType]
+    @abstractmethod
+    def used_config(self) -> List[ConfigFileType]:
+        '''
+        Extend to define the list of config file types the extending service requires.
+        '''
+        raise NotImplementedError
 
     def get_config(self, file_type: ConfigFileType):
         return self.__configs.get(file_type)

--- a/common/python/powerpi_common/config/config_retriever.py
+++ b/common/python/powerpi_common/config/config_retriever.py
@@ -3,10 +3,15 @@ import os
 
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient, MQTTConsumer, MQTTMessage
+
 from .config import Config
 
 
 class ConfigRetriever:
+    '''
+    Service to retrieve configuration files from the message queue.
+    '''
+
     def __init__(self, config: Config, logger: Logger, mqtt_client: MQTTClient):
         self.__config = config
         self.__logger = logger
@@ -45,6 +50,10 @@ class ConfigRetriever:
 
 
 class ConfigConsumer(MQTTConsumer):
+    '''
+    MQTT consumer for configuration files in the message queue.
+    '''
+
     def __init__(self, topic: str, config: Config, logger: Logger):
         MQTTConsumer.__init__(
             self, topic, config, logger
@@ -61,7 +70,7 @@ class ConfigConsumer(MQTTConsumer):
                 f'Restarting service due to changed {entity} config'
             )
 
-            #pylint: disable=protected-access
+            # pylint: disable=protected-access
             os._exit(0)
         else:
             # this is a new or unused config, so just set it

--- a/common/python/powerpi_common/config/controller_config.py
+++ b/common/python/powerpi_common/config/controller_config.py
@@ -1,0 +1,11 @@
+from .config import Config, ConfigFileType
+
+
+class ControllerConfig(Config):
+    '''
+    Configuration for a controller (one that controls devices) service.
+    '''
+
+    @property
+    def used_config(self):
+        return [ConfigFileType.DEVICES, ConfigFileType.EVENTS]

--- a/common/python/powerpi_common/container.py
+++ b/common/python/powerpi_common/container.py
@@ -1,7 +1,7 @@
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from dependency_injector import containers, providers
+
 from powerpi_common.condition import ConditionContainer
-from powerpi_common.config import Config
 from powerpi_common.config.config_retriever import ConfigRetriever
 from powerpi_common.controller import Controller
 from powerpi_common.device import DeviceContainer
@@ -23,9 +23,7 @@ class Container(containers.DeclarativeContainer):
 
     version = providers.Dependency()
 
-    config = providers.Singleton(
-        Config
-    )
+    config = providers.Dependency()
 
     logger = providers.Singleton(
         Logger,

--- a/common/python/powerpi_common/health/health.py
+++ b/common/python/powerpi_common/health/health.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
+
 from powerpi_common.config import Config
 from powerpi_common.logger import Logger, LogMixin
 from powerpi_common.mqtt import MQTTClient
@@ -25,8 +26,11 @@ class HealthService(LogMixin):
         self.__mqtt_client = mqtt_client
         self.__scheduler = scheduler
 
-    def start(self):
+    async def start(self):
         self.log_info('Scheduling health checks')
+
+        # run it now before the schedule
+        await self.run()
 
         interval = IntervalTrigger(seconds=10)
 

--- a/common/python/pyproject.toml
+++ b/common/python/pyproject.toml
@@ -17,7 +17,7 @@ toml = "~=0.10.2"
 
 [tool.poetry.group.dev.dependencies]
 autopep8 = "~=2.0.2"
-pylint = "~=2.17.3"
+pylint = "~=2.17.4"
 
 [tool.poetry.group.test.dependencies]
 powerpi-common-test = {path = "../pytest", develop = true}

--- a/common/python/pyproject.toml
+++ b/common/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "powerpi-common"
-version = "0.3.3"
+version = "0.4.0"
 description = "PowerPi Common Python Library"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/common/python/tests/health/test_health.py
+++ b/common/python/tests/health/test_health.py
@@ -4,14 +4,22 @@ from unittest.mock import PropertyMock, patch
 import pytest
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
+from pytest_mock import MockerFixture
+
 from powerpi_common.health import HealthService
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
-from pytest_mock import MockerFixture
 
 
 class TestHealthService:
-    def test_start(self, subject: HealthService, powerpi_scheduler: AsyncIOScheduler):
+
+    @pytest.mark.asyncio
+    async def test_start(
+        self,
+        subject: HealthService,
+        powerpi_scheduler: AsyncIOScheduler,
+        mocker: MockerFixture
+    ):
         methods = []
         timers = []
 
@@ -21,7 +29,11 @@ class TestHealthService:
 
         powerpi_scheduler.add_job = add_job
 
-        subject.start()
+        with patch('powerpi_common.health.health.Path') as path:
+            instance = mocker.MagicMock()
+            path.return_value = instance
+
+            await subject.start()
 
         assert len(methods) == 1
         assert len(timers) == 1

--- a/controllers/energenie/energenie_controller/config.py
+++ b/controllers/energenie/energenie_controller/config.py
@@ -1,9 +1,14 @@
 import os
 
 from powerpi_common.config import Config as CommonConfig
+from powerpi_common.config import ConfigFileType
 
 
 class EnergenieConfig(CommonConfig):
+    @property
+    def used_config(self):
+        return [ConfigFileType.DEVICES, ConfigFileType.EVENTS]
+
     @property
     def device_fatal(self):
         value = os.getenv('DEVICE_FATAL')

--- a/controllers/energenie/energenie_controller/config.py
+++ b/controllers/energenie/energenie_controller/config.py
@@ -1,13 +1,9 @@
 import os
 
-from powerpi_common.config import Config as CommonConfig
-from powerpi_common.config import ConfigFileType
+from powerpi_common.config import ControllerConfig
 
 
-class EnergenieConfig(CommonConfig):
-    @property
-    def used_config(self):
-        return [ConfigFileType.DEVICES, ConfigFileType.EVENTS]
+class EnergenieConfig(ControllerConfig):
 
     @property
     def device_fatal(self):

--- a/controllers/energenie/energenie_controller/container.py
+++ b/controllers/energenie/energenie_controller/container.py
@@ -1,8 +1,9 @@
 from dependency_injector import containers, providers
+from powerpi_common.container import Container as CommonContainer
+
 from energenie_controller.__version__ import __app_name__, __version__
 from energenie_controller.config import EnergenieConfig
 from energenie_controller.controller import Controller
-from powerpi_common.container import Container as CommonContainer
 
 
 class ApplicationContainer(containers.DeclarativeContainer):
@@ -13,19 +14,20 @@ class ApplicationContainer(containers.DeclarativeContainer):
         __self__
     )
 
-    common = providers.Container(
-        CommonContainer,
-        app_name=__app_name__,
-        version=__version__
-    )
-
     config = providers.Singleton(
         EnergenieConfig
     )
 
+    common = providers.Container(
+        CommonContainer,
+        app_name=__app_name__,
+        version=__version__,
+        config=config
+    )
+
     controller = providers.Singleton(
         Controller,
-        config=common.config,
+        config=config,
         logger=common.logger,
         config_retriever=common.config_retriever,
         device_manager=common.device.device_manager,

--- a/controllers/energenie/poetry.lock
+++ b/controllers/energenie/poetry.lock
@@ -32,14 +32,14 @@ zookeeper = ["kazoo"]
 
 [[package]]
 name = "astroid"
-version = "2.15.0"
+version = "2.15.5"
 description = "An abstract syntax tree for Python with inference support."
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "astroid-2.15.0-py3-none-any.whl", hash = "sha256:e3e4d0ffc2d15d954065579689c36aac57a339a4679a679579af6401db4d3fdb"},
-    {file = "astroid-2.15.0.tar.gz", hash = "sha256:525f126d5dc1b8b0b6ee398b33159105615d92dc4a17f2cd064125d57f6186fa"},
+    {file = "astroid-2.15.5-py3-none-any.whl", hash = "sha256:078e5212f9885fa85fbb0cf0101978a336190aadea6e13305409d099f71b2324"},
+    {file = "astroid-2.15.5.tar.gz", hash = "sha256:1039262575027b441137ab4a62a793a9b43defb42c32d5670f38686207cd780f"},
 ]
 
 [package.dependencies]
@@ -469,7 +469,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "powerpi-common"
-version = "0.3.3"
+version = "0.4.0"
 description = "PowerPi Common Python Library"
 category = "dev"
 optional = false
@@ -542,18 +542,18 @@ resolved_reference = "eec562c140dd34027b3184d81f549c9d4a65f5db"
 
 [[package]]
 name = "pylint"
-version = "2.17.1"
+version = "2.17.4"
 description = "python code static checker"
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "pylint-2.17.1-py3-none-any.whl", hash = "sha256:8660a54e3f696243d644fca98f79013a959c03f979992c1ab59c24d3f4ec2700"},
-    {file = "pylint-2.17.1.tar.gz", hash = "sha256:d4d009b0116e16845533bc2163493d6681846ac725eab8ca8014afb520178ddd"},
+    {file = "pylint-2.17.4-py3-none-any.whl", hash = "sha256:7a1145fb08c251bdb5cca11739722ce64a63db479283d10ce718b2460e54123c"},
+    {file = "pylint-2.17.4.tar.gz", hash = "sha256:5dcf1d9e19f41f38e4e85d10f511e5b9c35e1aa74251bf95cdd8cb23584e2db1"},
 ]
 
 [package.dependencies]
-astroid = ">=2.15.0,<=2.17.0-dev0"
+astroid = ">=2.15.4,<=2.17.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
     {version = ">=0.2", markers = "python_version < \"3.11\""},
@@ -893,4 +893,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "6c8415faf61046ead91deb88ad5692935920570d6cf16ab893fe0d8927f33b19"
+content-hash = "d4717e7fffe3d8c53dc8b7d7b0aa4c0b5da3bd900b987327645c8f817cc528bb"

--- a/controllers/energenie/pyproject.toml
+++ b/controllers/energenie/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "energenie_controller"
-version = "0.2.1"
+version = "0.2.2"
 description = "PowerPi Engergenie Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]
@@ -17,7 +17,7 @@ powerpi-common = {path = "../../common/python", develop = true}
 
 [tool.poetry.group.dev.dependencies]
 autopep8 = "~=2.0.2"
-pylint = "~=2.17.1"
+pylint = "~=2.17.4"
 
 [tool.poetry.group.test.dependencies]
 powerpi-common-test = {path = "../../common/pytest", develop = true}

--- a/controllers/harmony/harmony_controller/container.py
+++ b/controllers/harmony/harmony_controller/container.py
@@ -1,8 +1,9 @@
 from dependency_injector import containers, providers
+from powerpi_common.config import ControllerConfig
+from powerpi_common.container import Container as CommonContainer
 
 from harmony_controller.__version__ import __app_name__, __version__
 from harmony_controller.device.container import DeviceContainer
-from powerpi_common.container import Container as CommonContainer
 
 
 class ApplicationContainer(containers.DeclarativeContainer):
@@ -13,10 +14,15 @@ class ApplicationContainer(containers.DeclarativeContainer):
         __self__
     )
 
+    config = providers.Singleton(
+        ControllerConfig
+    )
+
     common = providers.Container(
         CommonContainer,
         app_name=__app_name__,
-        version=__version__
+        version=__version__,
+        config=config
     )
 
     device = providers.Container(

--- a/controllers/harmony/poetry.lock
+++ b/controllers/harmony/poetry.lock
@@ -173,14 +173,14 @@ zookeeper = ["kazoo"]
 
 [[package]]
 name = "astroid"
-version = "2.15.0"
+version = "2.15.5"
 description = "An abstract syntax tree for Python with inference support."
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "astroid-2.15.0-py3-none-any.whl", hash = "sha256:e3e4d0ffc2d15d954065579689c36aac57a339a4679a679579af6401db4d3fdb"},
-    {file = "astroid-2.15.0.tar.gz", hash = "sha256:525f126d5dc1b8b0b6ee398b33159105615d92dc4a17f2cd064125d57f6186fa"},
+    {file = "astroid-2.15.5-py3-none-any.whl", hash = "sha256:078e5212f9885fa85fbb0cf0101978a336190aadea6e13305409d099f71b2324"},
+    {file = "astroid-2.15.5.tar.gz", hash = "sha256:1039262575027b441137ab4a62a793a9b43defb42c32d5670f38686207cd780f"},
 ]
 
 [package.dependencies]
@@ -897,7 +897,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "powerpi-common"
-version = "0.3.3"
+version = "0.4.0"
 description = "PowerPi Common Python Library"
 category = "dev"
 optional = false
@@ -1054,18 +1054,18 @@ files = [
 
 [[package]]
 name = "pylint"
-version = "2.17.1"
+version = "2.17.4"
 description = "python code static checker"
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "pylint-2.17.1-py3-none-any.whl", hash = "sha256:8660a54e3f696243d644fca98f79013a959c03f979992c1ab59c24d3f4ec2700"},
-    {file = "pylint-2.17.1.tar.gz", hash = "sha256:d4d009b0116e16845533bc2163493d6681846ac725eab8ca8014afb520178ddd"},
+    {file = "pylint-2.17.4-py3-none-any.whl", hash = "sha256:7a1145fb08c251bdb5cca11739722ce64a63db479283d10ce718b2460e54123c"},
+    {file = "pylint-2.17.4.tar.gz", hash = "sha256:5dcf1d9e19f41f38e4e85d10f511e5b9c35e1aa74251bf95cdd8cb23584e2db1"},
 ]
 
 [package.dependencies]
-astroid = ">=2.15.0,<=2.17.0-dev0"
+astroid = ">=2.15.4,<=2.17.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
     {version = ">=0.2", markers = "python_version < \"3.11\""},
@@ -1484,4 +1484,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "72f49878d83bb27bd7145d79c707f984eb4582ef3d77ba70a79bbfd10af2f0c0"
+content-hash = "06ff3a3627a97b96907a754e3797a01ff45b8ff1dc087818da692231af49c86e"

--- a/controllers/harmony/pyproject.toml
+++ b/controllers/harmony/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "harmony_controller"
-version = "0.3.1"
+version = "0.3.2"
 description = "PowerPi Logitech Harmony Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]
@@ -19,7 +19,7 @@ powerpi-common = {path = "../../common/python", develop = true}
 
 [tool.poetry.group.dev.dependencies]
 autopep8 = "~=2.0.2"
-pylint = "~=2.17.1"
+pylint = "~=2.17.4"
 
 [tool.poetry.group.test.dependencies]
 powerpi-common-test = {path = "../../common/pytest", develop = true}

--- a/controllers/lifx/lifx_controller/container.py
+++ b/controllers/lifx/lifx_controller/container.py
@@ -1,4 +1,5 @@
 from dependency_injector import containers, providers
+from powerpi_common.config import ControllerConfig
 from powerpi_common.container import Container as CommonContainer
 
 from lifx_controller.__version__ import __app_name__, __version__
@@ -13,10 +14,15 @@ class ApplicationContainer(containers.DeclarativeContainer):
         __self__
     )
 
+    config = providers.Singleton(
+        ControllerConfig
+    )
+
     common = providers.Container(
         CommonContainer,
         app_name=__app_name__,
-        version=__version__
+        version=__version__,
+        config=config
     )
 
     device = providers.Container(

--- a/controllers/lifx/poetry.lock
+++ b/controllers/lifx/poetry.lock
@@ -2,19 +2,22 @@
 
 [[package]]
 name = "aiolifx"
-version = "0.8.9"
+version = "0.9.0"
 description = "API for local communication with LIFX devices over a LAN with asyncio."
 category = "main"
 optional = false
 python-versions = ">=3.4"
 files = [
-    {file = "aiolifx-0.8.9-py3-none-any.whl", hash = "sha256:26e0b7d13818a6ff258315e7710e6e385bdb0a6ec307d81938f9d40fff81538e"},
-    {file = "aiolifx-0.8.9.tar.gz", hash = "sha256:221f3674d0d9777b1b1878710d3b732505e48e7e8f81e7dbd12db882db6238ef"},
+    {file = "aiolifx-0.9.0-py3-none-any.whl", hash = "sha256:4e3c4a4dc651d8a0728a2de2dee0e47665ac329b40ae1e510d7040e0bef9041b"},
+    {file = "aiolifx-0.9.0.tar.gz", hash = "sha256:a0af0887ad84170bb75f93cd5452c7f9471ee9906cec83177ade7f0c7c5f7793"},
 ]
 
 [package.dependencies]
+async-timeout = ">=3.0.1"
 bitstring = "*"
+click = ">=8.1.0,<8.2.0"
 ifaddr = "*"
+InquirerPy = ">=0.3.0,<0.4.0"
 
 [[package]]
 name = "apscheduler"
@@ -48,14 +51,14 @@ zookeeper = ["kazoo"]
 
 [[package]]
 name = "astroid"
-version = "2.15.0"
+version = "2.15.5"
 description = "An abstract syntax tree for Python with inference support."
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "astroid-2.15.0-py3-none-any.whl", hash = "sha256:e3e4d0ffc2d15d954065579689c36aac57a339a4679a679579af6401db4d3fdb"},
-    {file = "astroid-2.15.0.tar.gz", hash = "sha256:525f126d5dc1b8b0b6ee398b33159105615d92dc4a17f2cd064125d57f6186fa"},
+    {file = "astroid-2.15.5-py3-none-any.whl", hash = "sha256:078e5212f9885fa85fbb0cf0101978a336190aadea6e13305409d099f71b2324"},
+    {file = "astroid-2.15.5.tar.gz", hash = "sha256:1039262575027b441137ab4a62a793a9b43defb42c32d5670f38686207cd780f"},
 ]
 
 [package.dependencies]
@@ -64,6 +67,18 @@ typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.11\""}
 wrapt = [
     {version = ">=1.11,<2", markers = "python_version < \"3.11\""},
     {version = ">=1.14,<2", markers = "python_version >= \"3.11\""},
+]
+
+[[package]]
+name = "async-timeout"
+version = "4.0.2"
+description = "Timeout context manager for asyncio programs"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "async-timeout-4.0.2.tar.gz", hash = "sha256:2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15"},
+    {file = "async_timeout-4.0.2-py3-none-any.whl", hash = "sha256:8ca1e4fcf50d07413d66d1a5e416e42cfdf5851c981d679a09851a6853383b3c"},
 ]
 
 [[package]]
@@ -96,10 +111,25 @@ files = [
 ]
 
 [[package]]
+name = "click"
+version = "8.1.3"
+description = "Composable command line interface toolkit"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
+    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
 name = "colorama"
 version = "0.4.5"
 description = "Cross-platform colored terminal text."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 files = [
@@ -332,6 +362,25 @@ files = [
 ]
 
 [[package]]
+name = "inquirerpy"
+version = "0.3.4"
+description = "Python port of Inquirer.js (A collection of common interactive command-line user interfaces)"
+category = "main"
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "InquirerPy-0.3.4-py3-none-any.whl", hash = "sha256:c65fdfbac1fa00e3ee4fb10679f4d3ed7a012abf4833910e63c295827fe2a7d4"},
+    {file = "InquirerPy-0.3.4.tar.gz", hash = "sha256:89d2ada0111f337483cb41ae31073108b2ec1e618a49d7110b0d7ade89fc197e"},
+]
+
+[package.dependencies]
+pfzy = ">=0.3.1,<0.4.0"
+prompt-toolkit = ">=3.0.1,<4.0.0"
+
+[package.extras]
+docs = ["Sphinx (>=4.1.2,<5.0.0)", "furo (>=2021.8.17-beta.43,<2022.0.0)", "myst-parser (>=0.15.1,<0.16.0)", "sphinx-autobuild (>=2021.3.14,<2022.0.0)", "sphinx-copybutton (>=0.4.0,<0.5.0)"]
+
+[[package]]
 name = "isort"
 version = "5.10.1"
 description = "A Python utility / library to sort Python imports."
@@ -451,6 +500,21 @@ files = [
 pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
+name = "pfzy"
+version = "0.3.4"
+description = "Python port of the fzy fuzzy string matching algorithm"
+category = "main"
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "pfzy-0.3.4-py3-none-any.whl", hash = "sha256:5f50d5b2b3207fa72e7ec0ef08372ef652685470974a107d0d4999fc5a903a96"},
+    {file = "pfzy-0.3.4.tar.gz", hash = "sha256:717ea765dd10b63618e7298b2d98efd819e0b30cd5905c9707223dceeb94b3f1"},
+]
+
+[package.extras]
+docs = ["Sphinx (>=4.1.2,<5.0.0)", "furo (>=2021.8.17-beta.43,<2022.0.0)", "myst-parser (>=0.15.1,<0.16.0)", "sphinx-autobuild (>=2021.3.14,<2022.0.0)", "sphinx-copybutton (>=0.4.0,<0.5.0)"]
+
+[[package]]
 name = "platformdirs"
 version = "2.5.2"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
@@ -484,7 +548,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "powerpi-common"
-version = "0.3.3"
+version = "0.4.0"
 description = "PowerPi Common Python Library"
 category = "dev"
 optional = false
@@ -524,6 +588,21 @@ type = "directory"
 url = "../../common/pytest"
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.38"
+description = "Library for building powerful interactive command lines in Python"
+category = "main"
+optional = false
+python-versions = ">=3.7.0"
+files = [
+    {file = "prompt_toolkit-3.0.38-py3-none-any.whl", hash = "sha256:45ea77a2f7c60418850331366c81cf6b5b9cf4c7fd34616f733c5427e6abbb1f"},
+    {file = "prompt_toolkit-3.0.38.tar.gz", hash = "sha256:23ac5d50538a9a38c8bde05fecb47d0b403ecd0662857a86f886f798563d5b9b"},
+]
+
+[package.dependencies]
+wcwidth = "*"
+
+[[package]]
 name = "pycodestyle"
 version = "2.10.0"
 description = "Python style guide checker"
@@ -537,18 +616,18 @@ files = [
 
 [[package]]
 name = "pylint"
-version = "2.17.1"
+version = "2.17.4"
 description = "python code static checker"
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "pylint-2.17.1-py3-none-any.whl", hash = "sha256:8660a54e3f696243d644fca98f79013a959c03f979992c1ab59c24d3f4ec2700"},
-    {file = "pylint-2.17.1.tar.gz", hash = "sha256:d4d009b0116e16845533bc2163493d6681846ac725eab8ca8014afb520178ddd"},
+    {file = "pylint-2.17.4-py3-none-any.whl", hash = "sha256:7a1145fb08c251bdb5cca11739722ce64a63db479283d10ce718b2460e54123c"},
+    {file = "pylint-2.17.4.tar.gz", hash = "sha256:5dcf1d9e19f41f38e4e85d10f511e5b9c35e1aa74251bf95cdd8cb23584e2db1"},
 ]
 
 [package.dependencies]
-astroid = ">=2.15.0,<=2.17.0-dev0"
+astroid = ">=2.15.4,<=2.17.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
     {version = ">=0.2", markers = "python_version < \"3.11\""},
@@ -796,6 +875,18 @@ devenv = ["black", "pyroma", "pytest-cov", "zest.releaser"]
 test = ["pytest (>=4.3)", "pytest-mock (>=3.3)"]
 
 [[package]]
+name = "wcwidth"
+version = "0.2.6"
+description = "Measures the displayed width of unicode strings in a terminal"
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "wcwidth-0.2.6-py2.py3-none-any.whl", hash = "sha256:795b138f6875577cd91bba52baf9e445cd5118fd32723b460e30a0af30ea230e"},
+    {file = "wcwidth-0.2.6.tar.gz", hash = "sha256:a5220780a404dbe3353789870978e472cfe477761f06ee55077256e509b156d0"},
+]
+
+[[package]]
 name = "wrapt"
 version = "1.14.1"
 description = "Module for decorators, wrappers and monkey patching."
@@ -872,4 +963,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "593300dd556353c9cf6cb7d5f98099b2a04ef977eb33a3f290a8432a34d2cdbc"
+content-hash = "cd6d02a404b24b179349fcc9cf91d34e640e538a4e3fa8beefd9d266588124d9"

--- a/controllers/lifx/pyproject.toml
+++ b/controllers/lifx/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lifx_controller"
-version = "0.4.0"
+version = "0.4.1"
 description = "PowerPi LIFX Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]
@@ -9,14 +9,14 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.9"
-aiolifx = "~=0.8.9"
+aiolifx = "~=0.9.0"
 
 [tool.poetry.group.powerpi.dependencies]
 powerpi-common = {path = "../../common/python", develop = true}
 
 [tool.poetry.group.dev.dependencies]
 autopep8 = "~=2.0.2"
-pylint = "~=2.17.1"
+pylint = "~=2.17.4"
 
 [tool.poetry.group.test.dependencies]
 powerpi-common-test = {path = "../../common/pytest", develop = true}

--- a/controllers/macro/macro_controller/container.py
+++ b/controllers/macro/macro_controller/container.py
@@ -1,8 +1,9 @@
 from dependency_injector import containers, providers
+from powerpi_common.config import ControllerConfig
+from powerpi_common.container import Container as CommonContainer
 
 from macro_controller.__version__ import __app_name__, __version__
 from macro_controller.device.container import DeviceContainer
-from powerpi_common.container import Container as CommonContainer
 
 
 class ApplicationContainer(containers.DeclarativeContainer):
@@ -13,10 +14,15 @@ class ApplicationContainer(containers.DeclarativeContainer):
         __self__
     )
 
+    config = providers.Singleton(
+        ControllerConfig
+    )
+
     common = providers.Container(
         CommonContainer,
         app_name=__app_name__,
-        version=__version__
+        version=__version__,
+        config=config
     )
 
     device = providers.Container(

--- a/controllers/macro/poetry.lock
+++ b/controllers/macro/poetry.lock
@@ -32,14 +32,14 @@ zookeeper = ["kazoo"]
 
 [[package]]
 name = "astroid"
-version = "2.15.0"
+version = "2.15.5"
 description = "An abstract syntax tree for Python with inference support."
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "astroid-2.15.0-py3-none-any.whl", hash = "sha256:e3e4d0ffc2d15d954065579689c36aac57a339a4679a679579af6401db4d3fdb"},
-    {file = "astroid-2.15.0.tar.gz", hash = "sha256:525f126d5dc1b8b0b6ee398b33159105615d92dc4a17f2cd064125d57f6186fa"},
+    {file = "astroid-2.15.5-py3-none-any.whl", hash = "sha256:078e5212f9885fa85fbb0cf0101978a336190aadea6e13305409d099f71b2324"},
+    {file = "astroid-2.15.5.tar.gz", hash = "sha256:1039262575027b441137ab4a62a793a9b43defb42c32d5670f38686207cd780f"},
 ]
 
 [package.dependencies]
@@ -443,7 +443,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "powerpi-common"
-version = "0.3.3"
+version = "0.4.0"
 description = "PowerPi Common Python Library"
 category = "dev"
 optional = false
@@ -496,18 +496,18 @@ files = [
 
 [[package]]
 name = "pylint"
-version = "2.17.1"
+version = "2.17.4"
 description = "python code static checker"
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "pylint-2.17.1-py3-none-any.whl", hash = "sha256:8660a54e3f696243d644fca98f79013a959c03f979992c1ab59c24d3f4ec2700"},
-    {file = "pylint-2.17.1.tar.gz", hash = "sha256:d4d009b0116e16845533bc2163493d6681846ac725eab8ca8014afb520178ddd"},
+    {file = "pylint-2.17.4-py3-none-any.whl", hash = "sha256:7a1145fb08c251bdb5cca11739722ce64a63db479283d10ce718b2460e54123c"},
+    {file = "pylint-2.17.4.tar.gz", hash = "sha256:5dcf1d9e19f41f38e4e85d10f511e5b9c35e1aa74251bf95cdd8cb23584e2db1"},
 ]
 
 [package.dependencies]
-astroid = ">=2.15.0,<=2.17.0-dev0"
+astroid = ">=2.15.4,<=2.17.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
     {version = ">=0.2", markers = "python_version < \"3.11\""},
@@ -831,4 +831,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "93e673341fff6ba5d894a9d1c03947186a814304dd7033c2657e016fe536e05f"
+content-hash = "764bbf54e9bfc33f43a01c6e60a17bb5f05e3af636409b4a33f5166b9fbf968c"

--- a/controllers/macro/pyproject.toml
+++ b/controllers/macro/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "macro_controller"
-version = "1.2.1"
+version = "1.2.2"
 description = "PowerPi Macro Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]
@@ -15,7 +15,7 @@ powerpi-common = {path = "../../common/python", develop = true}
 
 [tool.poetry.group.dev.dependencies]
 autopep8 = "~=2.0.2"
-pylint = "~=2.17.1"
+pylint = "~=2.17.4"
 
 [tool.poetry.group.test.dependencies]
 powerpi-common-test = {path = "../../common/pytest", develop = true}

--- a/controllers/network/network_controller/container.py
+++ b/controllers/network/network_controller/container.py
@@ -1,4 +1,5 @@
 from dependency_injector import containers, providers
+from powerpi_common.config import ControllerConfig
 from powerpi_common.container import Container as CommonContainer
 
 from network_controller.__version__ import __app_name__, __version__
@@ -12,8 +13,13 @@ class ApplicationContainer(containers.DeclarativeContainer):
         __self__
     )
 
+    config = providers.Singleton(
+        ControllerConfig
+    )
+
     common = providers.Container(
         CommonContainer,
         app_name=__app_name__,
-        version=__version__
+        version=__version__,
+        config=config
     )

--- a/controllers/network/poetry.lock
+++ b/controllers/network/poetry.lock
@@ -461,7 +461,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "powerpi-common"
-version = "0.3.3"
+version = "0.4.0"
 description = "PowerPi Common Python Library"
 category = "dev"
 optional = false

--- a/controllers/network/pyproject.toml
+++ b/controllers/network/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "network_controller"
-version = "0.1.1"
+version = "0.1.2"
 description = "PowerPi Network Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/node/node_controller/config.py
+++ b/controllers/node/node_controller/config.py
@@ -1,10 +1,10 @@
 import os
 
-from powerpi_common.config import Config as CommonConfig
+from powerpi_common.config import ControllerConfig
 from powerpi_common.config.config import as_int
 
 
-class NodeConfig(CommonConfig):
+class NodeConfig(ControllerConfig):
     @property
     def device_fatal(self):
         value = os.getenv('DEVICE_FATAL')

--- a/controllers/node/node_controller/container.py
+++ b/controllers/node/node_controller/container.py
@@ -14,14 +14,15 @@ class ApplicationContainer(containers.DeclarativeContainer):
         __self__
     )
 
+    config = providers.Singleton(
+        NodeConfig
+    )
+
     common = providers.Container(
         CommonContainer,
         app_name=__app_name__,
-        version=__version__
-    )
-
-    config = providers.Singleton(
-        NodeConfig
+        version=__version__,
+        config=config
     )
 
     shutdown = providers.Singleton(

--- a/controllers/node/poetry.lock
+++ b/controllers/node/poetry.lock
@@ -44,14 +44,14 @@ zookeeper = ["kazoo"]
 
 [[package]]
 name = "astroid"
-version = "2.15.0"
+version = "2.15.5"
 description = "An abstract syntax tree for Python with inference support."
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "astroid-2.15.0-py3-none-any.whl", hash = "sha256:e3e4d0ffc2d15d954065579689c36aac57a339a4679a679579af6401db4d3fdb"},
-    {file = "astroid-2.15.0.tar.gz", hash = "sha256:525f126d5dc1b8b0b6ee398b33159105615d92dc4a17f2cd064125d57f6186fa"},
+    {file = "astroid-2.15.5-py3-none-any.whl", hash = "sha256:078e5212f9885fa85fbb0cf0101978a336190aadea6e13305409d099f71b2324"},
+    {file = "astroid-2.15.5.tar.gz", hash = "sha256:1039262575027b441137ab4a62a793a9b43defb42c32d5670f38686207cd780f"},
 ]
 
 [package.dependencies]
@@ -484,7 +484,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "powerpi-common"
-version = "0.3.3"
+version = "0.4.0"
 description = "PowerPi Common Python Library"
 category = "dev"
 optional = false
@@ -537,18 +537,18 @@ files = [
 
 [[package]]
 name = "pylint"
-version = "2.17.1"
+version = "2.17.4"
 description = "python code static checker"
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "pylint-2.17.1-py3-none-any.whl", hash = "sha256:8660a54e3f696243d644fca98f79013a959c03f979992c1ab59c24d3f4ec2700"},
-    {file = "pylint-2.17.1.tar.gz", hash = "sha256:d4d009b0116e16845533bc2163493d6681846ac725eab8ca8014afb520178ddd"},
+    {file = "pylint-2.17.4-py3-none-any.whl", hash = "sha256:7a1145fb08c251bdb5cca11739722ce64a63db479283d10ce718b2460e54123c"},
+    {file = "pylint-2.17.4.tar.gz", hash = "sha256:5dcf1d9e19f41f38e4e85d10f511e5b9c35e1aa74251bf95cdd8cb23584e2db1"},
 ]
 
 [package.dependencies]
-astroid = ">=2.15.0,<=2.17.0-dev0"
+astroid = ">=2.15.4,<=2.17.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
     {version = ">=0.2", markers = "python_version < \"3.11\""},
@@ -902,4 +902,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "74286779704e192aedb094f2a5221f5b1713501a9d38221bee37531851bf1198"
+content-hash = "ae76645ed75889ff3f3f191f0528649400637a5faa45d5210ed6ed1c1b25d248"

--- a/controllers/node/pyproject.toml
+++ b/controllers/node/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "node_controller"
-version = "0.1.2"
+version = "0.1.3"
 description = "PowerPi Node Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]
@@ -20,7 +20,7 @@ powerpi-common = {path = "../../common/python", develop = true}
 
 [tool.poetry.group.dev.dependencies]
 autopep8 = "~=2.0.2"
-pylint = "~=2.17.1"
+pylint = "~=2.17.4"
 
 [tool.poetry.group.test.dependencies]
 powerpi-common-test = {path = "../../common/pytest", develop = true}

--- a/controllers/zigbee/poetry.lock
+++ b/controllers/zigbee/poetry.lock
@@ -156,14 +156,14 @@ zookeeper = ["kazoo"]
 
 [[package]]
 name = "astroid"
-version = "2.15.0"
+version = "2.15.5"
 description = "An abstract syntax tree for Python with inference support."
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "astroid-2.15.0-py3-none-any.whl", hash = "sha256:e3e4d0ffc2d15d954065579689c36aac57a339a4679a679579af6401db4d3fdb"},
-    {file = "astroid-2.15.0.tar.gz", hash = "sha256:525f126d5dc1b8b0b6ee398b33159105615d92dc4a17f2cd064125d57f6186fa"},
+    {file = "astroid-2.15.5-py3-none-any.whl", hash = "sha256:078e5212f9885fa85fbb0cf0101978a336190aadea6e13305409d099f71b2324"},
+    {file = "astroid-2.15.5.tar.gz", hash = "sha256:1039262575027b441137ab4a62a793a9b43defb42c32d5670f38686207cd780f"},
 ]
 
 [package.dependencies]
@@ -950,7 +950,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "powerpi-common"
-version = "0.3.3"
+version = "0.4.0"
 description = "PowerPi Common Python Library"
 category = "dev"
 optional = false
@@ -1015,18 +1015,18 @@ files = [
 
 [[package]]
 name = "pylint"
-version = "2.17.1"
+version = "2.17.4"
 description = "python code static checker"
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "pylint-2.17.1-py3-none-any.whl", hash = "sha256:8660a54e3f696243d644fca98f79013a959c03f979992c1ab59c24d3f4ec2700"},
-    {file = "pylint-2.17.1.tar.gz", hash = "sha256:d4d009b0116e16845533bc2163493d6681846ac725eab8ca8014afb520178ddd"},
+    {file = "pylint-2.17.4-py3-none-any.whl", hash = "sha256:7a1145fb08c251bdb5cca11739722ce64a63db479283d10ce718b2460e54123c"},
+    {file = "pylint-2.17.4.tar.gz", hash = "sha256:5dcf1d9e19f41f38e4e85d10f511e5b9c35e1aa74251bf95cdd8cb23584e2db1"},
 ]
 
 [package.dependencies]
-astroid = ">=2.15.0,<=2.17.0-dev0"
+astroid = ">=2.15.4,<=2.17.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
     {version = ">=0.2", markers = "python_version < \"3.11\""},
@@ -1507,14 +1507,14 @@ multidict = ">=4.0"
 
 [[package]]
 name = "zigpy"
-version = "0.53.3"
+version = "0.56.0"
 description = "Library implementing a ZigBee stack"
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "zigpy-0.53.3-py3-none-any.whl", hash = "sha256:ab37ea06523daa458021f94b9d87fbe363980fdc8c4546d04a12e9f26b0b9823"},
-    {file = "zigpy-0.53.3.tar.gz", hash = "sha256:0fe70d1036d5a9024147615433fa00d269609e0305afdb106f98d9d11942cacb"},
+    {file = "zigpy-0.56.0-py3-none-any.whl", hash = "sha256:7c461c7b73f8b7b12e5148f1644bd0dd5bbf046d401811680121947ba89bc8d5"},
+    {file = "zigpy-0.56.0.tar.gz", hash = "sha256:48852272d800fbf30a80cc1ed021f7af6d427bebeb535f285346944a6839f5fe"},
 ]
 
 [package.dependencies]
@@ -1528,18 +1528,19 @@ pyserial-asyncio = [
     {version = "*", markers = "platform_system != \"Windows\""},
     {version = "!=0.5", markers = "platform_system == \"Windows\""},
 ]
+typing-extensions = "*"
 voluptuous = "*"
 
 [[package]]
 name = "zigpy-znp"
-version = "0.9.3"
+version = "0.11.1"
 description = "A library for zigpy which communicates with TI ZNP radios"
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "zigpy-znp-0.9.3.tar.gz", hash = "sha256:d3a787fc8693b68b1c8cb08fb415800b1205daaf3869f4da61fc13314d4070c7"},
-    {file = "zigpy_znp-0.9.3-py3-none-any.whl", hash = "sha256:3d3308526dcffd0313e99be6b6d909aac8f43dbd0c2e258f594de6b416c3c4e3"},
+    {file = "zigpy-znp-0.11.1.tar.gz", hash = "sha256:2e671b1ac2cffb99f12dcb22df5cf59f6bc2ca8679843ed41a4663da0391d05b"},
+    {file = "zigpy_znp-0.11.1-py3-none-any.whl", hash = "sha256:cab9be6e64d7ae1852f0be88cc43a3249920eeeac9b0b807111de779f6ab142f"},
 ]
 
 [package.dependencies]
@@ -1547,7 +1548,7 @@ async-timeout = "*"
 coloredlogs = "*"
 jsonschema = "*"
 voluptuous = "*"
-zigpy = ">=0.52.0"
+zigpy = ">=0.55.0"
 
 [package.extras]
 testing = ["coveralls", "pytest (>=7.1.2)", "pytest-asyncio (>=0.19.0)", "pytest-cov (>=3.0.0)", "pytest-mock (>=3.8.2)", "pytest-timeout (>=2.1.0)"]
@@ -1555,4 +1556,4 @@ testing = ["coveralls", "pytest (>=7.1.2)", "pytest-asyncio (>=0.19.0)", "pytest
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "14cd9b8610e64142b6375932ca138d326b9f1965f7331a9b08fed863838de63f"
+content-hash = "1d695dac6636af0ff55ecaf97f8db2a41fd6695376a5d0bffcd992538627d03b"

--- a/controllers/zigbee/pyproject.toml
+++ b/controllers/zigbee/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zigbee_controller"
-version = "0.3.0"
+version = "0.3.1"
 description = "PowerPi ZigBee Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]
@@ -9,15 +9,15 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.9"
-zigpy = "~=0.53.3"
-zigpy-znp = "~=0.9.3"
+zigpy = "~=0.56.0"
+zigpy-znp = "~=0.11.1"
 
 [tool.poetry.group.powerpi.dependencies]
 powerpi-common = {path = "../../common/python", develop = true}
 
 [tool.poetry.group.dev.dependencies]
 autopep8 = "~=2.0.2"
-pylint = "~=2.17.1"
+pylint = "~=2.17.4"
 
 [tool.poetry.group.test.dependencies]
 powerpi-common-test = {path = "../../common/pytest", develop = true}

--- a/controllers/zigbee/tests/sensor/aqara/test_door_window_sensor.py
+++ b/controllers/zigbee/tests/sensor/aqara/test_door_window_sensor.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Tuple, Union
 from unittest.mock import MagicMock
 
@@ -58,7 +59,7 @@ class TestAqaraDoorWindowSensor(SensorTestBase, InitialisableMixinTestBase, Batt
         value += data.to_bytes(2, 'little')
         value = value.decode('utf8')
 
-        subject.on_attribute_updated(0xFF01, value)
+        subject.on_attribute_updated(0xFF01, value, datetime.utcnow())
 
         topic = 'event/test/battery'
         message = {'value': percent, 'unit': '%'}
@@ -78,7 +79,7 @@ class TestAqaraDoorWindowSensor(SensorTestBase, InitialisableMixinTestBase, Batt
         value += b'\x21\x00\x00'
         value = value.decode('utf8')
 
-        subject.on_attribute_updated(attribute_id, value)
+        subject.on_attribute_updated(attribute_id, value, datetime.utcnow())
 
         powerpi_mqtt_producer.assert_not_called()
 

--- a/controllers/zigbee/tests/sensor/osram/test_switch_mini.py
+++ b/controllers/zigbee/tests/sensor/osram/test_switch_mini.py
@@ -1,4 +1,5 @@
 from asyncio import Future
+from datetime import datetime
 from typing import List, Tuple
 from unittest.mock import MagicMock, PropertyMock
 
@@ -93,7 +94,7 @@ class TestOsramSwitchMiniSensor(SensorTestBase, InitialisableMixinTestBase, Batt
         type(attribute).id = PropertyMock(return_value=0x0020)
         zigbee_in_cluster.find_attribute.return_value = attribute
 
-        subject.on_attribute_updated(0x0020, data)
+        subject.on_attribute_updated(0x0020, data, datetime.utcnow())
 
         topic = 'event/test/battery'
         message = {'value': percent, 'unit': '%'}
@@ -111,7 +112,7 @@ class TestOsramSwitchMiniSensor(SensorTestBase, InitialisableMixinTestBase, Batt
         type(attribute).id = PropertyMock(return_value=0x0021)
         zigbee_in_cluster.find_attribute.return_value = attribute
 
-        subject.on_attribute_updated(0x0020, 29)
+        subject.on_attribute_updated(0x0020, 29, datetime.utcnow())
 
         powerpi_mqtt_producer.assert_not_called()
 

--- a/controllers/zigbee/zigbee_controller/config.py
+++ b/controllers/zigbee/zigbee_controller/config.py
@@ -1,9 +1,9 @@
 import os
 
-from powerpi_common.config import Config as CommonConfig
+from powerpi_common.config import ControllerConfig
 
 
-class ZigbeeConfig(CommonConfig):
+class ZigbeeConfig(ControllerConfig):
     @property
     def database_path(self):
         value = os.getenv('DATABASE_PATH')

--- a/controllers/zigbee/zigbee_controller/container.py
+++ b/controllers/zigbee/zigbee_controller/container.py
@@ -1,5 +1,6 @@
 from dependency_injector import containers, providers
 from powerpi_common.container import Container as CommonContainer
+
 from zigbee_controller.__version__ import __app_name__, __version__
 from zigbee_controller.config import ZigbeeConfig
 from zigbee_controller.controller import Controller
@@ -14,14 +15,15 @@ class ApplicationContainer(containers.DeclarativeContainer):
         __self__
     )
 
+    config = providers.Singleton(
+        ZigbeeConfig
+    )
+
     common = providers.Container(
         CommonContainer,
         app_name=__app_name__,
-        version=__version__
-    )
-
-    config = providers.Singleton(
-        ZigbeeConfig
+        version=__version__,
+        config=config
     )
 
     device = providers.Container(

--- a/controllers/zigbee/zigbee_controller/sensor/aqara/door_window_sensor.py
+++ b/controllers/zigbee/zigbee_controller/sensor/aqara/door_window_sensor.py
@@ -4,13 +4,14 @@ from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
 from powerpi_common.sensor import Sensor
 from powerpi_common.sensor.mixin.battery import BatteryMixin
+from zigpy.zcl.clusters.general import Basic
+from zigpy.zcl.clusters.general import OnOff as OnOffCluster
+from zigpy.zcl.foundation import Attribute, TypeValue
+
 from zigbee_controller.device import ZigbeeController
 from zigbee_controller.zigbee import (ClusterAttributeListener,
                                       ClusterGeneralCommandListener, OnOff,
                                       OpenClose, ZigbeeMixin)
-from zigpy.zcl.clusters.general import Basic
-from zigpy.zcl.clusters.general import OnOff as OnOffCluster
-from zigpy.zcl.foundation import Attribute, TypeValue
 
 
 class AqaraDoorWindowSensor(Sensor, ZigbeeMixin, BatteryMixin):
@@ -65,7 +66,7 @@ class AqaraDoorWindowSensor(Sensor, ZigbeeMixin, BatteryMixin):
 
             self._broadcast('change', message)
 
-    def on_attribute_updated(self, attribute_id: int, value: Any):
+    def on_attribute_updated(self, attribute_id: int, value: Any, _):
         if attribute_id == self.AQARA_ATTRIBUTE:
             additional_attributes: Dict[int, TypeValue] = {}
 

--- a/controllers/zigbee/zigbee_controller/sensor/osram/switch_mini.py
+++ b/controllers/zigbee/zigbee_controller/sensor/osram/switch_mini.py
@@ -6,14 +6,15 @@ from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
 from powerpi_common.sensor import Sensor
 from powerpi_common.sensor.mixin import BatteryMixin
-from zigbee_controller.device import ZigbeeController
-from zigbee_controller.zigbee import (ClusterAttributeListener,
-                                      ClusterCommandListener, ZigbeeMixin)
 from zigpy.zcl.clusters.general import LevelControl as LevelControlCluster
 from zigpy.zcl.clusters.general import OnOff as OnOffCluster
 from zigpy.zcl.clusters.general import \
     PowerConfiguration as PowerConfigurationCluster
 from zigpy.zcl.clusters.lighting import Color as ColorCluster
+
+from zigbee_controller.device import ZigbeeController
+from zigbee_controller.zigbee import (ClusterAttributeListener,
+                                      ClusterCommandListener, ZigbeeMixin)
 
 
 class ButtonEndpoint(int, Enum):
@@ -70,7 +71,7 @@ class OsramSwitchMiniSensor(Sensor, ZigbeeMixin, BatteryMixin):
     # the maximum expected voltage in mV
     MAX_VOLTAGE = 3100
 
-    #pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments
     def __init__(
         self,
         logger: Logger,
@@ -171,7 +172,7 @@ class OsramSwitchMiniSensor(Sensor, ZigbeeMixin, BatteryMixin):
             ClusterAttributeListener(self.on_attribute_updated)
         )
 
-    def on_attribute_updated(self, attribute_id: int, value: Any):
+    def on_attribute_updated(self, attribute_id: int, value: Any, _):
         device = self._zigbee_device
         cluster: PowerConfigurationCluster = device[1] \
             .in_clusters[PowerConfigurationCluster.cluster_id]

--- a/controllers/zigbee/zigbee_controller/zigbee/cluster_listener.py
+++ b/controllers/zigbee/zigbee_controller/zigbee/cluster_listener.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Any, Callable, List
 
 from zigpy.zcl.foundation import Attribute, ZCLHeader
@@ -6,11 +7,11 @@ from .zigbee_listener import ZigBeeListener
 
 
 class ClusterAttributeListener(ZigBeeListener):
-    def __init__(self, method: Callable[[int, Any], None]):
+    def __init__(self, method: Callable[[int, Any, datetime], None]):
         ZigBeeListener.__init__(self, method)
 
-    def attribute_updated(self, attribute_id: int, value: Any):
-        self._listener(attribute_id, value)
+    def attribute_updated(self, attribute_id: int, value: Any, date: datetime):
+        self._listener(attribute_id, value, date)
 
 
 class ClusterCommandListener(ZigBeeListener):

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -48,7 +48,7 @@ dependencies:
   - name: macro-controller
     version: 0.1.3
   - name: network-controller
-    version: 0.1.1
+    version: 0.1.2
     condition: global.network
   - name: node-controller
     version: 0.1.3

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -40,7 +40,7 @@ dependencies:
     version: 0.1.3
     condition: global.energenie
   - name: harmony-controller
-    version: 0.1.2
+    version: 0.1.3
     condition: global.harmony
   - name: lifx-controller
     version: 0.1.3

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -51,7 +51,7 @@ dependencies:
     version: 0.1.2
     condition: global.network
   - name: node-controller
-    version: 0.1.3
+    version: 0.1.4
     condition: global.node
   - name: zigbee-controller
     version: 0.1.3

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -43,7 +43,7 @@ dependencies:
     version: 0.1.3
     condition: global.harmony
   - name: lifx-controller
-    version: 0.1.3
+    version: 0.1.4
     condition: global.lifx
   - name: macro-controller
     version: 0.1.2

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -37,7 +37,7 @@ dependencies:
     condition: global.voiceAssistant
   # controllers
   - name: energenie-controller
-    version: 0.1.2
+    version: 0.1.3
     condition: global.energenie
   - name: harmony-controller
     version: 0.1.2

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -46,7 +46,7 @@ dependencies:
     version: 0.1.4
     condition: global.lifx
   - name: macro-controller
-    version: 0.1.2
+    version: 0.1.3
   - name: network-controller
     version: 0.1.1
     condition: global.network

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: powerpi
 description: A Helm chart for deploying the PowerPi home automation stack
 type: application
-version: 0.2.2
-appVersion: 0.2.2
+version: 0.2.3
+appVersion: 0.2.3
 dependencies:
   # services
   - name: config-server
@@ -26,7 +26,7 @@ dependencies:
     version: 0.1.2
     condition: global.persistence
   - name: scheduler
-    version: 0.2.3
+    version: 0.2.4
     condition: global.scheduler
   - name: smarter-device-manager
     version: 0.1.1

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -54,5 +54,5 @@ dependencies:
     version: 0.1.4
     condition: global.node
   - name: zigbee-controller
-    version: 0.1.3
+    version: 0.1.4
     condition: global.zigbee

--- a/kubernetes/charts/energenie-controller/Chart.yaml
+++ b/kubernetes/charts/energenie-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: energenie-controller
 description: A Helm chart for the PowerPi Energenie device controller
 type: application
-version: 0.1.2
-appVersion: 0.2.1
+version: 0.1.3
+appVersion: 0.2.2

--- a/kubernetes/charts/harmony-controller/Chart.yaml
+++ b/kubernetes/charts/harmony-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: harmony-controller
 description: A Helm chart for the PowerPi Logitech Harmony device controller
 type: application
-version: 0.1.2
-appVersion: 0.3.1
+version: 0.1.3
+appVersion: 0.3.2

--- a/kubernetes/charts/lifx-controller/Chart.yaml
+++ b/kubernetes/charts/lifx-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lifx-controller
 description: A Helm chart for the PowerPi LIFX device controller
 type: application
-version: 0.1.3
-appVersion: 0.4.0
+version: 0.1.4
+appVersion: 0.4.1

--- a/kubernetes/charts/macro-controller/Chart.yaml
+++ b/kubernetes/charts/macro-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: macro-controller
 description: A Helm chart for the PowerPi macro virtual device controller
 type: application
-version: 0.1.2
-appVersion: 1.2.1
+version: 0.1.3
+appVersion: 1.2.2

--- a/kubernetes/charts/network-controller/Chart.yaml
+++ b/kubernetes/charts/network-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: network-controller
 description: A Helm chart for the PowerPi Network device controller
 type: application
-version: 0.1.1
-appVersion: 0.1.1
+version: 0.1.2
+appVersion: 0.1.2

--- a/kubernetes/charts/node-controller/Chart.yaml
+++ b/kubernetes/charts/node-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: node-controller
 description: A Helm chart for the PowerPi cluster node monitoring controller
 type: application
-version: 0.1.3
-appVersion: 0.1.2
+version: 0.1.4
+appVersion: 0.1.3

--- a/kubernetes/charts/scheduler/Chart.yaml
+++ b/kubernetes/charts/scheduler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: scheduler
 description: A Helm chart for the PowerPi scheduler service
 type: application
-version: 0.2.3
-appVersion: 1.2.1
+version: 0.2.4
+appVersion: 1.2.2

--- a/kubernetes/charts/zigbee-controller/Chart.yaml
+++ b/kubernetes/charts/zigbee-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: zigbee-controller
 description: A Helm chart for the PowerPi ZigBee device controller
 type: application
-version: 0.1.3
-appVersion: 0.3.0
+version: 0.1.4
+appVersion: 0.3.1

--- a/kubernetes/templates/_controller.tpl
+++ b/kubernetes/templates/_controller.tpl
@@ -1,13 +1,13 @@
-{{- define "powerpi.controller" }}
+{{- define "powerpi.controller" -}}
 
-{{- $env := .Params.Env | default list }}
+{{- $env := .Params.Env | default list -}}
 
-{{- if eq (empty .Values.pollFrequency) false }}
+{{- if eq (empty .Values.pollFrequency) false -}}
 {{- $env = append $env (dict
   "Name" "POLL_FREQUENCY"
   "Value" (.Values.pollFrequency | quote)
-) }}
-{{- end }}
+) -}}
+{{- end -}}
 
 {{- $data := (merge 
   (dict
@@ -23,11 +23,11 @@
         "/usr/src/app/venv/lib/python3.9/site-packages/powerpi_common/health.sh"
       )
       "ReadinessInitialDelay" 10
-      "LivenessInitialDelay" 20
+      "LivenessInitialDelay" 30
     )
   ) 
   .Params
-) }}
+) -}}
 
-{{- include "powerpi.deployment" (merge (dict "Params" $data) . ) }}
-{{- end }}
+{{- include "powerpi.deployment" (merge (dict "Params" $data) . ) -}}
+{{- end -}}

--- a/services/scheduler/poetry.lock
+++ b/services/scheduler/poetry.lock
@@ -51,25 +51,6 @@ wrapt = [
 ]
 
 [[package]]
-name = "attrs"
-version = "23.1.0"
-description = "Classes Without Boilerplate"
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "attrs-23.1.0-py3-none-any.whl", hash = "sha256:1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04"},
-    {file = "attrs-23.1.0.tar.gz", hash = "sha256:6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"},
-]
-
-[package.extras]
-cov = ["attrs[tests]", "coverage[toml] (>=5.3)"]
-dev = ["attrs[docs,tests]", "pre-commit"]
-docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier", "zope-interface"]
-tests = ["attrs[tests-no-zope]", "zope-interface"]
-tests-no-zope = ["cloudpickle", "hypothesis", "mypy (>=1.1.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
-
-[[package]]
 name = "autopep8"
 version = "2.0.2"
 description = "A tool that automatically formats Python code to conform to the PEP 8 style guide"
@@ -459,7 +440,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "powerpi-common"
-version = "0.3.2"
+version = "0.4.0"
 description = "PowerPi Common Python Library"
 category = "dev"
 optional = false
@@ -480,7 +461,7 @@ url = "../../common/python"
 
 [[package]]
 name = "powerpi-common-test"
-version = "0.3.1"
+version = "0.4.0"
 description = "PowerPi Common Python Test Library"
 category = "dev"
 optional = false
@@ -489,9 +470,9 @@ files = []
 develop = true
 
 [package.dependencies]
-pytest = "~=7.2.2"
+pytest = "~=7.3.1"
 pytest-asyncio = "~=0.21.0"
-pytest-cov = "~=4.0.0"
+pytest-cov = "~=4.1.0"
 pytest-mock = "~=3.10.0"
 
 [package.source]
@@ -512,14 +493,14 @@ files = [
 
 [[package]]
 name = "pylint"
-version = "2.17.3"
+version = "2.17.4"
 description = "python code static checker"
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "pylint-2.17.3-py3-none-any.whl", hash = "sha256:a6cbb4c6e96eab4a3c7de7c6383c512478f58f88d95764507d84c899d656a89a"},
-    {file = "pylint-2.17.3.tar.gz", hash = "sha256:761907349e699f8afdcd56c4fe02f3021ab5b3a0fc26d19a9bfdc66c7d0d5cd5"},
+    {file = "pylint-2.17.4-py3-none-any.whl", hash = "sha256:7a1145fb08c251bdb5cca11739722ce64a63db479283d10ce718b2460e54123c"},
+    {file = "pylint-2.17.4.tar.gz", hash = "sha256:5dcf1d9e19f41f38e4e85d10f511e5b9c35e1aa74251bf95cdd8cb23584e2db1"},
 ]
 
 [package.dependencies]
@@ -542,18 +523,17 @@ testutils = ["gitpython (>3)"]
 
 [[package]]
 name = "pytest"
-version = "7.2.2"
+version = "7.3.2"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.2.2-py3-none-any.whl", hash = "sha256:130328f552dcfac0b1cec75c12e3f005619dc5f874f0a06e8ff7263f0ee6225e"},
-    {file = "pytest-7.2.2.tar.gz", hash = "sha256:c99ab0c73aceb050f68929bc93af19ab6db0558791c6a0715723abe9d0ade9d4"},
+    {file = "pytest-7.3.2-py3-none-any.whl", hash = "sha256:cdcbd012c9312258922f8cd3f1b62a6580fdced17db6014896053d47cddf9295"},
+    {file = "pytest-7.3.2.tar.gz", hash = "sha256:ee990a3cc55ba808b80795a79944756f315c67c12b56abd3ac993a7b8c17030b"},
 ]
 
 [package.dependencies]
-attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
@@ -562,7 +542,7 @@ pluggy = ">=0.12,<2.0"
 tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
-testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "pytest-asyncio"
@@ -585,14 +565,14 @@ testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy 
 
 [[package]]
 name = "pytest-cov"
-version = "4.0.0"
+version = "4.1.0"
 description = "Pytest plugin for measuring coverage."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "pytest-cov-4.0.0.tar.gz", hash = "sha256:996b79efde6433cdbd0088872dbc5fb3ed7fe1578b68cdbba634f14bb8dd0470"},
-    {file = "pytest_cov-4.0.0-py3-none-any.whl", hash = "sha256:2feb1b751d66a8bd934e5edfa2e961d11309dc37b73b0eabe73b5945fee20f6b"},
+    {file = "pytest-cov-4.1.0.tar.gz", hash = "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6"},
+    {file = "pytest_cov-4.1.0-py3-none-any.whl", hash = "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a"},
 ]
 
 [package.dependencies]
@@ -843,4 +823,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "02cbf90fe1bbf9a2114662c0ffbf101b93008ba243c4ed82cfda53079101e755"
+content-hash = "764bbf54e9bfc33f43a01c6e60a17bb5f05e3af636409b4a33f5166b9fbf968c"

--- a/services/scheduler/pyproject.toml
+++ b/services/scheduler/pyproject.toml
@@ -9,12 +9,13 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.9"
+
 [tool.poetry.group.powerpi.dependencies]
 powerpi-common = {path = "../../common/python", develop = true}
 
 [tool.poetry.group.dev.dependencies]
 autopep8 = "~=2.0.2"
-pylint = "~=2.17.3"
+pylint = "~=2.17.4"
 
 [tool.poetry.group.test.dependencies]
 powerpi-common-test = {path = "../../common/pytest", develop = true}

--- a/services/scheduler/pyproject.toml
+++ b/services/scheduler/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scheduler"
-version = "1.2.1"
+version = "1.2.2"
 description = "PowerPi Scheduler Service"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/services/scheduler/scheduler/container.py
+++ b/services/scheduler/scheduler/container.py
@@ -1,5 +1,6 @@
 from dependency_injector import containers, providers
 from powerpi_common.container import Container as CommonContainer
+
 from scheduler.__version__ import __app_name__, __version__
 from scheduler.application import Application
 from scheduler.config import SchedulerConfig
@@ -21,7 +22,8 @@ class ApplicationContainer(containers.DeclarativeContainer):
     common = providers.Container(
         CommonContainer,
         app_name=__app_name__,
-        version=__version__
+        version=__version__,
+        config=config
     )
 
     device_schedule = providers.Factory(


### PR DESCRIPTION
- Resolves #318, issue was due to many of the controllers not setting their own configuration, and therefore not overriding the `used_config` property which would enforce that all config files are required.
  - Make `used_config` abstract and therefore the `Config` class has to be extended.
  - Make `config` a dependency on the common container to allow the other services to pass their implementation in.
  - Add `ControllerConfig` as most of the controller implementations don't need any custom config beyond `used_config`.
- Resolves #355 
  - Allow controllers longer to start-up as `zigbee-controller` keeps failing deployment due to probe failing to start.
  - Run the health check immediately rather than waiting for the 10s delay for the first run.