### PR TITLE
#383/#408 Fix HA issues in API

### DIFF
--- a/kubernetes/templates/ingress.yaml
+++ b/kubernetes/templates/ingress.yaml
@@ -8,6 +8,12 @@ metadata:
     cert-manager.io/issuer: letsencrypt
     {{- end }}
     kubernetes.io/ingress.class: public
+    {{- if eq .Values.global.useCluster true }}
+    nginx.ingress.kubernetes.io/affinity: "cookie"
+    nginx.ingress.kubernetes.io/session-cookie-name: "route"
+    nginx.ingress.kubernetes.io/session-cookie-expires: "172800"
+    nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
+    {{- end }}
 spec:
   {{- if eq .Values.global.useSSL true }}
   tls:

--- a/kubernetes/templates/ingress.yaml
+++ b/kubernetes/templates/ingress.yaml
@@ -7,7 +7,6 @@ metadata:
     {{- if eq .Values.global.useSSL true }}
     cert-manager.io/issuer: letsencrypt
     {{- end }}
-    kubernetes.io/ingress.class: public
     {{- if eq .Values.global.useCluster true }}
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-name: "route"
@@ -15,6 +14,7 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
     {{- end }}
 spec:
+  ingressClassName: public
   {{- if eq .Values.global.useSSL true }}
   tls:
   - hosts:

--- a/kubernetes/templates/ingress.yaml
+++ b/kubernetes/templates/ingress.yaml
@@ -7,12 +7,6 @@ metadata:
     {{- if eq .Values.global.useSSL true }}
     cert-manager.io/issuer: letsencrypt
     {{- end }}
-    {{- if eq .Values.global.useCluster true }}
-    nginx.ingress.kubernetes.io/affinity: "cookie"
-    nginx.ingress.kubernetes.io/session-cookie-name: "route"
-    nginx.ingress.kubernetes.io/session-cookie-expires: "172800"
-    nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
-    {{- end }}
 spec:
   ingressClassName: public
   {{- if eq .Values.global.useSSL true }}
@@ -48,3 +42,48 @@ spec:
             name: ui
             port:
               number: 80
+
+{{- if eq .Values.global.useCluster true }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-ha
+  {{- include "powerpi.labels" . }}
+  annotations:
+    {{- if eq .Values.global.useSSL true }}
+    cert-manager.io/issuer: letsencrypt
+    {{- end }}
+    {{- if eq .Values.global.useCluster true }}
+    nginx.ingress.kubernetes.io/affinity: "cookie"
+    nginx.ingress.kubernetes.io/session-cookie-name: "route"
+    nginx.ingress.kubernetes.io/session-cookie-expires: "172800"
+    nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
+    {{- end }}
+spec:
+  ingressClassName: public
+  {{- if eq .Values.global.useSSL true }}
+  tls:
+  - hosts:
+    - {{ .Values.global.externalHostName }}
+    secretName: letsencrypt
+  {{- end }}
+  rules:
+  - host: {{ .Values.global.externalHostName }}
+    http:
+      paths:
+      - path: /api/auth
+        pathType: Prefix
+        backend:
+          service:
+            name: api
+            port:
+              number: 80
+      - path: /api/socket.io
+        pathType: Prefix
+        backend:
+          service:
+            name: api
+            port:
+              number: 80
+{{- end }}


### PR DESCRIPTION
- Add `ingress-ha` when using a cluster that applies sticky sessions to the following endpoints:
  - Resolve #383 by using sticky sessions for `/api/socket.io`.
  - Resolve #408 by using sticky sessions for `/api/auth`.
- Fix warning in ingress by using `ingressClassName` instead of annotation.