### PR TITLE
#375 Use current value of correct scene in scheduler

### DIFF
--- a/common/python/powerpi_common/device/additional_state.py
+++ b/common/python/powerpi_common/device/additional_state.py
@@ -84,7 +84,8 @@ class AdditionalStateDevice(Device, AdditionalStateMixin):
         '''
         Return the additional state for the specified scene.
         '''
-        return self.__additional_state.get_scene_state(scene)
+        _, additional_state = self.__additional_state.get_scene_state(scene)
+        return additional_state
 
     def set_state_and_additional(
         self,

--- a/common/python/powerpi_common/device/additional_state.py
+++ b/common/python/powerpi_common/device/additional_state.py
@@ -80,6 +80,12 @@ class AdditionalStateDevice(Device, AdditionalStateMixin):
         self.__additional_state.scene = new_scene
         self.__additional_state.state = self._filter_keys(new_additional_state)
 
+    def get_additional_state_for_scene(self, scene: Optional[str]):
+        '''
+        Return the additional state for the specified scene.
+        '''
+        return self.__additional_state.get_scene_state(scene)
+
     def set_state_and_additional(
         self,
         new_state: DeviceStatus,

--- a/common/python/powerpi_common/device/mixin/additional_state.py
+++ b/common/python/powerpi_common/device/mixin/additional_state.py
@@ -93,6 +93,13 @@ class AdditionalStateMixin(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def get_additional_state_for_scene(self, scene: Optional[str]):
+        '''
+        Return the additional state for the specified scene.
+        '''
+        raise NotImplementedError
+
+    @abstractmethod
     def set_state_and_additional(
         self,
         new_state: DeviceStatus,

--- a/common/python/powerpi_common/variable/device.py
+++ b/common/python/powerpi_common/variable/device.py
@@ -57,7 +57,8 @@ class DeviceVariable(Variable, DeviceStatusEventConsumer, AdditionalStateMixin):
         self.__additional_state.state = new_additional_state
 
     def get_additional_state_for_scene(self, scene: Optional[str]):
-        return self.__additional_state.get_scene_state(scene)
+        _, additional_state = self.__additional_state.get_scene_state(scene)
+        return additional_state
 
     def update_state_and_additional_no_broadcast(
         self,

--- a/common/python/powerpi_common/variable/device.py
+++ b/common/python/powerpi_common/variable/device.py
@@ -56,6 +56,9 @@ class DeviceVariable(Variable, DeviceStatusEventConsumer, AdditionalStateMixin):
     def additional_state(self, new_additional_state: AdditionalState):
         self.__additional_state.state = new_additional_state
 
+    def get_additional_state_for_scene(self, scene: Optional[str]):
+        return self.__additional_state.get_scene_state(scene)
+
     def update_state_and_additional_no_broadcast(
         self,
         new_scene: str,

--- a/common/python/tests/device/test_additional_state.py
+++ b/common/python/tests/device/test_additional_state.py
@@ -62,6 +62,21 @@ class TestAdditionalStateDevice(AdditionalStateDeviceTestBase):
 
         assert subject.additional_state == {'a': 1, 'b': 2, 'c': 3}
 
+    def test_get_additional_state_for_scene(self, subject: AdditionalStateDevice):
+        subject.set_scene_additional_state(
+            ReservedScenes.DEFAULT, {'brightness': 20}
+        )
+
+        subject.set_scene_additional_state(
+            'other', {'brightness': 55}
+        )
+
+        result = subject.get_additional_state_for_scene(ReservedScenes.DEFAULT)
+        assert result.get('brightness', None) == 20
+
+        result = subject.get_additional_state_for_scene('other')
+        assert result.get('brightness', None) == 55
+
     @pytest.fixture
     def subject(self, powerpi_config, powerpi_logger, powerpi_mqtt_client):
         return DeviceImpl(powerpi_config, powerpi_logger, powerpi_mqtt_client)

--- a/common/python/tests/variable/test_device.py
+++ b/common/python/tests/variable/test_device.py
@@ -25,6 +25,15 @@ class TestDeviceVariable(VariableTestBase):
         assert subject.state == DeviceStatus.ON
         assert subject.additional_state.get('brightness', None) == 33
 
+    def test_get_additional_state_for_scene(self, subject: DeviceVariable):
+        subject.additional_state = {'brightness': 20}
+
+        result = subject.get_additional_state_for_scene(ReservedScenes.DEFAULT)
+        assert result.get('brightness', None) == 20
+
+        result = subject.get_additional_state_for_scene('other')
+        assert result is None
+
     @pytest.fixture
     def subject(self, powerpi_config, powerpi_logger, powerpi_mqtt_client):
         return DeviceVariable(

--- a/services/scheduler/scheduler/services/device_schedule.py
+++ b/services/scheduler/scheduler/services/device_schedule.py
@@ -10,6 +10,7 @@ from dependency_injector import providers
 from powerpi_common.condition import (ConditionParser, Expression,
                                       ParseException)
 from powerpi_common.device import DeviceStatus
+from powerpi_common.device.mixin import AdditionalStateMixin
 from powerpi_common.logger import Logger, LogMixin
 from powerpi_common.mqtt import MQTTClient
 from powerpi_common.variable import VariableManager
@@ -266,9 +267,11 @@ class DeviceSchedule(LogMixin):
             remaining_intervals = 1
 
         # do we want to overwrite start with the current value from the device
-        device = self.__variable_manager.get_device(self.__device)
-        if delta_range.type in device.additional_state:
-            start = device.additional_state[delta_range.type]
+        device: AdditionalStateMixin = self.__variable_manager.get_device(
+            self.__device)
+        additional_state = device.get_additional_state_for_scene(self.__scene)
+        if delta_range.type in additional_state:
+            start = additional_state[delta_range.type]
         else:
             start = delta_range.start
 

--- a/services/scheduler/scheduler/services/device_schedule.py
+++ b/services/scheduler/scheduler/services/device_schedule.py
@@ -266,10 +266,12 @@ class DeviceSchedule(LogMixin):
         if remaining_intervals <= 0:
             remaining_intervals = 1
 
-        # do we want to overwrite start with the current value from the device
         device: AdditionalStateMixin = self.__variable_manager.get_device(
-            self.__device)
+            self.__device
+        )
         additional_state = device.get_additional_state_for_scene(self.__scene)
+
+        # do we want to overwrite start with the current value from the device
         if delta_range.type in additional_state:
             start = additional_state[delta_range.type]
         else:

--- a/services/scheduler/scheduler/services/device_schedule.py
+++ b/services/scheduler/scheduler/services/device_schedule.py
@@ -10,7 +10,6 @@ from dependency_injector import providers
 from powerpi_common.condition import (ConditionParser, Expression,
                                       ParseException)
 from powerpi_common.device import DeviceStatus
-from powerpi_common.device.mixin import AdditionalStateMixin
 from powerpi_common.logger import Logger, LogMixin
 from powerpi_common.mqtt import MQTTClient
 from powerpi_common.variable import VariableManager
@@ -266,7 +265,7 @@ class DeviceSchedule(LogMixin):
         if remaining_intervals <= 0:
             remaining_intervals = 1
 
-        device: AdditionalStateMixin = self.__variable_manager.get_device(
+        device = self.__variable_manager.get_device(
             self.__device
         )
         additional_state = device.get_additional_state_for_scene(self.__scene)

--- a/services/scheduler/tests/services/test_device_schedule.py
+++ b/services/scheduler/tests/services/test_device_schedule.py
@@ -202,9 +202,9 @@ class TestDeviceSchedule:
         variable = mocker.MagicMock()
         powerpi_variable_manager.get_device = lambda _: variable
 
-        type(variable).additional_state = PropertyMock(
-            return_value={'brightness': current}
-        )
+        variable.get_additional_state_for_scene = lambda _: {
+            'brightness': current
+        }
 
         with patch('scheduler.services.device_schedule.datetime') as mock_datetime:
             mock_datetime.now.return_value = datetime(
@@ -250,9 +250,9 @@ class TestDeviceSchedule:
         variable = mocker.MagicMock()
         powerpi_variable_manager.get_device = lambda _: variable
 
-        type(variable).additional_state = PropertyMock(
-            return_value={'hue': current}
-        )
+        variable.get_additional_state_for_scene = lambda _: {
+            'hue': current
+        }
 
         with patch('scheduler.services.device_schedule.datetime') as mock_datetime:
             mock_datetime.now.return_value = datetime(
@@ -355,9 +355,9 @@ class TestDeviceSchedule:
         })
 
         async def execute(minutes: float, current: float, expected: float):
-            type(variable).additional_state = PropertyMock(
-                return_value={'brightness': current}
-            )
+            variable.get_additional_state_for_scene = lambda _: {
+                'brightness': current
+            }
 
             with patch('scheduler.services.device_schedule.datetime') as mock_datetime:
                 mock_datetime.now.return_value = datetime(

--- a/services/scheduler/tests/services/test_device_schedule.py
+++ b/services/scheduler/tests/services/test_device_schedule.py
@@ -8,6 +8,7 @@ import pytest
 import pytz
 from apscheduler.triggers.interval import IntervalTrigger
 from powerpi_common.condition import ConditionParser, Expression
+from powerpi_common.device import ReservedScenes
 from pytest_mock import MockerFixture
 
 from scheduler.services import DeviceSchedule
@@ -380,6 +381,53 @@ class TestDeviceSchedule:
         powerpi_mqtt_producer.reset_mock()
 
         await execute(32, expected, next_expected)
+
+    @pytest.mark.asyncio
+    async def test_execute_current_value_scenes(
+        self,
+        subject_builder: SubjectBuilder,
+        powerpi_mqtt_producer: MagicMock,
+        powerpi_variable_manager: MagicMock,
+        mocker: MockerFixture
+    ):
+        variable = mocker.MagicMock()
+        powerpi_variable_manager.get_device = lambda _: variable
+
+        variable.get_additional_state_for_scene = lambda scene: \
+            {'brightness': 75} if scene == 'other' else {'brightness': 100}
+
+        subject = subject_builder({
+            'device': 'SomeDevice',
+            'scene': 'other',
+            'between': ['09:00:00', '09:50:00'],
+            'interval': 60,
+            'brightness': [0, 100],
+        })
+
+        async def execute(scene: str, expected: float):
+            powerpi_mqtt_producer.reset_mock()
+
+            type(variable).scene = PropertyMock(return_value=scene)
+
+            with patch('scheduler.services.device_schedule.datetime') as mock_datetime:
+                mock_datetime.now.return_value = datetime(
+                    2023, 3, 1, 9, 26
+                ).astimezone(pytz.UTC)
+
+                start_date = datetime(2023, 3, 1, 9, 0).astimezone(pytz.UTC)
+                end_date = datetime(2023, 3, 1, 9, 50).astimezone(pytz.UTC)
+
+                await subject.execute(start_date, end_date)
+
+            topic = 'device/SomeDevice/change'
+            message = {'brightness': expected, 'scene': 'other'}
+            powerpi_mqtt_producer.assert_called_once_with(topic, message)
+
+        # when we're in the wrong scene it pulls the value from correct scene anyway
+        await execute(ReservedScenes.DEFAULT, 75 + 1)
+
+        # still works when we're in the correct scene
+        await execute('other', 75 + 1)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize('set_condition,current_state,expected', [


### PR DESCRIPTION
Resolves #375:
- Add a way to request the additional state of a specific, not necessarily current scene in `AdditionalStateMixin`.
- When identifying the current additional state value of a device, use the scene specified by the config not the current scene.