### PR TITLE
#360 Add SceneDevice

### DIFF
--- a/common/python/powerpi_common/device/__init__.py
+++ b/common/python/powerpi_common/device/__init__.py
@@ -3,5 +3,6 @@ from .container import DeviceContainer
 from .device import Device
 from .factory import DeviceFactory
 from .manager import DeviceManager, DeviceNotFoundException
+from .scene_state import ReservedScenes
 from .status import DeviceStatusChecker
 from .types import DeviceConfigType, DeviceStatus

--- a/common/python/powerpi_common/device/additional_state.py
+++ b/common/python/powerpi_common/device/additional_state.py
@@ -115,9 +115,17 @@ class AdditionalStateDevice(Device, AdditionalStateMixin):
         Switch this device from the current scene to this new one, and apply any state changes.
         '''
         if not self._is_current_scene(new_scene):
+            old_scene_additional_state = {**self.__additional_state.state}
+
             self.__additional_state.scene = new_scene
 
-            new_additional_state = self.__additional_state.state
+            # join the old scene's state with the updated keys from the new, to ensure states
+            # that don't change with the scene are not changed
+            new_additional_state = {
+                **old_scene_additional_state,
+                **self.__additional_state.state
+            }
+
             await self.change_power_and_additional_state(
                 scene=new_scene,
                 new_additional_state=new_additional_state

--- a/common/python/powerpi_common/device/additional_state.py
+++ b/common/python/powerpi_common/device/additional_state.py
@@ -89,10 +89,11 @@ class AdditionalStateDevice(Device, AdditionalStateMixin):
         Update the state of this device to new_state, update the additional state
         to new_additional_state and broadcast the changes to the message queue.
         '''
-        new_additional_state = self._filter_keys(new_additional_state)
+        if new_additional_state is not None:
+            new_additional_state = self._filter_keys(new_additional_state)
 
-        if len(new_additional_state) > 0:
-            self.__additional_state.state = new_additional_state
+            if len(new_additional_state) > 0:
+                self.__additional_state.state = new_additional_state
 
         if new_state is not None:
             self.update_state_no_broadcast(new_state)
@@ -137,7 +138,11 @@ class AdditionalStateDevice(Device, AdditionalStateMixin):
         ))
         if len(scenes) >= 1:
             result['scenes'] = {
-                scene: self.__additional_state.format_scene_state(scene)
+                scene: {
+                    key: value
+                    for key, value in self.__additional_state.format_scene_state(scene).items()
+                    if key not in 'scene'
+                }
                 for scene in scenes
             }
 

--- a/common/python/powerpi_common/device/additional_state.py
+++ b/common/python/powerpi_common/device/additional_state.py
@@ -114,7 +114,7 @@ class AdditionalStateDevice(Device, AdditionalStateMixin):
         '''
         Switch this device from the current scene to this new one, and apply any state changes.
         '''
-        if not self.__additional_state.is_current_scene(new_scene):
+        if not self._is_current_scene(new_scene):
             self.__additional_state.scene = new_scene
 
             new_additional_state = self.__additional_state.state

--- a/common/python/powerpi_common/device/device.py
+++ b/common/python/powerpi_common/device/device.py
@@ -60,6 +60,13 @@ class Device(BaseDevice, DeviceChangeEventConsumer):
 
         self._broadcast_state_change()
 
+    @property
+    def executing(self):
+        '''
+        Returns whether the device is currently activating the on/off methods.
+        '''
+        return self.__lock.locked()
+
     def update_state_no_broadcast(self, new_state: DeviceStatus):
         '''
         Update this devices' state but do not broadcast to the message queue.

--- a/common/python/powerpi_common/device/mixin/__init__.py
+++ b/common/python/powerpi_common/device/mixin/__init__.py
@@ -2,4 +2,4 @@ from .additional_state import AdditionalState, AdditionalStateMixin
 from .capability import Capability, CapabilityMixin
 from .initialisable import InitialisableMixin
 from .orchestrator import DeviceOrchestratorMixin
-from .pollable import PollableMixin
+from .pollable import NewPollableMixin, PollableMixin

--- a/common/python/powerpi_common/device/mixin/additional_state.py
+++ b/common/python/powerpi_common/device/mixin/additional_state.py
@@ -28,11 +28,19 @@ class AdditionalStateMixin(ABC):
         try:
             # update additional state first
             if new_additional_state is not None and len(new_additional_state) > 0:
+                new_additional_state = self._filter_keys(new_additional_state)
+
                 if self._is_current_scene(scene):
                     new_additional_state = await self.on_additional_state_change(
                         new_additional_state
                     )
                 else:
+                    # capture any current additional state not included by the scene
+                    new_additional_state = {
+                        **self.additional_state,
+                        **new_additional_state
+                    }
+
                     # update just the additional state for that scene
                     self.set_scene_additional_state(
                         scene, new_additional_state
@@ -44,8 +52,6 @@ class AdditionalStateMixin(ABC):
 
                 func = self._turn_on if new_state == DeviceStatus.ON else self._turn_off
                 await func()
-
-            new_additional_state = self._filter_keys(new_additional_state)
 
             # hide the additional state change if it's for another scene
             update_additional_state = new_additional_state if self._is_current_scene(scene) \

--- a/common/python/powerpi_common/device/mixin/additional_state.py
+++ b/common/python/powerpi_common/device/mixin/additional_state.py
@@ -58,7 +58,7 @@ class AdditionalStateMixin(ABC):
 
     @property
     @abstractmethod
-    def scene(self):
+    def scene(self) -> str:
         '''
         Returns the current scene of this device.
         '''
@@ -105,6 +105,13 @@ class AdditionalStateMixin(ABC):
     ):
         '''
         Update the additional state for the specified scene.
