### PR TITLE
Version.sh wasn't updating controller versions in main helm Chart.yaml

### DIFF
--- a/.github/scripts/version.sh
+++ b/.github/scripts/version.sh
@@ -55,12 +55,15 @@ update_version() {
 
     local appPath="$scriptPath/../../services/$service"
     local subchartPath="$scriptPath/../../kubernetes/charts/$service/Chart.yaml"
+    
+    local serviceName=$service
 
     if [ ! -d $appPath ]
     then
         echo "Service $service is a controller"
+        serviceName="$service-controller"
         appPath="$scriptPath/../../controllers/$service"
-        subchartPath="$scriptPath/../../kubernetes/charts/$service-controller/Chart.yaml"
+        subchartPath="$scriptPath/../../kubernetes/charts/$serviceName/Chart.yaml"
     fi
 
     # check the service exists
@@ -87,7 +90,7 @@ update_version() {
     subchartVersion=$newVersion
     echo "Increasing helm subchart $service to v$subchartVersion"
     set_chart_version $subchartPath $appVersion $subchartVersion
-    set_chart_dependency_version $helmPath $service $subchartVersion
+    set_chart_dependency_version $helmPath $serviceName $subchartVersion
 
     # commit the change if enabled
     if $commit

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -40,7 +40,7 @@ dependencies:
     version: 0.1.5
     condition: global.energenie
   - name: harmony-controller
-    version: 0.1.5
+    version: 0.1.7
     condition: global.harmony
   - name: lifx-controller
     version: 0.1.6


### PR DESCRIPTION
- Fix `version.sh` so it'll update the main chart version for a controller.
- Fix the incorrect version for `harmony-controller`.