### PR TITLE
#381 Make device/sensor config error when they have unrecognised properties

### DIFF
--- a/services/config-server/src/schema/devices/GenericSensor.schema.json
+++ b/services/config-server/src/schema/devices/GenericSensor.schema.json
@@ -19,5 +19,6 @@
         { "properties": { "type": { "const": "motion" } } },
         { "properties": { "type": { "const": "temperature" } } }
     ],
-    "required": ["location", "entity"]
+    "required": ["location", "entity"],
+    "unevaluatedProperties": false
 }

--- a/services/config-server/src/schema/devices/PowerPiSensor.schema.json
+++ b/services/config-server/src/schema/devices/PowerPiSensor.schema.json
@@ -52,5 +52,6 @@
             },
             "additionalProperties": false
         }
-    }
+    },
+    "unevaluatedProperties": false
 }

--- a/services/config-server/src/schema/devices/energenie/EnergeniePairing.schema.json
+++ b/services/config-server/src/schema/devices/energenie/EnergeniePairing.schema.json
@@ -18,5 +18,6 @@
             "type": "number",
             "minimum": 1
         }
-    }
+    },
+    "unevaluatedProperties": false
 }

--- a/services/config-server/src/schema/devices/energenie/EnergenieSocket.schema.json
+++ b/services/config-server/src/schema/devices/energenie/EnergenieSocket.schema.json
@@ -19,5 +19,6 @@
             "minimum": 0,
             "maximum": 4
         }
-    }
+    },
+    "unevaluatedProperties": false
 }

--- a/services/config-server/src/schema/devices/energenie/EnergenieSocketGroup.schema.json
+++ b/services/config-server/src/schema/devices/energenie/EnergenieSocketGroup.schema.json
@@ -23,5 +23,6 @@
             }
         }
     },
-    "required": ["home_id", "devices"]
+    "required": ["home_id", "devices"],
+    "unevaluatedProperties": false
 }

--- a/services/config-server/src/schema/devices/harmony/HarmonyActivity.schema.json
+++ b/services/config-server/src/schema/devices/harmony/HarmonyActivity.schema.json
@@ -22,5 +22,6 @@
             "$ref": "https://raw.githubusercontent.com/TWilkin/powerpi/main/services/config-server/src/schema/common/Identifier.schema.json"
         }
     },
-    "required": ["hub"]
+    "required": ["hub"],
+    "unevaluatedProperties": false
 }

--- a/services/config-server/src/schema/devices/harmony/HarmonyHub.schema.json
+++ b/services/config-server/src/schema/devices/harmony/HarmonyHub.schema.json
@@ -27,5 +27,6 @@
             "format": "ipv4"
         }
     },
-    "oneOf": [{ "required": ["hostname"] }, { "required": ["ip"] }]
+    "oneOf": [{ "required": ["hostname"] }, { "required": ["ip"] }],
+    "unevaluatedProperties": false
 }

--- a/services/config-server/src/schema/devices/lifx/LIFXLight.schema.json
+++ b/services/config-server/src/schema/devices/lifx/LIFXLight.schema.json
@@ -37,5 +37,6 @@
         }
     },
     "required": ["mac"],
-    "oneOf": [{ "required": ["hostname"] }, { "required": ["ip"] }]
+    "oneOf": [{ "required": ["hostname"] }, { "required": ["ip"] }],
+    "unevaluatedProperties": false
 }

--- a/services/config-server/src/schema/devices/network/Computer.schema.json
+++ b/services/config-server/src/schema/devices/network/Computer.schema.json
@@ -38,5 +38,6 @@
         }
     },
     "required": ["mac"],
-    "oneOf": [{ "required": ["hostname"] }, { "required": ["ip"] }]
+    "oneOf": [{ "required": ["hostname"] }, { "required": ["ip"] }],
+    "unevaluatedProperties": false
 }

--- a/services/config-server/src/schema/devices/node/Node.schema.json
+++ b/services/config-server/src/schema/devices/node/Node.schema.json
@@ -86,5 +86,6 @@
             "additionalProperties": false
         }
     },
-    "required": ["ip"]
+    "required": ["ip"],
+    "unevaluatedProperties": false
 }

--- a/services/config-server/src/schema/devices/virtual/Composite.schema.json
+++ b/services/config-server/src/schema/devices/virtual/Composite.schema.json
@@ -25,5 +25,6 @@
             }
         }
     },
-    "required": ["devices"]
+    "required": ["devices"],
+    "unevaluatedProperties": false
 }

--- a/services/config-server/src/schema/devices/virtual/Condition.schema.json
+++ b/services/config-server/src/schema/devices/virtual/Condition.schema.json
@@ -40,5 +40,6 @@
         }
     },
     "required": ["device"],
-    "anyOf": [{ "required": ["on_condition"] }, { "required": ["off_condition"] }]
+    "anyOf": [{ "required": ["on_condition"] }, { "required": ["off_condition"] }],
+    "unevaluatedProperties": false
 }

--- a/services/config-server/src/schema/devices/virtual/Delay.schema.json
+++ b/services/config-server/src/schema/devices/virtual/Delay.schema.json
@@ -24,5 +24,6 @@
             "minimum": 0
         }
     },
-    "anyOf": [{ "required": ["start"] }, { "required": ["end"] }]
+    "anyOf": [{ "required": ["start"] }, { "required": ["end"] }],
+    "unevaluatedProperties": false
 }

