### PR TITLE
#442 feat: Support connecting to encrypted MQTT endpoint from shutdown service

### DIFF
--- a/services/shutdown/Makefile
+++ b/services/shutdown/Makefile
@@ -7,7 +7,7 @@ TARGET_OS?=linux
 TARGET_ARCH?=arm64
 
 # the version of the shutdown service
-VERSION=0.0.5
+VERSION=0.1.0
 
 all: compile
 

--- a/services/shutdown/src/go.mod
+++ b/services/shutdown/src/go.mod
@@ -5,13 +5,7 @@ go 1.18
 require github.com/eclipse/paho.mqtt.golang v1.4.3
 
 require (
-	github.com/gorilla/websocket v1.5.0 // indirect
-	golang.org/x/net v0.17.0 // indirect
-	golang.org/x/sync v0.4.0 // indirect
+	github.com/gorilla/websocket v1.5.1 // indirect
+	golang.org/x/net v0.20.0 // indirect
+	golang.org/x/sync v0.6.0 // indirect
 )
-
-replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.5.0
-
-replace golang.org/x/net => golang.org/x/net v0.17.0
-
-replace golang.org/x/sync => golang.org/x/sync v0.4.0

--- a/services/shutdown/src/go.sum
+++ b/services/shutdown/src/go.sum
@@ -1,8 +1,8 @@
 github.com/eclipse/paho.mqtt.golang v1.4.3 h1:2kwcUGn8seMUfWndX0hGbvH8r7crgcJguQNCyp70xik=
 github.com/eclipse/paho.mqtt.golang v1.4.3/go.mod h1:CSYvoAlsMkhYOXh/oKyxa8EcBci6dVkLCbo5tTC1RIE=
-github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
-github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
-golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
-golang.org/x/sync v0.4.0 h1:zxkM55ReGkDlKSM+Fu41A+zmbZuaPVbGMzvvdUPznYQ=
-golang.org/x/sync v0.4.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
+github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
+github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
+golang.org/x/net v0.20.0 h1:aCL9BSgETF1k+blQaYUBx9hJ9LOGP3gAVemcZlf1Kpo=
+golang.org/x/net v0.20.0/go.mod h1:z8BVo6PvndSri0LbOE3hAn0apkU+1YvI6E70E9jsnvY=
+golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
+golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=

--- a/services/shutdown/src/mqtt/mqtt.go
+++ b/services/shutdown/src/mqtt/mqtt.go
@@ -34,7 +34,12 @@ func New(hostname string, topicBase string, action MqttMessageAction) MqttClient
 }
 
 func (client MqttClient) Connect(host string, port int, user *string, password *string) {
-	address := fmt.Sprintf("tcp://%s:%d", host, port)
+	protocol := "tcp"
+	if port == 8883 {
+		protocol = "tcps"
+	}
+
+	address := fmt.Sprintf("%s://%s:%d", protocol, host, port)
 	clientId := fmt.Sprintf("shutdown-%s", client.hostname)
 
 	options := MQTT.NewClientOptions()


### PR DESCRIPTION
Resolves #442 
- Update `shutdown` service dependencies.
- If using port 8883 for MQTT use the `tcps` protocol instead of `tcp` when connecting to MQTT.