### PR TITLE
#394 Don't attempt to retrieve schedules config file if disabled

### DIFF
--- a/kubernetes/charts/config-server/templates/cron-job.yaml
+++ b/kubernetes/charts/config-server/templates/cron-job.yaml
@@ -34,7 +34,7 @@
     )
     (dict
       "Name" "SCHEDULER_ENABLED"
-      "Value" .Values.global.scheduler
+      "Value" (.Values.global.scheduler | quote)
     )
   )
 -}}

--- a/kubernetes/charts/config-server/templates/cron-job.yaml
+++ b/kubernetes/charts/config-server/templates/cron-job.yaml
@@ -32,6 +32,10 @@
       "Name" "BRANCH"
       "Value" .Values.branch
     )
+    (dict
+      "Name" "SCHEDULER_ENABLED"
+      "Value" .Values.global.scheduler
+    )
   )
 -}}
 {{- include "powerpi.cron-job" (merge (dict "Params" $data) . ) -}}

--- a/services/config-server/src/services/ConfigService.ts
+++ b/services/config-server/src/services/ConfigService.ts
@@ -1,4 +1,4 @@
-import { ConfigService as CommonConfigService } from "@powerpi/common";
+import { ConfigService as CommonConfigService, ConfigFileType } from "@powerpi/common";
 import { Service } from "typedi";
 import app from "../../package.json";
 import Container from "../container";
@@ -48,6 +48,17 @@ export default class ConfigService extends CommonConfigService {
         }
 
         return 5 * 60;
+    }
+
+    get configFileTypes() {
+        return super.configFileTypes.filter(
+            (fileType) => this.schedulerEnabled || fileType !== ConfigFileType.Schedules,
+        );
+    }
+
+    get schedulerEnabled() {
+        const enabled = process.env["SCHEDULER_ENABLED"] ?? "true";
+        return enabled.toLowerCase() === "true";
     }
 }
 

--- a/services/config-server/test/services/ConfigService.test.ts
+++ b/services/config-server/test/services/ConfigService.test.ts
@@ -1,0 +1,125 @@
+import { ConfigFileType, FileService } from "@powerpi/common";
+import { instance, mock, when } from "ts-mockito";
+import ConfigService from "../../src/services/ConfigService";
+
+const mockedFileService = mock<FileService>();
+
+describe("ConfigService", () => {
+    const oldEnv = process.env;
+
+    let subject: ConfigService | undefined = undefined;
+
+    beforeEach(() => {
+        jest.resetModules();
+        process.env = { ...oldEnv };
+
+        subject = new ConfigService(instance(mockedFileService));
+    });
+
+    afterAll(() => {
+        process.env = oldEnv;
+    });
+
+    test("service", () => expect(subject?.service).toBe("@powerpi/config-server"));
+
+    test("version", () => expect(subject?.version).not.toBeNull());
+
+    test("getUsedConfig", () => expect(subject?.getUsedConfig()).toHaveLength(0));
+
+    test("configIsNeeded", () => expect(subject?.configIsNeeded).toBeFalsy());
+
+    test("gitHubUser", () => {
+        process.env.GITHUB_USER = "MsUser";
+
+        expect(subject?.gitHubUser).toBe("MsUser");
+    });
+
+    test("gitHubToken", async () => {
+        process.env.GITHUB_SECRET_FILE = "token/path";
+
+        when(mockedFileService.read("token/path")).thenResolve(Buffer.from("token content"));
+
+        const result = await subject?.gitHubToken;
+        expect(result).toBe("token content");
+    });
+
+    describe("repo", () => {
+        test("default", () => {
+            process.env.REPO = undefined;
+
+            expect(subject?.repo).toBe("powerpi-config");
+        });
+
+        test("value", () => {
+            process.env.REPO = "MyConfigRepo";
+
+            expect(subject?.repo).toBe("MyConfigRepo");
+        });
+    });
+
+    describe("branch", () => {
+        test("default", () => {
+            process.env.BRANCH = undefined;
+            expect(subject?.branch).toBe("main");
+        });
+
+        test("value", () => {
+            process.env.BRANCH = "master";
+
+            expect(subject?.branch).toBe("master");
+        });
+    });
+
+    describe("path", () => {
+        test("default", () => {
+            process.env.FILE_PATH = undefined;
+
+            expect(subject?.path).toBe("");
+        });
+
+        test("value", () => {
+            process.env.FILE_PATH = "my/config/path";
+
+            expect(subject?.path).toBe("my/config/path");
+        });
+    });
+
+    describe("pollFrequency", () => {
+        test("default", () => {
+            process.env.POLL_FREQUENCY = undefined;
+
+            expect(subject?.pollFrequency).toBe(300);
+        });
+
+        test("value", () => {
+            process.env.POLL_FREQUENCY = "1234";
+
+            expect(subject?.pollFrequency).toBe(1234);
+        });
+    });
+
+    describe("configFileType", () => {
+        test("default", () =>
+            expect(subject?.configFileTypes).toStrictEqual(Object.values(ConfigFileType)));
+
+        test("no schedule", () => {
+            process.env.SCHEDULER_ENABLED = "false";
+
+            expect(subject?.configFileTypes).not.toContain(ConfigFileType.Schedules);
+        });
+    });
+
+    describe("schedulerEnabled", () => {
+        test("default", () => {
+            process.env.SCHEDULER_ENABLED = undefined;
+
+            expect(subject?.schedulerEnabled).toBeTruthy();
+        });
+
+        test("value", () => {
+            process.env.SCHEDULER_ENABLED = "false";
+
+            expect(subject?.schedulerEnabled).toBeFalsy();
+        });
+    });
+});


### PR DESCRIPTION
Resolves #394 by filtering the schedules config file from the list of file types to retrieve in `config-server` if the `scheduler` service is not being deployed.