### PR TITLE
#360 Add SceneDevice to config-server

### DIFF
--- a/services/config-server/src/schema/common/AdditionalState.schema.json
+++ b/services/config-server/src/schema/common/AdditionalState.schema.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/TWilkin/powerpi/main/services/config-server/src/schema/common/AdditionalState.schema.json",
+    "title": "AdditionalState",
+    "description": "The possible device additional state in PowerPi",
+    "type": "object",
+    "properties": {
+        "brightness": {
+            "description": "The additional state brightness value",
+            "$ref": "https://raw.githubusercontent.com/TWilkin/powerpi/main/services/config-server/src/schema/common/Percentage.schema.json"
+        },
+        "temperature": {
+            "description": "The additional state colour temperature value",
+            "$ref": "https://raw.githubusercontent.com/TWilkin/powerpi/main/services/config-server/src/schema/common/ColourTemperature.schema.json"
+        },
+        "hue": {
+            "description": "The additional state hue value",
+            "$ref": "https://raw.githubusercontent.com/TWilkin/powerpi/main/services/config-server/src/schema/common/Hue.schema.json"
+        },
+        "saturation": {
+            "description": "The additional state saturation value",
+            "$ref": "https://raw.githubusercontent.com/TWilkin/powerpi/main/services/config-server/src/schema/common/Percentage.schema.json"
+        }
+    },
+    "oneOf": [
+        { "required": ["brightness"] },
+        { "required": ["temperature"] },
+        { "required": ["hue"] },
+        { "required": ["saturation"] }
+    ],
+    "additionalProperties": false
+}

--- a/services/config-server/src/schema/common/AdditionalState.schema.json
+++ b/services/config-server/src/schema/common/AdditionalState.schema.json
@@ -22,7 +22,7 @@
             "$ref": "https://raw.githubusercontent.com/TWilkin/powerpi/main/services/config-server/src/schema/common/Percentage.schema.json"
         }
     },
-    "oneOf": [
+    "anyOf": [
         { "required": ["brightness"] },
         { "required": ["temperature"] },
         { "required": ["hue"] },

--- a/services/config-server/src/schema/common/ColourTemperature.schema.json
+++ b/services/config-server/src/schema/common/ColourTemperature.schema.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/TWilkin/powerpi/main/services/config-server/src/schema/common/ColourTemperature.schema.json",
+    "title": "ColourTemperature",
+    "description": "A colour temperature value between 1500 and 10000 kelvin",
+    "type": "integer",
+    "minimum": 1500,
+    "maximum": 10000
+}

--- a/services/config-server/src/schema/common/Hue.schema.json
+++ b/services/config-server/src/schema/common/Hue.schema.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/TWilkin/powerpi/main/services/config-server/src/schema/common/Hue.schema.json",
+    "title": "Hue",
+    "description": "A hue value between 0 and 360 degress",
+    "type": "integer",
+    "minimum": 0,
+    "maximum": 360
+}

--- a/services/config-server/src/schema/common/index.ts
+++ b/services/config-server/src/schema/common/index.ts
@@ -1,5 +1,8 @@
+import * as AdditionalState from "./AdditionalState.schema.json";
+import * as ColourTemperature from "./ColourTemperature.schema.json";
 import * as Condition from "./Condition.schema.json";
 import * as DeviceState from "./DeviceState.schema.json";
+import * as Hue from "./Hue.schema.json";
 import * as Identifier from "./Identifier.schema.json";
 import * as JsonPath from "./JsonPatch.schema.json";
 import * as MACAddress from "./MACAddress.schema.json";
@@ -9,8 +12,11 @@ import * as WeekDay from "./WeekDay.schema.json";
 
 export default function loadCommonSchema() {
     return {
+        AdditionalState,
+        ColourTemperature,
         Condition,
         DeviceState,
+        Hue,
         Identifier,
         JsonPath,
         MACAddress,

--- a/services/config-server/src/schema/config/devices.schema.json
+++ b/services/config-server/src/schema/config/devices.schema.json
@@ -53,6 +53,9 @@
                         "$ref": "https://raw.githubusercontent.com/TWilkin/powerpi/main/services/config-server/src/schema/devices/virtual/Mutex.schema.json"
                     },
                     {
+                        "$ref": "https://raw.githubusercontent.com/TWilkin/powerpi/main/services/config-server/src/schema/devices/virtual/Scene.schema.json"
+                    },
+                    {
                         "$ref": "https://raw.githubusercontent.com/TWilkin/powerpi/main/services/config-server/src/schema/devices/virtual/Variable.schema.json"
                     },
                     {

--- a/services/config-server/src/schema/config/schedules.schema.json
+++ b/services/config-server/src/schema/config/schedules.schema.json
@@ -62,9 +62,7 @@
                         "minItems": 2,
                         "maxItems": 2,
                         "items": {
-                            "type": "integer",
-                            "minimum": 0,
-                            "maximum": 360
+                            "$ref": "https://raw.githubusercontent.com/TWilkin/powerpi/main/services/config-server/src/schema/common/Hue.schema.json"
                         }
                     },
                     "saturation": {
@@ -91,9 +89,7 @@
                         "minItems": 2,
                         "maxItems": 2,
                         "items": {
-                            "type": "integer",
-                            "minimum": 1500,
-                            "maximum": 6500
+                            "$ref": "https://raw.githubusercontent.com/TWilkin/powerpi/main/services/config-server/src/schema/common/ColourTemperature.schema.json"
                         }
                     },
                     "scene": {

--- a/services/config-server/src/schema/devices/virtual/Scene.schema.json
+++ b/services/config-server/src/schema/devices/virtual/Scene.schema.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/TWilkin/powerpi/main/services/config-server/src/schema/devices/virtual/Scene.schema.json",
+    "title": "Scene",
+    "description": "The Scene device",
+    "type": "object",
+    "allOf": [
+        {
+            "$ref": "https://raw.githubusercontent.com/TWilkin/powerpi/main/services/config-server/src/schema/devices/BaseDevice.schema.json"
+        },
+        {
+            "$ref": "https://raw.githubusercontent.com/TWilkin/powerpi/main/services/config-server/src/schema/devices/PollableDevice.schema.json"
+        }
+    ],
+    "properties": {
+        "type": {
+            "const": "scene"
+        },
+        "devices": {
+            "description": "The list of devices that will have the scene activated in sequence",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "$ref": "https://raw.githubusercontent.com/TWilkin/powerpi/main/services/config-server/src/schema/common/Identifier.schema.json"
+            }
+        },
+        "state": {
+            "description": "The additional state to apply to the devices when they are turned on",
+            "$ref": "https://raw.githubusercontent.com/TWilkin/powerpi/main/services/config-server/src/schema/common/AdditionalState.schema.json"
+        },
+        "scene": {
+            "description": "The name of the scene to activate, by default will be the device name",
+            "$ref": "https://raw.githubusercontent.com/TWilkin/powerpi/main/services/config-server/src/schema/common/Identifier.schema.json"
+        }
+    },
+    "required": ["devices", "state"]
+}