+        '''
+        raise NotImplementedError
+
+    @abstractmethod
+    async def change_scene(self, new_scene: str):
+        '''
+        Switch this device from the current scene to this new one, and apply any state changes.
         '''
         raise NotImplementedError
 

--- a/common/python/powerpi_common/variable/device.py
+++ b/common/python/powerpi_common/variable/device.py
@@ -2,38 +2,16 @@ from typing import List, Optional
 
 from powerpi_common.config import Config
 from powerpi_common.device import DeviceStatus
-from powerpi_common.device.consumers import (DeviceStatusEventConsumer,
-                                             SceneEventConsumer)
+from powerpi_common.device.consumers import DeviceStatusEventConsumer
 from powerpi_common.device.mixin import AdditionalState, AdditionalStateMixin
 from powerpi_common.device.scene_state import SceneState
 from powerpi_common.logger import Logger
-from powerpi_common.mqtt import MQTTClient, MQTTMessage
+from powerpi_common.mqtt import MQTTClient
 from powerpi_common.variable.types import VariableType
 from powerpi_common.variable.variable import Variable
 
 
 class DeviceVariable(Variable, DeviceStatusEventConsumer, AdditionalStateMixin):
-
-    class ReferencedSceneEventConsumer(SceneEventConsumer):
-        def __init__(
-            self,
-            device: AdditionalStateMixin,
-            variable: 'DeviceVariable',
-            config: Config,
-            logger: Logger
-        ):
-            SceneEventConsumer.__init__(
-                self, device, config, logger
-            )
-
-            self.__device = device
-            self.__variable = variable
-
-        async def on_message(self, message: MQTTMessage, entity: str, __: str):
-            if entity == self.__device.name:
-                scene = message.pop('scene', None)
-
-                self.__variable.on_referenced_device_scene(scene)
 
     def __init__(
         self,
@@ -49,9 +27,6 @@ class DeviceVariable(Variable, DeviceStatusEventConsumer, AdditionalStateMixin):
         self.__additional_state = SceneState()
 
         mqtt_client.add_consumer(self)
-        mqtt_client.add_consumer(self.ReferencedSceneEventConsumer(
-            self, self, config, logger
-        ))
 
     @property
     def variable_type(self):
@@ -105,12 +80,6 @@ class DeviceVariable(Variable, DeviceStatusEventConsumer, AdditionalStateMixin):
         new_additional_state: AdditionalState
     ):
         self.__additional_state.update_scene_state(scene, new_additional_state)
-
-    def on_referenced_device_scene(self, scene: str):
-        '''
-        Capture when the current scene changes.
-        '''
-        self.scene = scene
 
     @property
     def json(self):

--- a/common/python/powerpi_common/variable/device.py
+++ b/common/python/powerpi_common/variable/device.py
@@ -66,6 +66,10 @@ class DeviceVariable(Variable, DeviceStatusEventConsumer, AdditionalStateMixin):
         self.__state = new_state
         self.__additional_state.state = new_additional_state
 
+    async def change_scene(self, _: str):
+        # ignore as we'll wait for a status message
+        pass
+
     def set_state_and_additional(
         self,
         new_state: DeviceStatus,

--- a/common/python/tests/device/test_additional_state.py
+++ b/common/python/tests/device/test_additional_state.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 import pytest
 from powerpi_common_test.device import AdditionalStateDeviceTestBase
 
-from powerpi_common.device import AdditionalStateDevice
+from powerpi_common.device import AdditionalStateDevice, ReservedScenes
 
 
 # pylint: disable=too-many-ancestors
@@ -28,6 +28,39 @@ class DeviceImpl(AdditionalStateDevice):
 
 
 class TestAdditionalStateDevice(AdditionalStateDeviceTestBase):
+
+    @pytest.mark.asyncio
+    async def test_change_power_and_additional_state_merges(
+        self,
+        subject: AdditionalStateDevice
+    ):
+        assert subject.additional_state == {}
+
+        await subject.change_power_and_additional_state(
+            ReservedScenes.DEFAULT,
+            new_additional_state={'a': 1, 'c': 3, 'd': 4}
+        )
+
+        assert subject.additional_state == {'a': 1, 'c': 3}
+
+        # now set the state of another scene
+        await subject.change_power_and_additional_state(
+            'other',
+            new_additional_state={'b': 2, 'c': 4, 'd': 5}
+        )
+
+        assert subject.additional_state == {'a': 1, 'c': 3}
+
+        # switching scene will apply the merged state,
+        # but keeping a as the scene had not value for it
+        await subject.change_scene('other')
+
+        assert subject.additional_state == {'a': 1, 'b': 2, 'c': 4}
+
+        # switching back will restore, but keep b as the scene had no value for it
+        await subject.change_scene(ReservedScenes.DEFAULT)
+
+        assert subject.additional_state == {'a': 1, 'b': 2, 'c': 3}
 
     @pytest.fixture
     def subject(self, powerpi_config, powerpi_logger, powerpi_mqtt_client):

--- a/controllers/virtual/README.md
+++ b/controllers/virtual/README.md
@@ -13,6 +13,8 @@ This controller provides the following virtual devices:
 -   **Delay** - Wait for the specified interval for turn on or turn off. Used if a device takes a few seconds to start-up, and we don't want the next step to happen before it's ready.
 -   **Log** - A device used for testing, will simply output the specified log message when turned on or off.
 -   **Mutex** - A device that will ensure all the devices in the off device specification are off before attempting to turn the devices in the on device specification, akin to a mutually exclusive lock, the on devices cannot be on if the off devices are on.
+-   **Scene** - A device that will send additional state (brightness, colour temperature, hue or saturation) to another device when switched on. The other device will remember its previous state which it will revert to when the scene is turned off.
+-   **Variable** - A device that provides an on/off switch, which can be used in conditions for events, and the `Condition` device. An example would be to only switch a light on, if the variable is true, allowing automations to be disabled.
 
 ## Building
 

--- a/controllers/virtual/tests/conftest.py
+++ b/controllers/virtual/tests/conftest.py
@@ -1,6 +1,7 @@
 # pylint: disable=unused-import
 
 import pytest
-from powerpi_common_test.fixture import (powerpi_config, powerpi_logger,
-                                         powerpi_mqtt_client,
+from powerpi_common_test.fixture import (powerpi_config,
+                                         powerpi_device_manager,
+                                         powerpi_logger, powerpi_mqtt_client,
                                          powerpi_mqtt_producer)

--- a/controllers/virtual/tests/device/test_composite.py
+++ b/controllers/virtual/tests/device/test_composite.py
@@ -10,6 +10,8 @@ from pytest_mock import MockerFixture
 
 from virtual_controller.device import CompositeDevice
 
+DeviceList = Dict[str, MagicMock]
+
 
 class TestCompositeDevice(
     AdditionalStateDeviceTestBase,
@@ -21,7 +23,7 @@ class TestCompositeDevice(
     async def test_all_on(
         self,
         subject: CompositeDevice,
-        devices: Dict[str, MagicMock]
+        devices: DeviceList
     ):
         # store the order they were called
         order = []
@@ -43,7 +45,7 @@ class TestCompositeDevice(
     async def test_all_off(
         self,
         subject: CompositeDevice,
-        devices: Dict[str, MagicMock]
+        devices: DeviceList
     ):
         # store the order they were called
         order = []
@@ -69,7 +71,7 @@ class TestCompositeDevice(
     async def test_all_change_power_and_additional_state(
         self,
         subject: CompositeDevice,
-        devices: Dict[str, MagicMock],
+        devices: DeviceList,
         new_state: str,
         expected_order: List[str]
     ):
@@ -101,7 +103,7 @@ class TestCompositeDevice(
     async def test_all_change_power_and_additional_state_scene(
         self,
         subject: CompositeDevice,
-        devices: Dict[str, MagicMock]
+        devices: DeviceList
     ):
         with patch('virtual_controller.device.composite.ismixin') as ismixin:
             ismixin.return_value = True
@@ -122,7 +124,7 @@ class TestCompositeDevice(
     async def test_all_change_power_and_additional_state_unsupported(
         self,
         subject: CompositeDevice,
-        devices: Dict[str, MagicMock]
+        devices: DeviceList
     ):
         new_state = 'on'
         new_additional_state = {'something': 'else'}
@@ -137,6 +139,20 @@ class TestCompositeDevice(
 
         for device in devices.values():
             device.turn_on.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_all_change_scene(
+        self,
+        subject: CompositeDevice,
+        devices: DeviceList
+    ):
+        with patch('virtual_controller.device.composite.ismixin') as ismixin:
+            ismixin.return_value = True
+
+            await subject.change_scene('other')
+
+        for device in devices.values():
+            device.change_scene.assert_called_once_with('other')
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize('initial_state,update_state,expected_states', [
@@ -212,7 +228,7 @@ class TestCompositeDevice(
 
         future = Future()
         future.set_result(True)
-        for method in ['turn_on', 'turn_off', 'change_power_and_additional_state']:
+        for method in ['turn_on', 'turn_off', 'change_power_and_additional_state', 'change_scene']:
             for device in devices.values():
                 mocker.patch.object(
                     device,

--- a/controllers/virtual/tests/device/test_composite.py
+++ b/controllers/virtual/tests/device/test_composite.py
@@ -223,9 +223,7 @@ class TestCompositeDevice(
         return devices
 
     @pytest.fixture
-    def device_manager(self, devices: Dict[str, MagicMock], mocker: MockerFixture):
-        manager = mocker.MagicMock()
+    def device_manager(self, devices: Dict[str, MagicMock], powerpi_device_manager):
+        powerpi_device_manager.get_device = lambda name: devices[name]
 
-        manager.get_device = lambda name: devices[name]
-
-        return manager
+        return powerpi_device_manager

--- a/controllers/virtual/tests/device/test_scene.py
+++ b/controllers/virtual/tests/device/test_scene.py
@@ -1,0 +1,145 @@
+from asyncio import Future
+from typing import Dict, List
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+from powerpi_common.device import DeviceStatus
+from powerpi_common.device.scene_state import ReservedScenes
+from powerpi_common_test.device import DeviceTestBase
+from powerpi_common_test.device.mixin import (DeviceOrchestratorMixinTestBase,
+                                              PollableMixinTestBase)
+from pytest_mock import MockerFixture
+
+from virtual_controller.device.scene import SceneDevice
+
+DeviceList = Dict[str, MagicMock]
+
+
+class TestSceneDevice(
+    DeviceTestBase,
+    DeviceOrchestratorMixinTestBase,
+    PollableMixinTestBase
+):
+
+    @pytest.mark.asyncio
+    async def test_turn_on_all_change_scene(self, subject: SceneDevice, devices: DeviceList):
+        assert subject.state == DeviceStatus.UNKNOWN
+
+        with patch('virtual_controller.device.scene.ismixin') as ismixin:
+            ismixin.return_value = True
+
+            await subject.turn_on()
+
+        assert subject.state == DeviceStatus.ON
+
+        for device in devices.values():
+            device.change_power_and_additional_state.assert_called_once_with(
+                scene='movie',
+                new_additional_state={'brightness': 10, 'temperature': 4000}
+            )
+
+            device.change_scene.assert_called_once_with('movie')
+
+    @pytest.mark.asyncio
+    async def test_turn_off_all_change_scene(self, subject: SceneDevice, devices: DeviceList):
+        assert subject.state == DeviceStatus.UNKNOWN
+
+        with patch('virtual_controller.device.scene.ismixin') as ismixin:
+            ismixin.return_value = True
+
+            await subject.turn_off()
+
+        assert subject.state == DeviceStatus.OFF
+
+        for device in devices.values():
+            device.change_power_and_additional_state.assert_not_called()
+
+            device.change_scene.assert_called_once_with(ReservedScenes.DEFAULT)
+
+    @pytest.mark.asyncio
+    async def test_turn_on_unsupported_device(self, subject: SceneDevice, devices: DeviceList):
+        assert subject.state == DeviceStatus.UNKNOWN
+
+        with patch('virtual_controller.device.scene.ismixin') as ismixin:
+            ismixin.return_value = False
+
+            await subject.turn_on()
+
+        assert subject.state == DeviceStatus.ON
+
+        for device in devices.values():
+            device.change_power_and_additional_state.assert_not_called()
+
+            device.change_scene.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('initial_scene,update_scene,expected_states', [
+        ('default', 'default', ['off', 'off']),
+        ('default', 'movie', ['off', 'on']),
+        ('default', 'other', ['off', 'off']),
+        ('movie', 'movie', ['on', 'on']),
+        ('movie', 'default', ['off', 'off'])
+    ])
+    async def test_on_referenced_device_status(
+        self,
+        subject: SceneDevice,
+        devices: DeviceList,
+        initial_scene: str,
+        update_scene: str,
+        expected_states: List[str]
+    ):
+        # pylint: disable=too-many-arguments
+        assert subject.state == DeviceStatus.UNKNOWN
+
+        with patch('virtual_controller.device.scene.ismixin') as ismixin:
+            ismixin.return_value = True
+
+            # initialise the devices
+            for device in devices.values():
+                type(device).scene = PropertyMock(return_value=initial_scene)
+
+            for device, expected in zip(devices.values(), expected_states):
+                type(device).scene = PropertyMock(return_value=update_scene)
+                await subject.on_referenced_device_status(device.name, 'on')
+
+                assert subject.state == expected
+
+    @pytest.fixture
+    def subject(
+        self,
+        powerpi_config,
+        powerpi_logger,
+        powerpi_mqtt_client,
+        device_manager
+    ):
+        return SceneDevice(
+            powerpi_config,
+            powerpi_logger,
+            powerpi_mqtt_client,
+            device_manager,
+            name='Scene',
+            poll_frequency=60,
+            devices=['device0', 'device1'],
+            scene='movie',
+            state={'brightness': 10, 'temperature': 4000}
+        )
+
+    @pytest.fixture
+    def devices(self, mocker: MockerFixture):
+        devices = {f'device{i}': mocker.MagicMock() for i in range(0, 2)}
+
+        future = Future()
+        future.set_result(True)
+        for method in ['change_power_and_additional_state', 'change_scene']:
+            for device in devices.values():
+                mocker.patch.object(
+                    device, method, return_value=future
+                )
+
+        return devices
+
+    @pytest.fixture
+    def device_manager(self, devices: DeviceList, powerpi_device_manager):
+        powerpi_device_manager.get_device = lambda name: devices[name]
+
+        return powerpi_device_manager

--- a/controllers/virtual/virtual_controller/device/composite.py
+++ b/controllers/virtual/virtual_controller/device/composite.py
@@ -59,6 +59,13 @@ class CompositeDevice(AdditionalStateDevice, DeviceOrchestratorMixin, NewPollabl
 
             self.set_state_and_additional(new_state, new_additional_state)
 
+    async def change_scene(self, new_scene: str):
+        for device in self.devices:
+            if ismixin(device, AdditionalStateMixin):
+                await device.change_scene(new_scene)
+
+        await AdditionalStateDevice.change_scene(self, new_scene)
+
     async def on_additional_state_change(self, new_additional_state: AdditionalState):
         # we are doing everything in change_power_and_additional_state
         return new_additional_state
@@ -69,15 +76,17 @@ class CompositeDevice(AdditionalStateDevice, DeviceOrchestratorMixin, NewPollabl
 
     def _additional_state_keys(self) -> List[str]:
         # we don't know what the actual implementation supports, so we're not setting keys
-        # but the test expect at least one
+        # but the tests expect at least one
         return ['a']
 
     async def _poll(self):
+        devices = self.devices
+
         # are any unknown
-        if any((device.state == DeviceStatus.UNKNOWN for device in self.devices)):
+        if any((device.state == DeviceStatus.UNKNOWN for device in devices)):
             await self.set_new_state(DeviceStatus.UNKNOWN)
         # are all devices on
-        elif all((device.state == DeviceStatus.ON for device in self.devices)):
+        elif all((device.state == DeviceStatus.ON for device in devices)):
             await self.set_new_state(DeviceStatus.ON)
         else:
             await self.set_new_state(DeviceStatus.OFF)

--- a/controllers/virtual/virtual_controller/device/composite.py
+++ b/controllers/virtual/virtual_controller/device/composite.py
@@ -5,14 +5,14 @@ from powerpi_common.device import (AdditionalStateDevice, DeviceManager,
                                    DeviceStatus)
 from powerpi_common.device.mixin import (AdditionalState, AdditionalStateMixin,
                                          DeviceOrchestratorMixin,
-                                         PollableMixin)
+                                         NewPollableMixin)
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
 from powerpi_common.util import ismixin
 
 
 # pylint: disable=too-many-ancestors
-class CompositeDevice(AdditionalStateDevice, DeviceOrchestratorMixin, PollableMixin):
+class CompositeDevice(AdditionalStateDevice, DeviceOrchestratorMixin, NewPollableMixin):
     # pylint: disable=too-many-arguments
     def __init__(
         self,
@@ -29,7 +29,7 @@ class CompositeDevice(AdditionalStateDevice, DeviceOrchestratorMixin, PollableMi
         DeviceOrchestratorMixin.__init__(
             self, config, logger, mqtt_client, device_manager, devices
         )
-        PollableMixin.__init__(self, config, **kwargs)
+        NewPollableMixin.__init__(self, config, **kwargs)
 
     async def on_referenced_device_status(self, _: str, __: DeviceStatus):
         await self.poll()
@@ -72,10 +72,7 @@ class CompositeDevice(AdditionalStateDevice, DeviceOrchestratorMixin, PollableMi
         # but the test expect at least one
         return ['a']
 
-    async def poll(self):
-        if self.executing:
-            return
-
+    async def _poll(self):
         # are any unknown
         if any((device.state == DeviceStatus.UNKNOWN for device in self.devices)):
             await self.set_new_state(DeviceStatus.UNKNOWN)

--- a/controllers/virtual/virtual_controller/device/composite.py
+++ b/controllers/virtual/virtual_controller/device/composite.py
@@ -73,6 +73,9 @@ class CompositeDevice(AdditionalStateDevice, DeviceOrchestratorMixin, PollableMi
         return ['a']
 
     async def poll(self):
+        if self.executing:
+            return
+
         # are any unknown
         if any((device.state == DeviceStatus.UNKNOWN for device in self.devices)):
             await self.set_new_state(DeviceStatus.UNKNOWN)

--- a/controllers/virtual/virtual_controller/device/container.py
+++ b/controllers/virtual/virtual_controller/device/container.py
@@ -7,6 +7,7 @@ from virtual_controller.device.factory import RemoteDeviceFactory
 from virtual_controller.device.log import LogDevice
 from virtual_controller.device.mutex import MutexDevice
 from virtual_controller.device.remote import RemoteDevice
+from virtual_controller.device.scene import SceneDevice
 from virtual_controller.device.variable import VariableDevice
 
 
@@ -97,6 +98,18 @@ def add_devices(container):
             config=container.common.config,
             logger=container.common.logger,
             mqtt_client=container.common.mqtt_client
+        )
+    )
+
+    setattr(
+        device_container,
+        'scene_device',
+        providers.Factory(
+            SceneDevice,
+            config=container.common.config,
+            logger=container.common.logger,
+            mqtt_client=container.common.mqtt_client,
+            device_manager=container.common.device.device_manager
         )
     )
 

--- a/controllers/virtual/virtual_controller/device/remote.py
+++ b/controllers/virtual/virtual_controller/device/remote.py
@@ -89,13 +89,17 @@ class RemoteDevice(DeviceVariable):
     async def turn_off(self):
         await self.__send_message(state=DeviceStatus.OFF)
 
+    async def change_scene(self, scene: str):
+        await self.__send_message(scene=scene, action='scene')
+
     async def __send_message(
         self,
         scene: Optional[str] = None,
         state: Optional[DeviceStatus] = None,
-        additional_state: Optional[AdditionalState] = None
+        additional_state: Optional[AdditionalState] = None,
+        action: Optional[str] = 'change'
     ):
-        topic = f'device/{self.name}/change'
+        topic = f'device/{self.name}/{action}'
         message = {}
 
         if additional_state is not None:

--- a/controllers/virtual/virtual_controller/device/remote.py
+++ b/controllers/virtual/virtual_controller/device/remote.py
@@ -36,6 +36,11 @@ class RemoteDevice(DeviceVariable):
         DeviceVariable.state.fset(self, new_state)
         self.__waiting.set()
 
+    @DeviceVariable.scene.setter
+    def scene(self, new_scene: str):
+        DeviceVariable.scene.fset(self, new_scene)
+        self.__waiting.set()
+
     @DeviceVariable.additional_state.setter
     def additional_state(self, new_additional_state: AdditionalState):
         DeviceVariable.additional_state.fset(self, new_additional_state)

--- a/controllers/virtual/virtual_controller/device/remote.py
+++ b/controllers/virtual/virtual_controller/device/remote.py
@@ -89,8 +89,8 @@ class RemoteDevice(DeviceVariable):
     async def turn_off(self):
         await self.__send_message(state=DeviceStatus.OFF)
 
-    async def change_scene(self, scene: str):
-        await self.__send_message(scene=scene, action='scene')
+    async def change_scene(self, new_scene: str):
+        await self.__send_message(scene=new_scene, action='scene')
 
     async def __send_message(
         self,

--- a/controllers/virtual/virtual_controller/device/scene.py
+++ b/controllers/virtual/virtual_controller/device/scene.py
@@ -4,14 +4,14 @@ from powerpi_common.config import Config
 from powerpi_common.device import Device, DeviceManager, DeviceStatus
 from powerpi_common.device.mixin import (AdditionalState, AdditionalStateMixin,
                                          DeviceOrchestratorMixin,
-                                         PollableMixin)
+                                         NewPollableMixin)
 from powerpi_common.device.scene_state import ReservedScenes
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
 from powerpi_common.util import ismixin
 
 
-class SceneDevice(Device, DeviceOrchestratorMixin, PollableMixin):
+class SceneDevice(Device, DeviceOrchestratorMixin, NewPollableMixin):
     # pylint: disable=too-many-ancestors
     '''
     A device for applying a scene, and additional state to the supplied device.
