### PR TITLE
#410 Fix device list height change in UI while state is loading

### DIFF
--- a/services/ui/src/components/Components/List/List.module.scss
+++ b/services/ui/src/components/Components/List/List.module.scss
@@ -5,5 +5,6 @@
     left: calc(#{$logo-width} + 2px);
     max-width: calc(100vw - #{$logo-width});
     margin: 0;
+    padding-bottom: 10px;
     overflow: auto;
 }


### PR DESCRIPTION
Resolves #410 by adding a padding to the bottom of the list.