--- a/services/config-server/src/schema/devices/virtual/Log.schema.json
+++ b/services/config-server/src/schema/devices/virtual/Log.schema.json
@@ -18,5 +18,6 @@
             "type": "string"
         }
     },
-    "required": ["message"]
+    "required": ["message"],
+    "unevaluatedProperties": false
 }

--- a/services/config-server/src/schema/devices/virtual/Mutex.schema.json
+++ b/services/config-server/src/schema/devices/virtual/Mutex.schema.json
@@ -33,5 +33,6 @@
             }
         }
     },
-    "required": ["on_devices", "off_devices"]
+    "required": ["on_devices", "off_devices"],
+    "unevaluatedProperties": false
 }

--- a/services/config-server/src/schema/devices/virtual/Scene.schema.json
+++ b/services/config-server/src/schema/devices/virtual/Scene.schema.json
@@ -33,5 +33,6 @@
             "$ref": "https://raw.githubusercontent.com/TWilkin/powerpi/main/services/config-server/src/schema/common/Identifier.schema.json"
         }
     },
-    "required": ["devices", "state"]
+    "required": ["devices", "state"],
+    "unevaluatedProperties": false
 }

--- a/services/config-server/src/schema/devices/virtual/Variable.schema.json
+++ b/services/config-server/src/schema/devices/virtual/Variable.schema.json
@@ -13,5 +13,6 @@
         "type": {
             "const": "variable"
         }
-    }
+    },
+    "unevaluatedProperties": false
 }

--- a/services/config-server/src/schema/devices/zigbee/AqaraDoor.schema.json
+++ b/services/config-server/src/schema/devices/zigbee/AqaraDoor.schema.json
@@ -19,5 +19,6 @@
         "type": {
             "oneOf": [{ "const": "aqara_door" }, { "const": "aqara_window" }]
         }
-    }
+    },
+    "unevaluatedProperties": false
 }

--- a/services/config-server/src/schema/devices/zigbee/OsramSwitchMini.schema.json
+++ b/services/config-server/src/schema/devices/zigbee/OsramSwitchMini.schema.json
@@ -19,5 +19,6 @@
         "type": {
             "const": "osram_switch_mini"
         }
-    }
+    },
+    "unevaluatedProperties": false
 }

--- a/services/config-server/src/schema/devices/zigbee/ZigBeeLight.schema.json
+++ b/services/config-server/src/schema/devices/zigbee/ZigBeeLight.schema.json
@@ -24,5 +24,6 @@
             "type": "integer",
             "minimum": 0
         }
-    }
+    },
+    "unevaluatedProperties": false
 }

--- a/services/config-server/src/schema/devices/zigbee/ZigBeePairing.schema.json
+++ b/services/config-server/src/schema/devices/zigbee/ZigBeePairing.schema.json
@@ -18,5 +18,6 @@
             "type": "number",
             "minimum": 1
         }
-    }
+    },
+    "unevaluatedProperties": false
 }

--- a/services/config-server/test/services/validator/DevicesConfigFile.test.ts
+++ b/services/config-server/test/services/validator/DevicesConfigFile.test.ts
@@ -22,7 +22,7 @@ describe("Devices", () => {
                 "https://raw.githubusercontent.com/TWilkin/powerpi/main/services/config-server/src/schema/config/devices.schema.json",
             devices: [
                 { type: "log", name: "Logger", message: "Test" },
-                { type: "delay", name: "Delay", start: 10, stop: 5 },
+                { type: "delay", name: "Delay", start: 10, end: 5 },
             ],
             sensors: [
                 { type: "temperature", name: "Temp", location: "Garden", entity: "Garden" },

--- a/services/config-server/test/services/validator/devices/commonDeviceTests.ts
+++ b/services/config-server/test/services/validator/devices/commonDeviceTests.ts
@@ -56,6 +56,13 @@ export default function commonDeviceTests(validFile: object) {
         });
     });
 
+    test("No extras", () => {
+        let device = getDevice(validFile);
+        device = { ...device, extraProperty: "not allowed" };
+
+        testInvalid({ sensors: [], ...validFile, devices: [device] });
+    });
+
     return {
         getDevice,
         testValid,

--- a/services/config-server/test/services/validator/devices/commonSensorTests.ts
+++ b/services/config-server/test/services/validator/devices/commonSensorTests.ts
@@ -1,9 +1,9 @@
 import { ConfigFileType, IDeviceConfigFile } from "@powerpi/common";
 import ValidatorService from "../../../../src/services/ValidatorService";
 import {
-    setupValidator,
     testInvalid as _testInvalid,
     testValid as _testValid,
+    setupValidator,
 } from "../setupValidator";
 
 export default function commonSensorTests(validFile: object) {
@@ -54,6 +54,13 @@ export default function commonSensorTests(validFile: object) {
             ...validFile,
             sensors: [{ ...sensor, categories: ["TV", "Music"] }],
         });
+    });
+
+    test("No extras", () => {
+        let sensor = getSensor(validFile);
+        sensor = { ...sensor, extraProperty: "not allowed" };
+
+        testInvalid({ devices: [], ...validFile, sensors: [sensor] });
     });
 
     return {


### PR DESCRIPTION
Resolves #381 by adding `"unevaluatedProperties": false` to each device and sensor config, so if an unexpected property is found (like a spelling mistake) the file will fail validation.