@@ -37,7 +37,7 @@ class SceneDevice(Device, DeviceOrchestratorMixin, PollableMixin):
             self, config, logger, mqtt_client, device_manager, devices,
             capability=False
         )
-        PollableMixin.__init__(self, config, **kwargs)
+        NewPollableMixin.__init__(self, config, **kwargs)
 
         self.__state = state
         self.__scene = scene
@@ -52,10 +52,7 @@ class SceneDevice(Device, DeviceOrchestratorMixin, PollableMixin):
     async def on_referenced_device_status(self, _, __):
         await self.poll()
 
-    async def poll(self):
-        if self.executing:
-            return
-
+    async def _poll(self):
         if all(device.scene == self.scene for device in self.devices):
             await self.set_new_state(DeviceStatus.ON)
         else:

--- a/controllers/virtual/virtual_controller/device/scene.py
+++ b/controllers/virtual/virtual_controller/device/scene.py
@@ -1,16 +1,17 @@
 from typing import Awaitable, Callable, List, Optional
 
 from powerpi_common.config import Config
-from powerpi_common.device import Device, DeviceManager
+from powerpi_common.device import Device, DeviceManager, DeviceStatus
 from powerpi_common.device.mixin import (AdditionalState, AdditionalStateMixin,
-                                         DeviceOrchestratorMixin)
+                                         DeviceOrchestratorMixin,
+                                         PollableMixin)
 from powerpi_common.device.scene_state import ReservedScenes
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
 from powerpi_common.util import ismixin
 
 
