### PR TITLE
#435 fix: Include repo in config-server chart

### DIFF
--- a/kubernetes/charts/config-server/Chart.yaml
+++ b/kubernetes/charts/config-server/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: config-server
 description: A Helm chart for the PowerPi configuration server
 type: application
-version: 0.1.13
+version: 0.1.14
 appVersion: 1.1.2

--- a/kubernetes/charts/config-server/templates/cron-job.yaml
+++ b/kubernetes/charts/config-server/templates/cron-job.yaml
@@ -25,6 +25,10 @@
   )
   "Env" (list
     (dict
+      "Name" "REPO"
+      "Value" .Values.repo
+    )
+    (dict
       "Name" "FILE_PATH"
       "Value" .Values.path
     )

--- a/kubernetes/values.schema.json
+++ b/kubernetes/values.schema.json
@@ -149,6 +149,10 @@
                 "branch": {
                     "description": "The branch in the GitHub repository to get the configuration files",
                     "type": "string"
+                },
+                "repo": {
+                    "description": "The GitHub repository to get the configuration files",
+                    "type": "string"
                 }
             },
             "unevaluatedProperties": false


### PR DESCRIPTION
Resolves #435 by including `repo` in config-server chart