--- a/services/config-server/src/schema/devices/virtual/index.ts
+++ b/services/config-server/src/schema/devices/virtual/index.ts
@@ -3,6 +3,7 @@ import * as ConditionDevice from "./Condition.schema.json";
 import * as Delay from "./Delay.schema.json";
 import * as Log from "./Log.schema.json";
 import * as Mutex from "./Mutex.schema.json";
+import * as Scene from "./Scene.schema.json";
 import * as Variable from "./Variable.schema.json";
 
 export default function loadVirtualSchema() {
@@ -12,6 +13,7 @@ export default function loadVirtualSchema() {
         Delay,
         Log,
         Mutex,
+        Scene,
         Variable,
     };
 }

--- a/services/config-server/test/services/validator/devices/VirtualDevicesConfigFile.test.ts
+++ b/services/config-server/test/services/validator/devices/VirtualDevicesConfigFile.test.ts
@@ -154,6 +154,93 @@ describe("Virtual Devices", () => {
         );
     });
 
+    describe("Scene", () => {
+        const { testValid, testInvalid } = commonDeviceTests({
+            devices: [
+                {
+                    type: "scene",
+                    name: "Scene",
+                    devices: ["Device1", "Device2"],
+                    scene: "movie",
+                    state: { brightness: 50, temperature: 9999, hue: 120, saturation: 100 },
+                },
+            ],
+        });
+
+        [[], undefined, [1]].forEach((devices) =>
+            test(`Bad devices ${devices}`, () =>
+                testInvalid({
+                    devices: [{ type: "scene", name: "Scene", devices, state: { brightness: 50 } }],
+                }))
+        );
+
+        describe("State", () => {
+            test("Missing", () =>
+                testInvalid({
+                    devices: [
+                        {
+                            type: "scene",
+                            name: "Scene",
+                            devices: ["Device1", "Device2"],
+                        },
+                    ],
+                }));
+
+            test("Unknown state", () =>
+                testInvalid({
+                    devices: [
+                        {
+                            type: "scene",
+                            name: "Scene",
+                            devices: ["Device1", "Device2"],
+                            state: { something: "else" },
+                        },
+                    ],
+                }));
+
+            [
+                { state: "brightness", goodValues: [0, 20.23, 100], badValues: [-1, 101, "e"] },
+                {
+                    state: "temperature",
+                    goodValues: [1500, 6000, 10000],
+                    badValues: [-1, 6000.1, 10001, "e"],
+                },
+                { state: "hue", goodValues: [0, 240, 360], badValues: [-1, 23.23, 361, "e"] },
+                { state: "saturation", goodValues: [0, 20.23, 100], badValues: [-1, 101, "e"] },
+            ].forEach(({ state, goodValues, badValues }) =>
+                describe(state, () => {
+                    goodValues.forEach((value) =>
+                        test(`Good data ${value}`, () =>
+                            testValid({
+                                devices: [
+                                    {
+                                        type: "scene",
+                                        name: "Scene",
+                                        devices: ["Device1"],
+                                        state: { [state]: value },
+                                    },
+                                ],
+                            }))
+                    );
+
+                    badValues.forEach((value) =>
+                        test(`Bad data ${value}`, () =>
+                            testInvalid({
+                                devices: [
+                                    {
+                                        type: "scene",
+                                        name: "Scene",
+                                        devices: ["Device1"],
+                                        state: { [state]: value },
+                                    },
+                                ],
+                            }))
+                    );
+                })
+            );
+        });
+    });
+
     describe("Variable", () => {
         commonDeviceTests({
             devices: [{ type: "variable", name: "Variable" }],

--- a/services/config-server/test/services/validator/devices/commonDeviceTests.ts
+++ b/services/config-server/test/services/validator/devices/commonDeviceTests.ts
@@ -1,9 +1,9 @@
 import { ConfigFileType, IDeviceConfigFile } from "@powerpi/common";
 import ValidatorService from "../../../../src/services/ValidatorService";
 import {
-    setupValidator,
     testInvalid as _testInvalid,
     testValid as _testValid,
+    setupValidator,
 } from "../setupValidator";
 
 export default function commonDeviceTests(validFile: object) {


### PR DESCRIPTION
Resolves #360 for `config-server`:
- Add `SceneDevice` config to `config-server`.
- Update `schedules` config to use new `hue` and `saturation` schema.