-class SceneDevice(Device, DeviceOrchestratorMixin):
+class SceneDevice(Device, DeviceOrchestratorMixin, PollableMixin):
     # pylint: disable=too-many-ancestors
     '''
     A device for applying a scene, and additional state to the supplied device.
@@ -36,6 +37,7 @@ class SceneDevice(Device, DeviceOrchestratorMixin):
             self, config, logger, mqtt_client, device_manager, devices,
             capability=False
         )
+        PollableMixin.__init__(self, config, **kwargs)
 
         self.__state = state
         self.__scene = scene
@@ -50,6 +52,12 @@ class SceneDevice(Device, DeviceOrchestratorMixin):
     async def on_referenced_device_status(self, _, __):
         # we don't care if the device is on or off
         pass
+
+    async def poll(self):
+        if all(device.scene == self.scene for device in self.devices):
+            await self.set_new_state(DeviceStatus.ON)
+        else:
+            await self.set_new_state(DeviceStatus.OFF)
 
     async def _turn_on(self):
         await self.__apply(self.__start_scene)

--- a/controllers/virtual/virtual_controller/device/scene.py
+++ b/controllers/virtual/virtual_controller/device/scene.py
@@ -1,0 +1,79 @@
+from typing import Awaitable, Callable, List, Optional
+
+from powerpi_common.config import Config
+from powerpi_common.device import Device, DeviceManager, DeviceStatus
+from powerpi_common.device.mixin import (AdditionalState, AdditionalStateMixin,
+                                         DeviceOrchestratorMixin)
+from powerpi_common.device.scene_state import ReservedScenes
+from powerpi_common.logger import Logger
+from powerpi_common.mqtt import MQTTClient
+from powerpi_common.util import ismixin
+
+
+class SceneDevice(Device, DeviceOrchestratorMixin):
+    # pylint: disable=too-many-ancestors
+    '''
+    A device for applying a scene, and additional state to the supplied device.
+    '''
+
+    def __init__(
+        self,
+        config: Config,
+        logger: Logger,
+        mqtt_client: MQTTClient,
+        device_manager: DeviceManager,
+        devices: List[str],
+        state: AdditionalState,
+        scene: Optional[str] = None,
+        **kwargs
+    ):
+        # pylint: disable=too-many-arguments
+
+        Device.__init__(
+            self, config, logger, mqtt_client, **kwargs
+        )
+        DeviceOrchestratorMixin.__init__(
+            self, config, logger, mqtt_client, device_manager, devices
+        )
+
+        self.__state = state
+        self.__scene = scene
+
+    @property
+    def scene(self):
+        '''
+        Return the name of the scene this device controls.
+        '''
+        return self.__scene if self.__scene is not None else self._name
+
+    async def on_referenced_device_status(self, _: str, __: DeviceStatus):
+        # we don't care if the device is on or off
+        pass
+
+    async def _turn_on(self):
+        await self.__apply(self.__start_scene)
+
+    async def _turn_off(self):
+        await self.__apply(self.__revert_scene)
+
+    async def __apply(self, func: Callable[[AdditionalStateMixin], Awaitable]):
+        for device in self.devices:
+            if ismixin(device, AdditionalStateMixin):
+                await func(device)
+
+    async def __start_scene(self, device: AdditionalStateMixin):
+        '''
+        Change the supplied device state for the scene and switch to that scene.
+        '''
+        await device.change_power_and_additional_state(
+            scene=self.scene,
+            new_additional_state=self.__state
+        )
+
+        await device.change_scene(self.scene)
+
+    async def __revert_scene(self, device: AdditionalStateMixin):
+        '''
+        Revert the supplied device back to the default scene.
+        '''
+        await device.change_scene(ReservedScenes.DEFAULT)

--- a/controllers/virtual/virtual_controller/device/scene.py
+++ b/controllers/virtual/virtual_controller/device/scene.py
@@ -50,8 +50,7 @@ class SceneDevice(Device, DeviceOrchestratorMixin, PollableMixin):
         return self.__scene if self.__scene is not None else self._name
 
     async def on_referenced_device_status(self, _, __):
-        # we don't care if the device is on or off
-        pass
+        await self.poll()
 
     async def poll(self):
         if all(device.scene == self.scene for device in self.devices):

--- a/controllers/virtual/virtual_controller/device/scene.py
+++ b/controllers/virtual/virtual_controller/device/scene.py
@@ -14,7 +14,7 @@ from powerpi_common.util import ismixin
 class SceneDevice(Device, DeviceOrchestratorMixin, NewPollableMixin):
     # pylint: disable=too-many-ancestors
     '''
