### PR TITLE
#121/#361 Add support for scenes for controllers and scheduler

### DIFF
--- a/.github/scripts/buildx.sh
+++ b/.github/scripts/buildx.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+scriptPath=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+help() {
+    echo "PowerPi buildx script"
+    echo "expects 'bash buildx.sh service repo"
+    echo "  service: one of the PowerPi services"
+    echo "  repo: the local repo"
+    exit
+}
+
+get_old_version() {
+    local url=https://raw.githubusercontent.com/TWilkin/powerpi/main/kubernetes/charts/$1/Chart.yaml
+    local path=Chart.yaml
+
+    curl $url --output $path
+
+    appVersion=`yq .appVersion $path`
+
+    rm $path
+}
+
+get_version() {
+    local path=$scriptPath/../../kubernetes/charts/$1/Chart.yaml
+
+    appVersion=`yq .appVersion $path`
+}
+
+if [ $# -ne 2 ]
+then
+    help
+fi
+
+service=$1
+repo=$2
+
+powerpiPath=$scriptPath/../../
+
+get_old_version $service
+oldVersion=$appVersion
+
+get_version $service
+version=$appVersion
+
+name=powerpi-$service
+
+path=services/$service
+platform=linux/arm64
+
+if [[ $service == *controller ]]
+then
+    split=(${service//-/ })
+
+    path=controllers/${split[0]}
+    platform=linux/arm/v7
+fi
+
+if [[ $service == "scheduler" ]]
+then
+    platform=linux/arm/v7
+fi
+
+# retrieve the previous image
+echo "Pulling previous image"
+docker pull twilkin/$name:$oldVersion
+echo
+
+# build the image
+echo "Building image $name:$version"
+docker buildx build --load --platform $platform -t $repo/$name:$version -t twilkin/$name:$version -f $powerpiPath/$path/Dockerfile $powerpiPath
+echo
+
+echo "Pushing image $name:$version"
+docker push $repo/$name:$version
+echo

--- a/.github/scripts/buildx.sh
+++ b/.github/scripts/buildx.sh
@@ -66,6 +66,11 @@ echo "Pulling previous image"
 docker pull twilkin/$name:$oldVersion
 echo
 
+# attempt to retrieve the new image, in case it's an update
+echo "Pulling current image"
+docker pull $repo/$name:$version
+echo
+
 # build the image
 echo "Building image $name:$version"
 docker buildx build --load --platform $platform -t $repo/$name:$version -t twilkin/$name:$version -f $powerpiPath/$path/Dockerfile $powerpiPath

--- a/.github/scripts/test_python.sh
+++ b/.github/scripts/test_python.sh
@@ -7,6 +7,6 @@ echo Testing $project
 # required to allow node-controller to build
 export PIJUICE_BUILD_BASE=1
 
-poetry install --only main,powerpi,test --no-root --no-interaction --no-ansi
+poetry install --only main,powerpi,test
 
 poetry run pytest

--- a/.github/scripts/test_python.sh
+++ b/.github/scripts/test_python.sh
@@ -7,6 +7,6 @@ echo Testing $project
 # required to allow node-controller to build
 export PIJUICE_BUILD_BASE=1
 
-poetry install
+poetry install --only main,test --no-root --no-interaction --no-ansi
 
 poetry run pytest

--- a/.github/scripts/test_python.sh
+++ b/.github/scripts/test_python.sh
@@ -7,6 +7,6 @@ echo Testing $project
 # required to allow node-controller to build
 export PIJUICE_BUILD_BASE=1
 
-poetry install --only main,test --no-root --no-interaction --no-ansi
+poetry install --only main,powerpi,test --no-root --no-interaction --no-ansi
 
 poetry run pytest

--- a/.pylintrc
+++ b/.pylintrc
@@ -5,3 +5,6 @@ disable=
     missing-function-docstring,
     missing-module-docstring,
     too-few-public-methods
+
+[STRING]
+check-quote-consistency=yes

--- a/common/pytest/powerpi_common_test/device/additional_state.py
+++ b/common/pytest/powerpi_common_test/device/additional_state.py
@@ -75,6 +75,27 @@ class AdditionalStateDeviceTestBase(DeviceTestBase):
         assert all(key in message for message in messages)
 
     @pytest.mark.asyncio
+    async def test_change_scene(self, subject: AdditionalStateDevice):
+        assert subject.scene == 'default'
+
+        await subject.change_scene('other')
+        assert subject.scene == 'other'
+
+        # pylint: disable=protected-access
+        key = subject._additional_state_keys()[0]
+        additional_state = {}
+        additional_state[key] = 10
+        subject.additional_state = additional_state
+
+        await subject.change_scene('current')
+        assert subject.scene == 'other'
+        assert subject.additional_state.get(key, None) == 10
+
+        await subject.change_scene('default')
+        assert subject.scene == 'default'
+        assert subject.additional_state.get(key, None) is None
+
+    @pytest.mark.asyncio
     async def test_initial_additional_state_message(self, subject: AdditionalStateDevice):
         # pylint: disable=protected-access
         key = subject._additional_state_keys()[0]

--- a/common/pytest/powerpi_common_test/device/additional_state.py
+++ b/common/pytest/powerpi_common_test/device/additional_state.py
@@ -1,8 +1,9 @@
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 from unittest.mock import MagicMock
 
 from powerpi_common.device import AdditionalStateDevice
+from powerpi_common.device.scene_state import ReservedScenes
 
 import pytest
 
@@ -23,7 +24,12 @@ class AdditionalStateDeviceTestBase(DeviceTestBase):
         assert len(keys) > 0
 
     @pytest.mark.asyncio
-    async def test_change_additional_state_message(self, subject: AdditionalStateDevice):
+    @pytest.mark.parametrize('scene', [None, 'default'])
+    async def test_change_additional_state_message(
+        self,
+        subject: AdditionalStateDevice,
+        scene: Optional[str]
+    ):
         # pylint: disable=protected-access
         key = subject._additional_state_keys()[0]
         message = {
@@ -32,6 +38,10 @@ class AdditionalStateDeviceTestBase(DeviceTestBase):
         }
         message[key] = 1
 
+        if scene is not None:
+            message['scene'] = scene
+
+        assert subject.scene == ReservedScenes.DEFAULT
         assert subject.state == 'unknown'
         assert subject.additional_state == {}
 

--- a/common/pytest/pyproject.toml
+++ b/common/pytest/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "powerpi-common-test"
-version = "0.4.0"
+version = "0.5.0"
 description = "PowerPi Common Python Test Library"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/common/python/powerpi_common/condition/parser.py
+++ b/common/python/powerpi_common/condition/parser.py
@@ -1,11 +1,11 @@
 from typing import Callable, Dict, List, Union
 
-from powerpi_common.condition.errors import InvalidArgumentException, InvalidIdentifierException, \
-    UnexpectedTokenException
+from powerpi_common.condition.errors import (InvalidArgumentException,
+                                             InvalidIdentifierException,
+                                             UnexpectedTokenException)
 from powerpi_common.condition.lexeme import Lexeme
 from powerpi_common.mqtt import MQTTMessage
 from powerpi_common.variable import VariableManager, VariableType
-
 
 Expression = Union[Dict, List, str, float, bool]
 
@@ -108,6 +108,8 @@ class ConditionParser:
 
         if prop == 'state':
             return variable.state
+        if prop == 'scene':
+            return variable.scene
 
         try:
             return variable.additional_state[prop]

--- a/common/python/powerpi_common/config/config.py
+++ b/common/python/powerpi_common/config/config.py
@@ -43,7 +43,7 @@ class Config(ABC):
 
     @property
     def health_check_file(self):
-        health_file = os.getenv("HEALTH_CHECK_FILE")
+        health_file = os.getenv('HEALTH_CHECK_FILE')
         return health_file if health_file is not None else '/usr/src/app/powerpi_health'
 
     @property
@@ -67,8 +67,8 @@ class Config(ABC):
 
     @property
     def use_config_file(self):
-        use = os.getenv("USE_CONFIG_FILE")
-        return use.upper() == "TRUE" if use is not None else False
+        use = os.getenv('USE_CONFIG_FILE')
+        return use.upper() == 'TRUE' if use is not None else False
 
     @property
     def devices(self):

--- a/common/python/powerpi_common/device/additional_state.py
+++ b/common/python/powerpi_common/device/additional_state.py
@@ -122,6 +122,19 @@ class AdditionalStateDevice(Device, AdditionalStateMixin):
         if self.__additional_state.state:
             result = {**result, **self.__additional_state.format_scene_state()}
 
+        # only include scenes if we have > just the current and they have additional state
+        scenes = list(filter(
+            lambda scene:
+                not self.__additional_state.is_current_scene(scene)
+                and len(self.__additional_state.get_scene_state(scene)) >= 1,
+            self.__additional_state.scenes
+        ))
+        if len(scenes) >= 1:
+            result['scenes'] = {
+                scene: self.__additional_state.format_scene_state(scene)
+                for scene in scenes
+            }
+
         return result
 
     def _is_current_scene(self, scene: Optional[str]):

--- a/common/python/powerpi_common/device/additional_state.py
+++ b/common/python/powerpi_common/device/additional_state.py
@@ -67,14 +67,17 @@ class AdditionalStateDevice(Device, AdditionalStateMixin):
 
     def update_state_and_additional_no_broadcast(
         self,
+        new_scene: str,
         new_state: DeviceStatus,
         new_additional_state: AdditionalState
     ):
         '''
-        Update the state of this device to new_state, update the additional state
-        to new_additional_state but do not broadcast to the message queue.
+        Update the scene of of this device to new_scene, the state to new_state, 
+        update the additional state to new_additional_state but do not broadcast 
+        to the message queue.
         '''
         self.update_state_no_broadcast(new_state)
+        self.__additional_state.scene = new_scene
         self.__additional_state.state = self._filter_keys(new_additional_state)
 
     def set_state_and_additional(
@@ -96,7 +99,7 @@ class AdditionalStateDevice(Device, AdditionalStateMixin):
 
         self._broadcast_state_change()
 
-    def _set_scene_additional_state(
+    def set_scene_additional_state(
         self,
         scene: Optional[str],
         new_additional_state: AdditionalState

--- a/common/python/powerpi_common/device/additional_state.py
+++ b/common/python/powerpi_common/device/additional_state.py
@@ -72,7 +72,7 @@ class AdditionalStateDevice(Device, AdditionalStateMixin):
         new_additional_state: AdditionalState
     ):
         '''
-        Update the scene of this device to new_scene, the state to new_state, 
+        Update the scene of this device to new_scene, the state to new_state and
         update the additional state to new_additional_state but do not broadcast 
         to the message queue.
         '''

--- a/common/python/powerpi_common/device/additional_state.py
+++ b/common/python/powerpi_common/device/additional_state.py
@@ -117,7 +117,10 @@ class AdditionalStateDevice(Device, AdditionalStateMixin):
             self.__additional_state.scene = new_scene
 
             new_additional_state = self.__additional_state.state
-            await self.change_power_and_additional_state(new_additional_state=new_additional_state)
+            await self.change_power_and_additional_state(
+                scene=new_scene,
+                new_additional_state=new_additional_state
+            )
 
     def _format_state(self):
         result = Device._format_state(self)

--- a/common/python/powerpi_common/device/additional_state.py
+++ b/common/python/powerpi_common/device/additional_state.py
@@ -72,7 +72,7 @@ class AdditionalStateDevice(Device, AdditionalStateMixin):
         new_additional_state: AdditionalState
     ):
         '''
-        Update the scene of of this device to new_scene, the state to new_state, 
+        Update the scene of this device to new_scene, the state to new_state, 
         update the additional state to new_additional_state but do not broadcast 
         to the message queue.
         '''

--- a/common/python/powerpi_common/device/additional_state.py
+++ b/common/python/powerpi_common/device/additional_state.py
@@ -1,6 +1,7 @@
+from typing import Optional
+
 from powerpi_common.config import Config
-from powerpi_common.device.consumers.scene_event_consumer import \
-    SceneEventConsumer
+from powerpi_common.device.consumers import SceneEventConsumer
 from powerpi_common.device.types import DeviceStatus
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
@@ -36,6 +37,13 @@ class AdditionalStateDevice(Device, AdditionalStateMixin):
         if listener:
             # add listener for scene changes
             mqtt_client.add_consumer(SceneEventConsumer(self, config, logger))
+
+    @property
+    def scene(self):
+        '''
+        Returns the current scene of this device.
+        '''
+        return self.__additional_state.scene
 
     @property
     def additional_state(self):
@@ -88,6 +96,16 @@ class AdditionalStateDevice(Device, AdditionalStateMixin):
 
         self._broadcast_state_change()
 
+    def _set_scene_additional_state(
+        self,
+        scene: Optional[str],
+        new_additional_state: AdditionalState
+    ):
+        '''
+        Update the additional state for the specified scene.
+        '''
+        self.__additional_state.update_scene_state(scene, new_additional_state)
+
     async def change_scene(self, new_scene: str):
         '''
         Switch this device from the current scene to this new one, and apply any state changes.
@@ -105,3 +123,9 @@ class AdditionalStateDevice(Device, AdditionalStateMixin):
             result = {**result, **self.__additional_state.format_scene_state()}
 
         return result
+
+    def _is_current_scene(self, scene: Optional[str]):
+        '''
+        Returns whether the specified scene is the current scene or not.
+        '''
+        return self.__additional_state.is_current_scene(scene)

--- a/common/python/powerpi_common/device/consumers/__init__.py
+++ b/common/python/powerpi_common/device/consumers/__init__.py
@@ -1,4 +1,5 @@
 from .capability_event_consumer import CapabilityEventConsumer
 from .change_event_consumer import DeviceChangeEventConsumer
 from .initial_status_event_consumer import DeviceInitialStatusEventConsumer
+from .scene_event_consumer import SceneEventConsumer
 from .status_event_consumer import DeviceStatusEventConsumer

--- a/common/python/powerpi_common/device/consumers/change_event_consumer.py
+++ b/common/python/powerpi_common/device/consumers/change_event_consumer.py
@@ -6,11 +6,17 @@ from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTMessage
 from powerpi_common.typing import AdditionalStateDeviceType, DeviceType
 from powerpi_common.util import ismixin
+
 from .device_event_consumer import DeviceEventConsumer
 
 
 class DeviceChangeEventConsumer(DeviceEventConsumer):
-    def __init__(self, device: Union[DeviceType, AdditionalStateDeviceType], config: Config, logger: Logger):
+    def __init__(
+        self,
+        device: Union[DeviceType, AdditionalStateDeviceType],
+        config: Config,
+        logger: Logger
+    ):
         topic = f'device/{device.name}/change'
 
         DeviceEventConsumer.__init__(
@@ -22,8 +28,13 @@ class DeviceChangeEventConsumer(DeviceEventConsumer):
             new_state = message.get('state', None)
 
             if ismixin(self._device, AdditionalStateMixin):
+                scene = message.get('scene', None)
                 new_additional_state = self._get_additional_state(message)
 
-                await self._device.change_power_and_additional_state(new_state, new_additional_state)
+                await self._device.change_power_and_additional_state(
+                    scene,
+                    new_state,
+                    new_additional_state
+                )
             else:
                 await self._device.change_power(new_state)

--- a/common/python/powerpi_common/device/consumers/device_event_consumer.py
+++ b/common/python/powerpi_common/device/consumers/device_event_consumer.py
@@ -45,5 +45,6 @@ class DeviceEventConsumer(MQTTConsumer):
 
         result.pop('state', None)
         result.pop('timestamp', None)
+        result.pop('scene', None)
 
         return result

--- a/common/python/powerpi_common/device/consumers/device_event_consumer.py
+++ b/common/python/powerpi_common/device/consumers/device_event_consumer.py
@@ -28,11 +28,11 @@ class DeviceEventConsumer(MQTTConsumer):
             valid = True
 
         if state is not None and state != DeviceStatus.ON and state != DeviceStatus.OFF:
-            self._logger.error(f'Unrecognisable state {state}')
+            self.log_error('Unrecognisable state %s', state)
             valid = False
 
         if device_name is None or device_name.strip() == '':
-            self._logger.error('Device is a required field')
+            self.log_error('Device is a required field')
             valid = False
         else:
             valid &= device_name == self._device.name

--- a/common/python/powerpi_common/device/consumers/initial_status_event_consumer.py
+++ b/common/python/powerpi_common/device/consumers/initial_status_event_consumer.py
@@ -1,13 +1,16 @@
-from typing import Union
+from copy import deepcopy
+from typing import Dict, Tuple, Union
 
 import powerpi_common
-
 from powerpi_common.config import Config
+from powerpi_common.device.mixin.additional_state import AdditionalState
+from powerpi_common.device.scene_state import ReservedScenes
 from powerpi_common.device.types import DeviceStatus
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient, MQTTMessage
 from powerpi_common.typing import AdditionalStateDeviceType, DeviceType
 from powerpi_common.util import ismixin
+
 from .status_event_consumer import DeviceStatusEventConsumer
 
 
@@ -30,18 +33,34 @@ class DeviceInitialStatusEventConsumer(DeviceStatusEventConsumer):
 
     async def on_message(self, message: MQTTMessage, entity: str, _: str):
         if self.__active and self._is_message_valid(entity, message.get('state')):
-            new_power_state = message.pop('state', DeviceStatus.UNKNOWN)
+            new_power_state = message.get('state', DeviceStatus.UNKNOWN)
 
             # don't broadcast as this is the device's initial state on startup
             if ismixin(self._device, powerpi_common.device.additional_state.AdditionalStateDevice):
-                new_additional_state = self._get_additional_state(message)
+                new_additional_state, new_scene, scenes = \
+                    self.__extract(message)
 
                 self._device.update_state_and_additional_no_broadcast(
-                    new_power_state, new_additional_state
+                    new_scene, new_power_state, new_additional_state
                 )
+
+                for scene, additional_state in scenes.items():
+                    self._device.set_scene_additional_state(
+                        scene, additional_state
+                    )
             else:
                 self._device.update_state_no_broadcast(new_power_state)
 
             # remove this consumer as it has completed its job
             self.__active = False
             self.__mqtt_client.remove_consumer(self)
+
+    def __extract(self, message: MQTTMessage) \
+            -> Tuple[AdditionalState, str, Dict[str, AdditionalState]]:
+        new_additional_state = self._get_additional_state(message)
+
+        scene = message.get('scene', ReservedScenes.DEFAULT)
+
+        scenes = deepcopy(message.get('scenes', {}))
+
+        return new_additional_state, scene, scenes

--- a/common/python/powerpi_common/device/consumers/scene_event_consumer.py
+++ b/common/python/powerpi_common/device/consumers/scene_event_consumer.py
@@ -1,0 +1,27 @@
+from powerpi_common.config import Config
+from powerpi_common.device.scene_state import ReservedScenes
+from powerpi_common.logger import Logger
+from powerpi_common.mqtt import MQTTMessage
+from powerpi_common.typing import AdditionalStateDeviceType
+
+from .device_event_consumer import DeviceEventConsumer
+
+
+class SceneEventConsumer(DeviceEventConsumer):
+    def __init__(
+        self,
+        device: AdditionalStateDeviceType,
+        config: Config,
+        logger: Logger
+    ):
+        topic = f'device/{device.name}/scene'
+
+        DeviceEventConsumer.__init__(
+            self, topic, device, config, logger
+        )
+
+    async def on_message(self, message: MQTTMessage, _: str, __: str):
+        scene = message.get('scene', None)
+
+        if scene is not None and scene is not ReservedScenes.CURRENT:
+            await self._device.change_scene(scene)

--- a/common/python/powerpi_common/device/consumers/status_event_consumer.py
+++ b/common/python/powerpi_common/device/consumers/status_event_consumer.py
@@ -2,11 +2,13 @@ from typing import Union
 
 from powerpi_common.config import Config
 from powerpi_common.device.mixin import AdditionalStateMixin
+from powerpi_common.device.scene_state import ReservedScenes
 from powerpi_common.device.types import DeviceStatus
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTMessage
 from powerpi_common.typing import AdditionalStateDeviceType, DeviceType
 from powerpi_common.util import ismixin
+
 from .device_event_consumer import DeviceEventConsumer
 
 
@@ -28,10 +30,11 @@ class DeviceStatusEventConsumer(DeviceEventConsumer):
             new_power_state = message.get('state', DeviceStatus.UNKNOWN)
 
             if ismixin(self._device, AdditionalStateMixin):
+                new_scene = message.get('scene', ReservedScenes.DEFAULT)
                 new_additional_state = self._get_additional_state(message)
 
-                self._device.set_state_and_additional(
-                    new_power_state, new_additional_state
+                self._device.update_state_and_additional_no_broadcast(
+                    new_scene, new_power_state, new_additional_state
                 )
             else:
                 self._device.state = new_power_state

--- a/common/python/powerpi_common/device/consumers/status_event_consumer.py
+++ b/common/python/powerpi_common/device/consumers/status_event_consumer.py
@@ -37,4 +37,4 @@ class DeviceStatusEventConsumer(DeviceEventConsumer):
                     new_scene, new_power_state, new_additional_state
                 )
             else:
-                self._device.state = new_power_state
+                self._device.update_state_no_broadcast(new_power_state)

--- a/common/python/powerpi_common/device/device.py
+++ b/common/python/powerpi_common/device/device.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from asyncio import Lock
-from typing import Awaitable, Callable, Union
+from typing import Awaitable, Callable
 
 from powerpi_common.config import Config
 from powerpi_common.device.types import DeviceStatus
@@ -121,8 +121,7 @@ class Device(BaseDevice, DeviceChangeEventConsumer):
 
         self._logger.info(f'Device "{self._name}" now has state {message}')
 
-        topic = f'device/{self._name}/status'
-        self._producer(topic, message)
+        self._broadcast('status', message)
 
     def _format_state(self):
         return {'state': self.state}
@@ -134,7 +133,7 @@ class Device(BaseDevice, DeviceChangeEventConsumer):
 
     async def __change_power_handler(
         self,
-        func: Union[Awaitable[None], Callable[[], None]],
+        func: Callable[[], Awaitable[bool]],
         new_status: DeviceStatus
     ):
         # pylint: disable=broad-except

--- a/common/python/powerpi_common/device/mixin/additional_state.py
+++ b/common/python/powerpi_common/device/mixin/additional_state.py
@@ -12,6 +12,7 @@ class AdditionalStateMixin(ABC):
     are received alternate state update methods are called from this mixin
     to allow an implementing device to set additional as well as power state.
     '''
+
     async def change_power_and_additional_state(
         self,
         scene: Optional[str] = None,
@@ -26,7 +27,7 @@ class AdditionalStateMixin(ABC):
         # pylint: disable=broad-except
         try:
             # update additional state first
-            if len(new_additional_state) > 0:
+            if new_additional_state is not None and len(new_additional_state) > 0:
                 if self._is_current_scene(scene):
                     new_additional_state = await self.on_additional_state_change(
                         new_additional_state

--- a/common/python/powerpi_common/device/mixin/additional_state.py
+++ b/common/python/powerpi_common/device/mixin/additional_state.py
@@ -57,6 +57,14 @@ class AdditionalStateMixin(ABC):
 
     @property
     @abstractmethod
+    def scene(self):
+        '''
+        Returns the current scene of this device.
+        '''
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
     def additional_state(self):
         '''
         Implement this method to support returning additional state.

--- a/common/python/powerpi_common/device/mixin/additional_state.py
+++ b/common/python/powerpi_common/device/mixin/additional_state.py
@@ -72,6 +72,20 @@ class AdditionalStateMixin(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def update_state_and_additional_no_broadcast(
+        self,
+        new_scene: str,
+        new_state: DeviceStatus,
+        new_additional_state: AdditionalState
+    ):
+        '''
+        Update the scene of this device to new_scene, the state to new_state, 
+        update the additional state to new_additional_state but do not broadcast 
+        to the message queue.
+        '''
+        raise NotImplementedError
+
+    @abstractmethod
     def set_state_and_additional(
         self,
         new_state: DeviceStatus,

--- a/common/python/powerpi_common/device/mixin/additional_state.py
+++ b/common/python/powerpi_common/device/mixin/additional_state.py
@@ -74,6 +74,7 @@ class AdditionalStateMixin(ABC):
         '''
         raise NotImplementedError
 
+    @abstractmethod
     def set_scene_additional_state(
         self,
         scene: Optional[str],
@@ -82,6 +83,7 @@ class AdditionalStateMixin(ABC):
         '''
         Update the additional state for the specified scene.
         '''
+        raise NotImplementedError
 
     async def on_additional_state_change(self, new_additional_state: AdditionalState):
         '''
@@ -106,8 +108,9 @@ class AdditionalStateMixin(ABC):
         '''
         raise NotImplementedError
 
+    @abstractmethod
     def _is_current_scene(self, scene: Optional[str]):
         '''
         Returns whether the specified scene is the current scene or not.
         '''
-        return True
+        raise NotImplementedError

--- a/common/python/powerpi_common/device/mixin/additional_state.py
+++ b/common/python/powerpi_common/device/mixin/additional_state.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from powerpi_common.device.types import DeviceStatus
 
@@ -14,8 +14,8 @@ class AdditionalStateMixin(ABC):
     '''
     async def change_power_and_additional_state(
         self,
-        new_state: DeviceStatus,
-        new_additional_state: AdditionalState
+        new_state: Optional[DeviceStatus] = None,
+        new_additional_state: Optional[AdditionalState] = None
     ):
         '''
         Turn this device on or off, depending on the value of new_state

--- a/common/python/powerpi_common/device/mixin/additional_state.py
+++ b/common/python/powerpi_common/device/mixin/additional_state.py
@@ -80,7 +80,7 @@ class AdditionalStateMixin(ABC):
         new_additional_state: AdditionalState
     ):
         '''
-        Update the scene of this device to new_scene, the state to new_state, 
+        Update the scene of this device to new_scene, the state to new_state and
         update the additional state to new_additional_state but do not broadcast 
         to the message queue.
         '''

--- a/common/python/powerpi_common/device/mixin/additional_state.py
+++ b/common/python/powerpi_common/device/mixin/additional_state.py
@@ -33,7 +33,7 @@ class AdditionalStateMixin(ABC):
                     )
                 else:
                     # update just the additional state for that scene
-                    self._set_scene_additional_state(
+                    self.set_scene_additional_state(
                         scene, new_additional_state
                     )
 
@@ -74,7 +74,7 @@ class AdditionalStateMixin(ABC):
         '''
         raise NotImplementedError
 
-    def _set_scene_additional_state(
+    def set_scene_additional_state(
         self,
         scene: Optional[str],
         new_additional_state: AdditionalState

--- a/common/python/powerpi_common/device/scene_state.py
+++ b/common/python/powerpi_common/device/scene_state.py
@@ -1,0 +1,128 @@
+from enum import Enum
+from typing import Dict, Optional
+
+from .mixin import AdditionalState
+
+
+class ReservedScenes(str, Enum):
+    DEFAULT = 'default'
+    CURRENT = 'current'
+
+
+class SceneState:
+    '''
+    Class to handle additional state, and which scenes they belong to for a device.
+    All additional state updates and retrievals should come through here so the state for the 
+    current scene is always returned.
+    Caches the state for each scene as messages come through, indicating whether a device needs
+    to actually play the change or not depending on the scene it is in.
+    '''
+
+    def __init__(self):
+        self.__scene = ReservedScenes.DEFAULT
+
+        self.__state: Dict[str, Optional[AdditionalState]] = {
+            ReservedScenes.DEFAULT: None
+        }
+
+    @property
+    def scene(self):
+        '''
+        Returns the current scene for the device.
+        '''
+        return self.__scene
+
+    @scene.setter
+    def scene(self, new_scene: str):
+        self.__scene = new_scene
+
+        if new_scene not in self.__state:
+            self.__state[new_scene] = None
+
+    @property
+    def scenes(self):
+        '''
+        Returns the scenes with state for the device.
+        '''
+        return list(self.__state.keys())
+
+    @property
+    def state(self):
+        '''
+        Returns the current additional state for the device.
+        '''
+        _, current_state = self.get_scene_state()
+
+        if current_state:
+            return current_state
+
+        return {}
+
+    @state.setter
+    def state(self, new_state: AdditionalState):
+        '''
+        Update the additional state of this device to new_state.
+        '''
+        self.__state[self.__scene] = new_state
+
+    def is_current_scene(self, scene: Optional[str] = ReservedScenes.CURRENT):
+        '''
+        Returns whether the supplier scene is the current scene.
+        None and 'current' are synonyms for whatever the current scene is.
+        '''
+        if scene is None or scene == ReservedScenes.CURRENT:
+            return True
+
+        return scene == self.__scene
+
+    def get_scene_state(self, scene: Optional[str] = ReservedScenes.CURRENT):
+        '''
+        Return the actual name of the scene and the state for the specified scene. 
+        If None or 'current' is provided, return the name and state for the current scene.
+        '''
+        if self.is_current_scene(scene):
+            scene = self.__scene
+
+        if scene in self.__state:
+            return scene, self.__state[scene]
+
+        return scene, None
+
+    def update_scene_state(
+        self,
+        scene: Optional[str] = ReservedScenes.CURRENT,
+        new_state: Optional[AdditionalState] = None
+    ):
+        '''
+        Update the state of the specified scene.
+        '''
+        if self.is_current_scene(scene):
+            scene = self.__scene
+
+        self.__state[scene] = new_state
+
+    def format_scene_state(self, scene: Optional[str] = ReservedScenes.CURRENT):
+        '''
+        Return a JSON formatted string for the specified scene.
+        '''
+        scene, state = self.get_scene_state(scene)
+
+        result = {
+            'scene': scene,
+        }
+
+        if state:
+            for key in state:
+                to_json = getattr(
+                    state[key], 'to_json', None
+                )
+
+                if callable(to_json):
+                    result[key] = to_json()
+                else:
+                    result[key] = state[key]
+
+        return f'{result}'
+
+    def __str__(self):
+        return f'[{", ".join([self.format_scene_state(scene) for scene in self.scenes])}]'

--- a/common/python/powerpi_common/device/scene_state.py
+++ b/common/python/powerpi_common/device/scene_state.py
@@ -52,11 +52,7 @@ class SceneState:
         Returns the current additional state for the device.
         '''
         _, current_state = self.get_scene_state()
-
-        if current_state:
-            return current_state
-
-        return {}
+        return current_state
 
     @state.setter
     def state(self, new_state: AdditionalState):
@@ -80,13 +76,17 @@ class SceneState:
         Return the actual name of the scene and the state for the specified scene. 
         If None or 'current' is provided, return the name and state for the current scene.
         '''
+        state = None
+
         if self.is_current_scene(scene):
             scene = self.__scene
 
         if scene in self.__state:
-            return scene, self.__state[scene]
+            state = self.__state[scene]
+            if state is None:
+                state = {}
 
-        return scene, None
+        return scene, state
 
     def update_scene_state(
         self,
@@ -125,4 +125,4 @@ class SceneState:
         return result
 
     def __str__(self):
-        return f'[{", ".join([self.format_scene_state(scene) for scene in self.scenes])}]'
+        return f'[{", ".join([f"{self.format_scene_state(scene)}" for scene in self.scenes])}]'

--- a/common/python/powerpi_common/device/scene_state.py
+++ b/common/python/powerpi_common/device/scene_state.py
@@ -103,7 +103,7 @@ class SceneState:
 
     def format_scene_state(self, scene: Optional[str] = ReservedScenes.CURRENT):
         '''
-        Return a JSON formatted string for the specified scene.
+        Return an object representation for the specified scene.
         '''
         scene, state = self.get_scene_state(scene)
 
@@ -122,7 +122,7 @@ class SceneState:
                 else:
                     result[key] = state[key]
 
-        return f'{result}'
+        return result
 
     def __str__(self):
         return f'[{", ".join([self.format_scene_state(scene) for scene in self.scenes])}]'

--- a/common/python/powerpi_common/event/action.py
+++ b/common/python/powerpi_common/event/action.py
@@ -3,8 +3,7 @@ from typing import Any, Dict, Optional
 from jsonpatch import JsonPatch
 
 from powerpi_common.condition import ConditionParser
-from powerpi_common.device import Device
-from powerpi_common.device.mixin import AdditionalStateMixin
+from powerpi_common.device import AdditionalStateDevice, Device
 from powerpi_common.variable import VariableManager
 
 
@@ -23,7 +22,7 @@ def device_additional_state_action(
 ):
     json_patch = JsonPatch(patch)
 
-    async def wrapper(device: AdditionalStateMixin):
+    async def wrapper(device: AdditionalStateDevice):
         current_state = device.additional_state
 
         parser = ConditionParser(variable_manager)
@@ -40,5 +39,12 @@ def device_additional_state_action(
             scene=scene,
             new_additional_state=patched
         )
+
+    return wrapper
+
+
+def device_scene_action(scene: Optional[str]):
+    async def wrapper(device: AdditionalStateDevice):
+        await device.change_scene(scene)
 
     return wrapper

--- a/common/python/powerpi_common/event/action.py
+++ b/common/python/powerpi_common/event/action.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from jsonpatch import JsonPatch
 
@@ -16,7 +16,11 @@ async def device_off_action(device: Device):
     await device.turn_off()
 
 
-def device_additional_state_action(patch: Dict[str, Any], variable_manager: VariableManager):
+def device_additional_state_action(
+    scene: Optional[str],
+    patch: Dict[str, Any],
+    variable_manager: VariableManager
+):
     json_patch = JsonPatch(patch)
 
     async def wrapper(device: AdditionalStateMixin):
@@ -31,6 +35,10 @@ def device_additional_state_action(patch: Dict[str, Any], variable_manager: Vari
             )
 
         patched = json_patch.apply(current_state)
-        await device.change_power_and_additional_state(new_additional_state=patched)
+
+        await device.change_power_and_additional_state(
+            scene=scene,
+            new_additional_state=patched
+        )
 
     return wrapper

--- a/common/python/powerpi_common/event/manager.py
+++ b/common/python/powerpi_common/event/manager.py
@@ -1,9 +1,10 @@
-from typing import List
+from typing import Any, Dict, List
 
 from powerpi_common.config import Config
-from powerpi_common.device import Device, DeviceManager, DeviceNotFoundException, DeviceStatus
-from powerpi_common.event.action import device_additional_state_action, device_off_action, \
-    device_on_action
+from powerpi_common.device import (Device, DeviceManager,
+                                   DeviceNotFoundException, DeviceStatus)
+from powerpi_common.event.action import (device_additional_state_action,
+                                         device_off_action, device_on_action)
 from powerpi_common.event.consumer import EventConsumer
 from powerpi_common.event.handler import EventHandler
 from powerpi_common.logger import Logger
@@ -20,7 +21,7 @@ class EventManager:
         device_manager: DeviceManager,
         variable_manager: VariableManager
     ):
-        #pylint: disable=too-many-arguments
+        # pylint: disable=too-many-arguments
         self.__config = config
         self.__logger = logger
         self.__mqtt_client = mqtt_client
@@ -93,7 +94,7 @@ class EventManager:
             f'Found {len(self.__consumers)} matching listener(s)'
         )
 
-    def __get_action(self, action: dict):
+    def __get_action(self, action: Dict[str, Any]):
         try:
             state = action['state']
 
@@ -105,7 +106,9 @@ class EventManager:
             pass
 
         try:
-            return device_additional_state_action(action['patch'], self.__variable_manager)
+            scene = action.get('scene', None)
+
+            return device_additional_state_action(scene, action['patch'], self.__variable_manager)
         except KeyError:
             pass
 

--- a/common/python/powerpi_common/event/manager.py
+++ b/common/python/powerpi_common/event/manager.py
@@ -4,7 +4,8 @@ from powerpi_common.config import Config
 from powerpi_common.device import (Device, DeviceManager,
                                    DeviceNotFoundException, DeviceStatus)
 from powerpi_common.event.action import (device_additional_state_action,
-                                         device_off_action, device_on_action)
+                                         device_off_action, device_on_action,
+                                         device_scene_action)
 from powerpi_common.event.consumer import EventConsumer
 from powerpi_common.event.handler import EventHandler
 from powerpi_common.logger import Logger
@@ -109,6 +110,13 @@ class EventManager:
             scene = action.get('scene', None)
 
             return device_additional_state_action(scene, action['patch'], self.__variable_manager)
+        except KeyError:
+            pass
+
+        try:
+            scene = action['scene']
+
+            return device_scene_action(scene)
         except KeyError:
             pass
 

--- a/common/python/powerpi_common/mqtt/consumer.py
+++ b/common/python/powerpi_common/mqtt/consumer.py
@@ -3,11 +3,11 @@ from datetime import datetime
 from typing import Union
 
 from powerpi_common.config import Config
-from powerpi_common.logger import Logger
-from .types import MQTTMessage
+from powerpi_common.logger import Logger, LogMixin
+from powerpi_common.mqtt.types import MQTTMessage
 
 
-class MQTTConsumer(ABC):
+class MQTTConsumer(ABC, LogMixin):
     def __init__(self, topic: str, config: Config, logger: Logger):
         self._topic = topic
         self._config = config

--- a/common/python/powerpi_common/variable/device.py
+++ b/common/python/powerpi_common/variable/device.py
@@ -40,6 +40,10 @@ class DeviceVariable(Variable, DeviceStatusEventConsumer, AdditionalStateMixin):
         self.__state = new_state
 
     @property
+    def scene(self):
+        return self.__additional_state.scene
+
+    @property
     def additional_state(self):
         return self.__additional_state.state
 

--- a/common/python/powerpi_common/variable/device.py
+++ b/common/python/powerpi_common/variable/device.py
@@ -1,9 +1,10 @@
-from typing import List
+from typing import List, Optional
 
 from powerpi_common.config import Config
 from powerpi_common.device import DeviceStatus
 from powerpi_common.device.consumers import DeviceStatusEventConsumer
 from powerpi_common.device.mixin import AdditionalState, AdditionalStateMixin
+from powerpi_common.device.scene_state import SceneState
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
 from powerpi_common.variable.types import VariableType
@@ -22,7 +23,7 @@ class DeviceVariable(Variable, DeviceStatusEventConsumer, AdditionalStateMixin):
         DeviceStatusEventConsumer.__init__(self, self, config, logger)
 
         self.__state = DeviceStatus.UNKNOWN
-        self.__additional_state = {}
+        self.__additional_state = SceneState()
 
         mqtt_client.add_consumer(self)
 
@@ -40,11 +41,11 @@ class DeviceVariable(Variable, DeviceStatusEventConsumer, AdditionalStateMixin):
 
     @property
     def additional_state(self):
-        return self.__additional_state
+        return self.__additional_state.state
 
     @additional_state.setter
     def additional_state(self, new_additional_state: AdditionalState):
-        self.__additional_state = new_additional_state
+        self.__additional_state.state = new_additional_state
 
     def set_state_and_additional(
         self,
@@ -52,11 +53,18 @@ class DeviceVariable(Variable, DeviceStatusEventConsumer, AdditionalStateMixin):
         new_additional_state: AdditionalState
     ):
         self.__state = new_state
-        self.__additional_state = new_additional_state
+        self.__additional_state.state = new_additional_state
+
+    def set_scene_additional_state(
+        self,
+        scene: Optional[str],
+        new_additional_state: AdditionalState
+    ):
+        self.__additional_state.update_scene_state(scene, new_additional_state)
 
     @property
     def json(self):
-        return {'state': self.__state, **self.__additional_state}
+        return {'state': self.__state, **self.__additional_state.format_scene_state()}
 
     @property
     def suffix(self):
@@ -65,3 +73,6 @@ class DeviceVariable(Variable, DeviceStatusEventConsumer, AdditionalStateMixin):
     def _additional_state_keys(self) -> List[str]:
         # we don't know what the actual implementation supports, so we're not setting keys
         return []
+
+    def _is_current_scene(self, scene: Optional[str]):
+        return self.__additional_state.is_current_scene(scene)

--- a/common/python/powerpi_common/variable/device.py
+++ b/common/python/powerpi_common/variable/device.py
@@ -51,6 +51,16 @@ class DeviceVariable(Variable, DeviceStatusEventConsumer, AdditionalStateMixin):
     def additional_state(self, new_additional_state: AdditionalState):
         self.__additional_state.state = new_additional_state
 
+    def update_state_and_additional_no_broadcast(
+        self,
+        new_scene: str,
+        new_state: DeviceStatus,
+        new_additional_state: AdditionalState
+    ):
+        self.__additional_state.scene = new_scene
+        self.__state = new_state
+        self.__additional_state.state = new_additional_state
+
     def set_state_and_additional(
         self,
         new_state: DeviceStatus,

--- a/common/python/powerpi_common/variable/manager.py
+++ b/common/python/powerpi_common/variable/manager.py
@@ -1,7 +1,7 @@
-from typing import Dict, Union
+from typing import Dict, Optional, Union
 
 from powerpi_common.device import DeviceManager, DeviceNotFoundException
-from powerpi_common.logger import Logger
+from powerpi_common.logger import Logger, LogMixin
 from powerpi_common.typing import DeviceType, SensorType
 from powerpi_common.variable.device import DeviceVariable
 from powerpi_common.variable.sensor import SensorVariable
@@ -9,7 +9,7 @@ from powerpi_common.variable.types import VariableType
 from powerpi_common.variable.variable import Variable
 
 
-class VariableManager:
+class VariableManager(LogMixin):
     '''
     Class to retrieve a variable, or if it's a local device/sensor, the actual device
     from DeviceManager, which has the live state.
@@ -21,7 +21,7 @@ class VariableManager:
         device_manager: DeviceManager,
         service_provider
     ):
-        self.__logger = logger
+        self._logger = logger
         self.__device_manager = device_manager
         self.__service_provider = service_provider
 
@@ -58,17 +58,17 @@ class VariableManager:
 
         self.__variables[variable_type][key] = variable
 
-        self.__logger.info(f'Adding variable {variable}')
+        self.log_info(f'Adding variable {variable}')
         return True
 
-    def __create(self, variable_type: VariableType, name: str, action: Union[str, None]):
+    def __create(self, variable_type: VariableType, name: str, action: Optional[str]):
         variable_attribute = f'{variable_type}_variable'
 
         factory = getattr(self.__service_provider, variable_attribute, None)
 
         if factory is None:
-            self.__logger.debug(
-                f'Could not find variable type "{variable_type}'
+            self.log_debug(
+                f'Could not find variable type "{variable_type}"'
             )
             return None
 
@@ -82,7 +82,7 @@ class VariableManager:
 
         return instance
 
-    def __get(self, variable_type: VariableType, name: str, action: Union[str, None] = None):
+    def __get(self, variable_type: VariableType, name: str, action: Optional[str] = None):
         key = self.__key(variable_type, name, action)
 
         variable = self.__variables[variable_type].get(key)
@@ -103,7 +103,7 @@ class VariableManager:
         return self.__create(variable_type, name, action)
 
     @classmethod
-    def __key(cls, variable_type: VariableType, name: str, action: Union[str, None] = None):
+    def __key(cls, variable_type: VariableType, name: str, action: Optional[str] = None):
         if variable_type == VariableType.DEVICE:
             return name
         if variable_type == VariableType.SENSOR and action is not None:

--- a/common/python/pyproject.toml
+++ b/common/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "powerpi-common"
-version = "0.4.0"
+version = "0.5.0"
 description = "PowerPi Common Python Library"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/common/python/tests/condition/test_parser.py
+++ b/common/python/tests/condition/test_parser.py
@@ -13,6 +13,7 @@ class DeviceVariableImpl:
     def __init__(self, name: str):
         self.state = name
         self.additional_state = {'brightness': name}
+        self.scene = 'movie'
 
 
 class SensorVariableImpl:
@@ -43,6 +44,7 @@ class TestConditionParser:
 
     @pytest.mark.parametrize('identifier,expected', [
         ('device.socket.state', 'socket'),
+        ('device.light.scene', 'movie'),
         ('device.light.brightness', 'light'),
         ('sensor.office.temperature.value', 'office/temperature'),
         ('sensor.office.temperature.unit', 'temperature/office'),

--- a/common/python/tests/device/test_scene_state.py
+++ b/common/python/tests/device/test_scene_state.py
@@ -1,0 +1,98 @@
+from typing import Optional
+
+import pytest
+
+from powerpi_common.device.mixin import AdditionalState
+from powerpi_common.device.scene_state import SceneState
+
+
+class TestSceneState:
+    def test_defaults(self):
+        subject = SceneState()
+
+        assert subject.scene == 'default'
+        assert subject.scenes == ['default']
+
+        assert subject.state == {}
+
+        current_scene, current_state = subject.get_scene_state()
+        assert current_scene == 'default'
+        assert current_state == {}
+
+    def test_is_current_scene(self):
+        subject = SceneState()
+
+        assert subject.is_current_scene() is True
+        assert subject.is_current_scene('current') is True
+        assert subject.is_current_scene('default') is True
+        assert subject.is_current_scene('other') is False
+
+        subject.scene = 'other'
+
+        assert subject.is_current_scene() is True
+        assert subject.is_current_scene('current') is True
+        assert subject.is_current_scene('default') is False
+        assert subject.is_current_scene('other') is True
+
+    @pytest.mark.parametrize('additional_state,expected_additional_state', [
+        [{'brightness': 10}, {'brightness': 10}],
+        [None, {}],
+        [{}, {}]
+    ])
+    def test_update_scene_state(
+        self,
+        additional_state: Optional[AdditionalState],
+        expected_additional_state: AdditionalState
+    ):
+        subject = SceneState()
+
+        assert subject.scene == 'default'
+        assert subject.state == {}
+
+        subject.update_scene_state(
+            new_state=additional_state
+        )
+
+        assert subject.scene == 'default'
+        assert subject.state == expected_additional_state
+
+    def test_change_scene(self):
+        subject = SceneState()
+
+        assert subject.scene == 'default'
+        assert subject.scenes == ['default']
+        assert subject.state == {}
+
+        subject.update_scene_state(
+            'other',
+            {'brightness': 10}
+        )
+
+        assert subject.scene == 'default'
+        assert subject.scenes == ['default', 'other']
+        assert subject.state == {}
+
+        subject.scene = 'other'
+
+        assert subject.scene == 'other'
+        assert subject.scenes == ['default', 'other']
+        assert subject.state == {'brightness': 10}
+
+        subject.scene = 'another'
+
+        assert subject.scene == 'another'
+        assert subject.scenes == ['default', 'other', 'another']
+        assert subject.state == {}
+
+    # pylint: disable=line-too-long
+    @pytest.mark.parametrize('additional_state,expected', [
+        [{'brightness': 10, 'temperature': 4000},
+            "[{'scene': <ReservedScenes.DEFAULT: 'default'>, 'brightness': 10, 'temperature': 4000}]"],
+        [None, "[{'scene': <ReservedScenes.DEFAULT: 'default'>}]"]
+    ])
+    def test_str(self, additional_state: Optional[AdditionalState], expected: str):
+        subject = SceneState()
+
+        subject.update_scene_state(new_state=additional_state)
+
+        assert f'{subject}' == expected

--- a/common/python/tests/event/test_action.py
+++ b/common/python/tests/event/test_action.py
@@ -5,7 +5,8 @@ import pytest
 from powerpi_common.device.mixin import AdditionalState
 from powerpi_common.device.scene_state import ReservedScenes
 from powerpi_common.event.action import (device_additional_state_action,
-                                         device_off_action, device_on_action)
+                                         device_off_action, device_on_action,
+                                         device_scene_action)
 
 
 class DeviceImpl:
@@ -31,6 +32,9 @@ class DeviceImpl:
     ):
         self.scene = scene
         self.additional_state = new_additional_state
+
+    async def change_scene(self, scene: Optional[str]):
+        self.scene = scene
 
 
 @pytest.mark.asyncio
@@ -114,3 +118,17 @@ async def test_device_additional_state_action_with_variable(powerpi_variable_man
 
     assert device.additional_state['brightness'] == 'untouched'
     assert device.additional_state['other'] == 'untouched'
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('scene', [None, 'default', 'other'])
+async def test_device_change_scene(scene: Optional[str]):
+    device = DeviceImpl()
+
+    func = device_scene_action(scene)
+
+    assert device.scene == ReservedScenes.DEFAULT
+
+    await func(device)
+
+    assert device.scene == scene

--- a/common/python/tests/event/test_action.py
+++ b/common/python/tests/event/test_action.py
@@ -1,5 +1,8 @@
+from typing import Optional
+
 import pytest
 
+from powerpi_common.device.mixin import AdditionalState
 from powerpi_common.event.action import (device_additional_state_action,
                                          device_off_action, device_on_action)
 
@@ -18,7 +21,12 @@ class DeviceImpl:
     async def turn_off(self):
         self.state = 'off'
 
-    async def change_power_and_additional_state(self, _, new_additional_state: dict):
+    async def change_power_and_additional_state(
+        self,
+        _: Optional[str] = None,
+        __: Optional[str] = None,
+        new_additional_state: Optional[AdditionalState] = None
+    ):
         self.additional_state = new_additional_state
 
 

--- a/common/python/tests/event/test_manager.py
+++ b/common/python/tests/event/test_manager.py
@@ -89,7 +89,7 @@ class TestEventManager:
         assert subject.consumers[0].events[1].device == 'Device2'
         assert subject.consumers[0].events[1].condition == 'condition2'
 
-        # we're expecting the second consumer to have 1 events
+        # we're expecting the second consumer to have 1 event
         assert len(subject.consumers[1].events) == 1
         assert subject.consumers[1].topic == 'event/Something/Else'
 

--- a/common/python/tests/variable/test_device.py
+++ b/common/python/tests/variable/test_device.py
@@ -1,10 +1,29 @@
 import pytest
 from powerpi_common_test.variable import VariableTestBase
 
+from powerpi_common.device import DeviceStatus
+from powerpi_common.device.scene_state import ReservedScenes
 from powerpi_common.variable.device import DeviceVariable
 
 
 class TestDeviceVariable(VariableTestBase):
+
+    @pytest.mark.asyncio
+    async def test_on_status_change(self, subject: DeviceVariable):
+        assert subject.scene == ReservedScenes.DEFAULT
+        assert subject.state == DeviceStatus.UNKNOWN
+        assert subject.additional_state.get('brightness', None) is None
+
+        message = {
+            'scene': 'other',
+            'state': 'on',
+            'brightness': 33
+        }
+        await subject.on_message(message, subject.name, 'status')
+
+        assert subject.scene == 'other'
+        assert subject.state == DeviceStatus.ON
+        assert subject.additional_state.get('brightness', None) == 33
 
     @pytest.fixture
     def subject(self, powerpi_config, powerpi_logger, powerpi_mqtt_client):

--- a/controllers/energenie/poetry.lock
+++ b/controllers/energenie/poetry.lock
@@ -469,7 +469,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "powerpi-common"
-version = "0.4.0"
+version = "0.5.0"
 description = "PowerPi Common Python Library"
 category = "dev"
 optional = false
@@ -490,7 +490,7 @@ url = "../../common/python"
 
 [[package]]
 name = "powerpi-common-test"
-version = "0.4.0"
+version = "0.5.0"
 description = "PowerPi Common Python Test Library"
 category = "dev"
 optional = false

--- a/controllers/energenie/pyproject.toml
+++ b/controllers/energenie/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "energenie_controller"
 version = "0.2.3"
-description = "PowerPi Engergenie Controller"
+description = "PowerPi Energenie Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]
 repository = "https://github.com/TWilkin/powerpi.git"

--- a/controllers/energenie/pyproject.toml
+++ b/controllers/energenie/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "energenie_controller"
-version = "0.2.2"
+version = "0.2.3"
 description = "PowerPi Engergenie Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/harmony/poetry.lock
+++ b/controllers/harmony/poetry.lock
@@ -897,7 +897,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "powerpi-common"
-version = "0.4.0"
+version = "0.5.0"
 description = "PowerPi Common Python Library"
 category = "dev"
 optional = false
@@ -918,7 +918,7 @@ url = "../../common/python"
 
 [[package]]
 name = "powerpi-common-test"
-version = "0.4.0"
+version = "0.5.0"
 description = "PowerPi Common Python Test Library"
 category = "dev"
 optional = false

--- a/controllers/harmony/pyproject.toml
+++ b/controllers/harmony/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "harmony_controller"
-version = "0.3.2"
+version = "0.3.3"
 description = "PowerPi Logitech Harmony Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/lifx/poetry.lock
+++ b/controllers/lifx/poetry.lock
@@ -548,7 +548,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "powerpi-common"
-version = "0.4.0"
+version = "0.5.0"
 description = "PowerPi Common Python Library"
 category = "dev"
 optional = false
@@ -569,7 +569,7 @@ url = "../../common/python"
 
 [[package]]
 name = "powerpi-common-test"
-version = "0.4.0"
+version = "0.5.0"
 description = "PowerPi Common Python Test Library"
 category = "dev"
 optional = false

--- a/controllers/lifx/pyproject.toml
+++ b/controllers/lifx/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lifx_controller"
-version = "0.4.1"
+version = "0.5.0"
 description = "PowerPi LIFX Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/lifx/tests/device/test_lifx_light.py
+++ b/controllers/lifx/tests/device/test_lifx_light.py
@@ -153,6 +153,7 @@ class TestLIFXLightDevice(
 
         topic = 'device/light/status'
         message = {
+            'scene': 'default',
             'state': 'off',
             'brightness': 100
         }

--- a/controllers/macro/macro_controller/device/remote.py
+++ b/controllers/macro/macro_controller/device/remote.py
@@ -49,6 +49,17 @@ class RemoteDevice(DeviceVariable):
     ):
         await self.__send_message(scene, new_state, new_additional_state)
 
+    def update_state_and_additional_no_broadcast(
+        self,
+        new_scene: str,
+        new_state: DeviceStatus,
+        new_additional_state: AdditionalState
+    ):
+        DeviceVariable.update_state_and_additional_no_broadcast(
+            self, new_scene, new_state, new_additional_state
+        )
+        self.__waiting.set()
+
     def set_state_and_additional(
         self,
         new_state: DeviceStatus,

--- a/controllers/macro/poetry.lock
+++ b/controllers/macro/poetry.lock
@@ -443,7 +443,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "powerpi-common"
-version = "0.4.0"
+version = "0.5.0"
 description = "PowerPi Common Python Library"
 category = "dev"
 optional = false
@@ -464,7 +464,7 @@ url = "../../common/python"
 
 [[package]]
 name = "powerpi-common-test"
-version = "0.4.0"
+version = "0.5.0"
 description = "PowerPi Common Python Test Library"
 category = "dev"
 optional = false

--- a/controllers/macro/pyproject.toml
+++ b/controllers/macro/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "macro_controller"
-version = "1.2.2"
+version = "1.3.0"
 description = "PowerPi Macro Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/macro/tests/device/test_composite.py
+++ b/controllers/macro/tests/device/test_composite.py
@@ -98,6 +98,27 @@ class TestCompositeDevice(
         assert order == expected_order
 
     @pytest.mark.asyncio
+    async def test_all_change_power_and_additional_state_scene(
+        self,
+        subject: CompositeDevice,
+        devices: Dict[str, MagicMock]
+    ):
+        with patch('macro_controller.device.composite.ismixin') as ismixin:
+            ismixin.return_value = True
+
+            await subject.change_power_and_additional_state(
+                scene='other',
+                new_additional_state={'something': 'else'}
+            )
+
+        for device in devices.values():
+            device.change_power_and_additional_state.assert_called_once_with(
+                'other',
+                None,
+                {'something': 'else'}
+            )
+
+    @pytest.mark.asyncio
     async def test_all_change_power_and_additional_state_unsupported(
         self,
         subject: CompositeDevice,

--- a/controllers/macro/tests/device/test_composite.py
+++ b/controllers/macro/tests/device/test_composite.py
@@ -1,5 +1,5 @@
 from asyncio import Future
-from typing import Dict, List, Tuple
+from typing import Dict, List
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
@@ -62,7 +62,7 @@ class TestCompositeDevice(
         assert order == ['device3', 'device2', 'device1', 'device0']
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize('states', [
+    @pytest.mark.parametrize('new_state,expected_order', [
         ('on', ['device0', 'device1', 'device2', 'device3']),
         ('off', ['device3', 'device2', 'device1', 'device0'])
     ])
@@ -70,15 +70,14 @@ class TestCompositeDevice(
         self,
         subject: CompositeDevice,
         devices: Dict[str, MagicMock],
-        states: Tuple[str, List[str]]
+        new_state: str,
+        expected_order: List[str]
     ):
-        (new_state, expected_order) = states
-
         # store the order they were called
         order = []
 
         def mock(name: str):
-            async def change_power_and_additional_state(_: str, __: dict):
+            async def change_power_and_additional_state(_: str, __: str, ___: dict):
                 order.append(name)
             return change_power_and_additional_state
 
@@ -90,7 +89,10 @@ class TestCompositeDevice(
         with patch('macro_controller.device.composite.ismixin') as ismixin:
             ismixin.return_value = True
 
-            await subject.change_power_and_additional_state(new_state, new_additional_state)
+            await subject.change_power_and_additional_state(
+                new_state=new_state,
+                new_additional_state=new_additional_state
+            )
 
         # ensure they were called in the correct order
         assert order == expected_order
@@ -107,13 +109,16 @@ class TestCompositeDevice(
         with patch('macro_controller.device.composite.ismixin') as ismixin:
             ismixin.return_value = False
 
-            await subject.change_power_and_additional_state(new_state, new_additional_state)
+            await subject.change_power_and_additional_state(
+                new_state=new_state,
+                new_additional_state=new_additional_state
+            )
 
         for device in devices.values():
             device.turn_on.assert_called_once()
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize('states', [
+    @pytest.mark.parametrize('initial_state,update_state,expected_states', [
         ('unknown', 'on', ['unknown', 'unknown', 'unknown', 'on']),
         ('unknown', 'off', ['unknown', 'unknown', 'unknown', 'off']),
         ('unknown', 'unknown', ['unknown', 'unknown', 'unknown', 'unknown']),
@@ -128,9 +133,11 @@ class TestCompositeDevice(
         self,
         subject: CompositeDevice,
         devices: Dict[str, MagicMock],
-        states: Tuple[str, str, List[str]]
+        initial_state: str,
+        update_state: str,
+        expected_states: List[str]
     ):
-        (initial_state, update_state, expected_states) = states
+        # pylint: disable=too-many-arguments
 
         assert subject.state == 'unknown'
 
@@ -145,6 +152,23 @@ class TestCompositeDevice(
             assert subject.state == expected
 
         assert subject.state == update_state
+
+    @pytest.mark.asyncio
+    async def test_scene_event_message(self, subject: CompositeDevice):
+        scene_event_consumer = self._mqtt_consumers['scene']
+
+        message = {
+            'scene': 'other'
+        }
+
+        assert subject.scene == 'default'
+        assert subject.state == 'unknown'
+
+        # should change the scene
+        await scene_event_consumer.on_message(message, subject.name, 'scene')
+        assert subject.scene == 'other'
+
+        # additional state will always be applied to the composite regardless of scene
 
     @pytest.fixture
     def subject(

--- a/controllers/network/poetry.lock
+++ b/controllers/network/poetry.lock
@@ -461,7 +461,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "powerpi-common"
-version = "0.4.0"
+version = "0.5.0"
 description = "PowerPi Common Python Library"
 category = "dev"
 optional = false
@@ -482,7 +482,7 @@ url = "../../common/python"
 
 [[package]]
 name = "powerpi-common-test"
-version = "0.4.0"
+version = "0.5.0"
 description = "PowerPi Common Python Test Library"
 category = "dev"
 optional = false

--- a/controllers/network/pyproject.toml
+++ b/controllers/network/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "network_controller"
-version = "0.1.2"
+version = "0.1.3"
 description = "PowerPi Network Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/node/poetry.lock
+++ b/controllers/node/poetry.lock
@@ -484,7 +484,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "powerpi-common"
-version = "0.4.0"
+version = "0.5.0"
 description = "PowerPi Common Python Library"
 category = "dev"
 optional = false
@@ -505,7 +505,7 @@ url = "../../common/python"
 
 [[package]]
 name = "powerpi-common-test"
-version = "0.4.0"
+version = "0.5.0"
 description = "PowerPi Common Python Test Library"
 category = "dev"
 optional = false

--- a/controllers/node/pyproject.toml
+++ b/controllers/node/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "node_controller"
-version = "0.1.3"
+version = "0.1.4"
 description = "PowerPi Node Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/zigbee/poetry.lock
+++ b/controllers/zigbee/poetry.lock
@@ -950,7 +950,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "powerpi-common"
-version = "0.4.0"
+version = "0.5.0"
 description = "PowerPi Common Python Library"
 category = "dev"
 optional = false
@@ -971,7 +971,7 @@ url = "../../common/python"
 
 [[package]]
 name = "powerpi-common-test"
-version = "0.4.0"
+version = "0.5.0"
 description = "PowerPi Common Python Test Library"
 category = "dev"
 optional = false

--- a/controllers/zigbee/pyproject.toml
+++ b/controllers/zigbee/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zigbee_controller"
-version = "0.3.1"
+version = "0.4.0"
 description = "PowerPi ZigBee Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/zigbee/tests/device/test_zigbee_light.py
+++ b/controllers/zigbee/tests/device/test_zigbee_light.py
@@ -77,6 +77,7 @@ class TestZigbeeeLight(
 
         topic = 'device/Light/status'
         message = {
+            'scene': 'default',
             'state': 'on' if state else 'off',
             **expected
         }

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     version: 0.1.3
     condition: global.persistence
   - name: scheduler
-    version: 0.2.4
+    version: 0.2.5
     condition: global.scheduler
   - name: smarter-device-manager
     version: 0.1.1
@@ -37,22 +37,22 @@ dependencies:
     condition: global.voiceAssistant
   # controllers
   - name: energenie-controller
-    version: 0.1.3
+    version: 0.1.4
     condition: global.energenie
   - name: harmony-controller
-    version: 0.1.3
+    version: 0.1.4
     condition: global.harmony
   - name: lifx-controller
-    version: 0.1.4
+    version: 0.1.5
     condition: global.lifx
   - name: macro-controller
-    version: 0.1.3
+    version: 0.1.4
   - name: network-controller
-    version: 0.1.2
+    version: 0.1.3
     condition: global.network
   - name: node-controller
-    version: 0.1.4
+    version: 0.1.5
     condition: global.node
   - name: zigbee-controller
-    version: 0.1.4
+    version: 0.1.5
     condition: global.zigbee

--- a/kubernetes/charts/energenie-controller/Chart.yaml
+++ b/kubernetes/charts/energenie-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: energenie-controller
 description: A Helm chart for the PowerPi Energenie device controller
 type: application
-version: 0.1.3
-appVersion: 0.2.2
+version: 0.1.4
+appVersion: 0.2.3

--- a/kubernetes/charts/harmony-controller/Chart.yaml
+++ b/kubernetes/charts/harmony-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: harmony-controller
 description: A Helm chart for the PowerPi Logitech Harmony device controller
 type: application
-version: 0.1.3
-appVersion: 0.3.2
+version: 0.1.4
+appVersion: 0.3.3

--- a/kubernetes/charts/lifx-controller/Chart.yaml
+++ b/kubernetes/charts/lifx-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lifx-controller
 description: A Helm chart for the PowerPi LIFX device controller
 type: application
-version: 0.1.4
-appVersion: 0.4.1
+version: 0.1.5
+appVersion: 0.5.0

--- a/kubernetes/charts/macro-controller/Chart.yaml
+++ b/kubernetes/charts/macro-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: macro-controller
 description: A Helm chart for the PowerPi macro virtual device controller
 type: application
-version: 0.1.3
-appVersion: 1.2.2
+version: 0.1.4
+appVersion: 1.3.0

--- a/kubernetes/charts/network-controller/Chart.yaml
+++ b/kubernetes/charts/network-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: network-controller
 description: A Helm chart for the PowerPi Network device controller
 type: application
-version: 0.1.2
-appVersion: 0.1.2
+version: 0.1.3
+appVersion: 0.1.3

--- a/kubernetes/charts/node-controller/Chart.yaml
+++ b/kubernetes/charts/node-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: node-controller
 description: A Helm chart for the PowerPi cluster node monitoring controller
 type: application
-version: 0.1.4
-appVersion: 0.1.3
+version: 0.1.5
+appVersion: 0.1.4

--- a/kubernetes/charts/scheduler/Chart.yaml
+++ b/kubernetes/charts/scheduler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: scheduler
 description: A Helm chart for the PowerPi scheduler service
 type: application
-version: 0.2.4
-appVersion: 1.2.2
+version: 0.2.5
+appVersion: 1.2.3

--- a/kubernetes/charts/zigbee-controller/Chart.yaml
+++ b/kubernetes/charts/zigbee-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: zigbee-controller
 description: A Helm chart for the PowerPi ZigBee device controller
 type: application
-version: 0.1.4
-appVersion: 0.3.1
+version: 0.1.5
+appVersion: 0.4.0

--- a/services/scheduler/poetry.lock
+++ b/services/scheduler/poetry.lock
@@ -440,7 +440,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "powerpi-common"
-version = "0.4.0"
+version = "0.5.0"
 description = "PowerPi Common Python Library"
 category = "dev"
 optional = false
@@ -461,7 +461,7 @@ url = "../../common/python"
 
 [[package]]
 name = "powerpi-common-test"
-version = "0.4.0"
+version = "0.5.0"
 description = "PowerPi Common Python Test Library"
 category = "dev"
 optional = false

--- a/services/scheduler/pyproject.toml
+++ b/services/scheduler/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scheduler"
-version = "1.2.2"
+version = "1.2.3"
 description = "PowerPi Scheduler Service"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/services/scheduler/scheduler/services/device_schedule.py
+++ b/services/scheduler/scheduler/services/device_schedule.py
@@ -305,7 +305,7 @@ class DeviceSchedule(LogMixin):
             builder += f' for scene {self.__scene}'
 
         for device_type, delta in self.__delta.items():
-            builder += f' {device_type} between {delta.start} and {delta.end}'
+            builder += f', {device_type} between {delta.start} and {delta.end}'
 
         if self.__power:
             builder += ' and turn it on'

--- a/services/scheduler/tests/services/test_device_schedule.py
+++ b/services/scheduler/tests/services/test_device_schedule.py
@@ -1,6 +1,4 @@
-
-
-from collections import namedtuple
+from dataclasses import dataclass
 from datetime import datetime
 from types import MethodType
 from typing import Any, Callable, Dict, List, Tuple, Union
@@ -11,9 +9,15 @@ import pytz
 from apscheduler.triggers.interval import IntervalTrigger
 from powerpi_common.condition import ConditionParser, Expression
 from pytest_mock import MockerFixture
+
 from scheduler.services import DeviceSchedule
 
-ExpectedTime = namedtuple('ExpectedTime', 'day hour minute')
+
+@dataclass
+class ExpectedTime:
+    day: int
+    hour: int
+    minute: int
 
 
 class TestDeviceSchedule:
@@ -128,10 +132,12 @@ class TestDeviceSchedule:
         (
             {
                 'power': False,
+                'scene': 'other',
                 'brightness': [0, 100],
                 'temperature': [2000, 4000]
             },
             {
+                'scene': 'other',
                 'brightness': 62,
                 'temperature': 3240,
                 'state': 'off'

--- a/services/scheduler/tests/services/test_device_schedule.py
+++ b/services/scheduler/tests/services/test_device_schedule.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from datetime import datetime
 from types import MethodType
-from typing import Any, Callable, Dict, List, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
@@ -54,7 +54,7 @@ class TestDeviceSchedule:
         add_job,
         start_time: str,
         end_time: str,
-        days: Union[List[str], None],
+        days: Optional[List[str]],
         expected_start: ExpectedTime,
         expected_end: ExpectedTime,
         interval: List[int]
@@ -102,7 +102,7 @@ class TestDeviceSchedule:
         self,
         subject_builder: Callable[[Dict[str, Any]], DeviceSchedule],
         add_job,
-        condition: Union[Expression, None],
+        condition: Optional[Expression],
         expected: bool
     ):
         subject = subject_builder({
@@ -149,8 +149,8 @@ class TestDeviceSchedule:
         subject_builder: Callable[[Dict[str, Any]], DeviceSchedule],
         add_job,
         powerpi_mqtt_producer: MagicMock,
-        config: Dict,
-        expected: Dict
+        config: Dict[str, Any],
+        expected: Dict[str, Any]
     ):
         # pylint: disable=too-many-arguments
 


### PR DESCRIPTION
- Resolves #121 
  - Add scene to `AdditionalStateMixin` and `AdditionalStateDevice`.
  - Use `SceneState` to capture the scene cache and broadcast the cache on status update.
  - Only apply additional state to the actual device if it's in the correct scene. Except `CompositeDevice` which will do it anyway as the groups will intentionally ignore scenes, but still pass them on to referenced devices.
  - Support scene in `ConditionParser`.
  - Support changing scene using new `powerpi/device/x/scene` topic.
  - Support changing scene from event configuration.
- Resolves #361 by adding support for scenes to `scheduler`.
- Add script `buildx.sh` to build a service's docker image.