-    A device for applying a scene, and additional state to the supplied device.
+    A device for applying a scene, and additional state to the supplied device(s).
     '''
 
     def __init__(
@@ -71,7 +71,7 @@ class SceneDevice(Device, DeviceOrchestratorMixin, NewPollableMixin):
 
     async def __start_scene(self, device: AdditionalStateMixin):
         '''
-        Change the supplied device state for the scene and switch to that scene.
+        Change the supplied device(s) additional state for the scene and switch to that scene.
         '''
         await device.change_power_and_additional_state(
             scene=self.scene,
@@ -82,6 +82,6 @@ class SceneDevice(Device, DeviceOrchestratorMixin, NewPollableMixin):
 
     async def __revert_scene(self, device: AdditionalStateMixin):
         '''
-        Revert the supplied device back to the default scene.
+        Revert the supplied device(s) back to the default scene.
         '''
         await device.change_scene(ReservedScenes.DEFAULT)

--- a/controllers/virtual/virtual_controller/device/scene.py
+++ b/controllers/virtual/virtual_controller/device/scene.py
@@ -43,7 +43,7 @@ class SceneDevice(Device, DeviceOrchestratorMixin, NewPollableMixin):
         self.__scene = scene
 
     @property
-    def scene(self):
+    def scene(self) -> str:
         '''
         Return the name of the scene this device controls.
         '''

--- a/controllers/virtual/virtual_controller/device/scene.py
+++ b/controllers/virtual/virtual_controller/device/scene.py
@@ -1,7 +1,7 @@
 from typing import Awaitable, Callable, List, Optional
 
 from powerpi_common.config import Config
-from powerpi_common.device import Device, DeviceManager, DeviceStatus
+from powerpi_common.device import Device, DeviceManager
 from powerpi_common.device.mixin import (AdditionalState, AdditionalStateMixin,
                                          DeviceOrchestratorMixin)
 from powerpi_common.device.scene_state import ReservedScenes

--- a/controllers/virtual/virtual_controller/device/scene.py
+++ b/controllers/virtual/virtual_controller/device/scene.py
@@ -53,6 +53,9 @@ class SceneDevice(Device, DeviceOrchestratorMixin, PollableMixin):
         await self.poll()
 
     async def poll(self):
+        if self.executing:
+            return
+
         if all(device.scene == self.scene for device in self.devices):
             await self.set_new_state(DeviceStatus.ON)
         else:

--- a/controllers/virtual/virtual_controller/device/scene.py
+++ b/controllers/virtual/virtual_controller/device/scene.py
@@ -33,7 +33,8 @@ class SceneDevice(Device, DeviceOrchestratorMixin):
             self, config, logger, mqtt_client, **kwargs
         )
         DeviceOrchestratorMixin.__init__(
-            self, config, logger, mqtt_client, device_manager, devices
+            self, config, logger, mqtt_client, device_manager, devices,
+            capability=False
         )
 
         self.__state = state
@@ -46,7 +47,7 @@ class SceneDevice(Device, DeviceOrchestratorMixin):
         '''
         return self.__scene if self.__scene is not None else self._name
 
-    async def on_referenced_device_status(self, _: str, __: DeviceStatus):
+    async def on_referenced_device_status(self, _, __):
         # we don't care if the device is on or off
         pass
 


### PR DESCRIPTION
Resolves #360:
- Add `SceneDevice` to `virtual-controller`.
- Make `change_scene` an abstract method on `AdditionalStateMixin`.
- Works towards #371 for `SceneDevice` and `CompositeDevice` as they're likely to be waiting when polling happens.
- Fix issue with other additional state resetting when switching scenes if that additional state key is not changed by the scene.
- Update documentation to include `SceneDevice`, but also `VariableDevice` as it was missing.