### PR TITLE
#467, #475 feat: Add StorageClass options and make mosquitto restart with new secrets

### DIFF
--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
     version: 0.1.4
     condition: global.freeDNS
   - name: mosquitto
-    version: 0.3.0
+    version: 0.3.1
   - name: persistence
     version: 0.1.7
     condition: global.persistence

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -50,7 +50,7 @@ mosquitto:
 -   **global**:
     -   **clusterIssuer** - The name of a [`ClusterIssuer`](https://cert-manager.io/docs/concepts/issuer/) deployed in Kubernetes that should be used for retrieving SSL certificates, default is _null_.
 -   **mosquitto**:
-    - **hostName** - The hostname to utilise in SSL certificates for outside (i.e. sensors/`shutdown` service) cluster connections to MQTT. Requires the global `clusterIssuer` option to be set. Default is _null_.
+    -   **hostName** - The hostname to utilise in SSL certificates for outside (i.e. sensors/`shutdown` service) cluster connections to MQTT. Requires the global `clusterIssuer` option to be set. Default is _null_.
 
 ## Deploying
 
@@ -84,7 +84,7 @@ The deployment expects the following secrets to already exist, they are describe
 
 ```bash
 microk8s kubectl create secret generic freedns-secret --namespace powerpi \
-    --from-literal username=__USERNAME__ \
+    --from-literal=username=__USERNAME__ \
     --from-file=password=./__SECRET_NAME__
 ```
 
@@ -92,7 +92,7 @@ microk8s kubectl create secret generic freedns-secret --namespace powerpi \
 
 ```bash
 microk8s kubectl create secret generic google-auth-secret --namespace powerpi \
-    --from-literal client_id=__CLIENT_ID__ \
+    --from-literal=client_id=__CLIENT_ID__ \
     --from-file=secret=./__SECRET_NAME__
 ```
 
@@ -107,7 +107,7 @@ microk8s kubectl create secret generic ihd-secret --namespace powerpi \
 
 ```bash
 microk8s kubectl create secret generic github-secret --namespace powerpi \
-    --from-literal username=__USERNAME__ \
+    --from-literal=username=__USERNAME__ \
     --from-file=password=./__SECRET_NAME__
 ```
 

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -49,6 +49,7 @@ mosquitto:
 
 -   **global**:
     -   **clusterIssuer** - The name of a [`ClusterIssuer`](https://cert-manager.io/docs/concepts/issuer/) deployed in Kubernetes that should be used for retrieving SSL certificates, default is _null_.
+    -   **storageClass** - The name of a [`StorageClass`](https://kubernetes.io/docs/concepts/storage/storage-classes/) deployed in Kuberenetes that should be used when creating persistent storage for services that require this, default is _null_ which will use a custom hostpath class. Can be defined per service instead of globally if different classes are required per service. Effective for `mosquitto`, `database` and [`zigbee-controller`](../controllers/zigbee/README.md) services.
 -   **mosquitto**:
     -   **hostName** - The hostname to utilise in SSL certificates for outside (i.e. sensors/`shutdown` service) cluster connections to MQTT. Requires the global `clusterIssuer` option to be set. Default is _null_.
 
@@ -121,4 +122,4 @@ microk8s kubectl label node NODE_NAME powerpi-storage=true
 
 The following service also utilises labels, if you wish to use this apply their labels as well:
 
--   [energenie-controller](../controllers/energenie/README.md#kubernetes) - ENER314/ENER314-RT Pi controller
+-   [`energenie-controller`](../controllers/energenie/README.md#kubernetes) - ENER314/ENER314-RT Pi controller

--- a/kubernetes/charts/database/templates/backup-job.yaml
+++ b/kubernetes/charts/database/templates/backup-job.yaml
@@ -1,10 +1,11 @@
+{{- $needsNodeSelector := include "powerpi.persistent-volume-node-selector" . -}}
 {{- $nodeSelector := ternary (list
-    (dict
-      "Name" "powerpi-storage"
-      "Value" "true"
-    )
-  ) (list) .Values.global.useCluster 
-}}
+  (dict
+    "Name" $needsNodeSelector
+    "Value" "true"
+  )
+) (list) (not (empty $needsNodeSelector))
+-}}
 
 {{- $data := dict
   "Name" "database-backup"

--- a/kubernetes/charts/database/templates/stateful-set.yaml
+++ b/kubernetes/charts/database/templates/stateful-set.yaml
@@ -1,10 +1,11 @@
+{{- $needsNodeSelector := include "powerpi.persistent-volume-node-selector" . -}}
 {{- $nodeSelector := ternary (list
-    (dict
-      "Name" "powerpi-storage"
-      "Value" "true"
-    )
-  ) (list) .Values.global.useCluster 
-}}
+  (dict
+    "Name" $needsNodeSelector
+    "Value" "true"
+  )
+) (list) (not (empty $needsNodeSelector))
+-}}
 
 {{- $data := dict
   "Kind" "StatefulSet"

--- a/kubernetes/charts/mosquitto/Chart.yaml
+++ b/kubernetes/charts/mosquitto/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: mosquitto
 description: A Helm chart for deploying the mosquitto message queue for PowerPi
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: 2.0.18

--- a/kubernetes/charts/mosquitto/templates/stateful-set.yaml
+++ b/kubernetes/charts/mosquitto/templates/stateful-set.yaml
@@ -5,12 +5,13 @@
   (not (eq .Values.hostName nil))
 -}}
 
+{{- $needsNodeSelector := include "powerpi.persistent-volume-node-selector" . -}}
 {{- $nodeSelector := ternary (list
-    (dict
-      "Name" "powerpi-storage"
-      "Value" "true"
-    )
-  ) (list) .Values.global.useCluster 
+  (dict
+    "Name" $needsNodeSelector
+    "Value" "true"
+  )
+) (list) (not (empty $needsNodeSelector))
 -}}
 
 {{- $ports := list (dict

--- a/kubernetes/charts/mosquitto/templates/stateful-set.yaml
+++ b/kubernetes/charts/mosquitto/templates/stateful-set.yaml
@@ -42,6 +42,12 @@
   "Command" (list "/bin/sh" "-c")
   "Args" (list
     "cp /var/run/secrets/mosquitto-passwords-secret/passwords /mosquitto/passwords && mosquitto_passwd -U /mosquitto/passwords && exec /usr/sbin/mosquitto -c /mosquitto/config/mosquitto.conf"
+  ) 
+  "Annotations" (list
+    (dict
+      "Name" "checksum/mosquitto-passwords-secret"
+      "Value" (include (print $.Template.BasePath "/secret.yaml") $ | sha256sum)
+    )
   )
   "Ports" $ports
   "NodeSelector" $nodeSelector

--- a/kubernetes/templates/_persistent_volume_claim.tpl
+++ b/kubernetes/templates/_persistent_volume_claim.tpl
@@ -1,5 +1,4 @@
-{{- define "powerpi.persistent-volume-claim" -}}
-
+{{- define "powerpi.persistent-volume-claim-name" -}}
 {{- $storageClassName := .Values.storageClass | default .Values.global.storageClass -}}
 
 {{- $name := .Params.Name | default (printf "%s-volume-claim" .Chart.Name) -}}
@@ -8,10 +7,19 @@
 {{- $name = printf "%s-%s" $name $storageClassName -}}
 {{- end -}}
 
+StorageClass: {{ $storageClassName }}
+ClaimName: {{ $name }}
+
+{{- end -}}
+
+{{- define "powerpi.persistent-volume-claim" -}}
+
+{{- $claim := include "powerpi.persistent-volume-claim-name" . | fromYaml -}}
+
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ $name }}
+  name: {{ $claim.ClaimName }}
   {{- include "powerpi.labels" . }}
 spec:
   accessModes:
@@ -19,5 +27,5 @@ spec:
   resources:
     requests:
       storage: {{ .Params.Size }} 
-  storageClassName: {{ $storageClassName | default "powerpi-storage" }}
+  storageClassName: {{ $claim.StorageClass | default "powerpi-storage" }}
 {{- end }}

--- a/kubernetes/templates/_persistent_volume_claim.tpl
+++ b/kubernetes/templates/_persistent_volume_claim.tpl
@@ -7,7 +7,7 @@
 {{- $name = printf "%s-%s" $name $storageClassName -}}
 {{- end -}}
 
-StorageClass: {{ $storageClassName }}
+StorageClass: {{ $storageClassName | default "powerpi-storage" }}
 ClaimName: {{ $name }}
 
 {{- end -}}
@@ -27,5 +27,5 @@ spec:
   resources:
     requests:
       storage: {{ .Params.Size }} 
-  storageClassName: {{ $claim.StorageClass | default "powerpi-storage" }}
+  storageClassName: {{ $claim.StorageClass }}
 {{- end }}

--- a/kubernetes/templates/_persistent_volume_claim.tpl
+++ b/kubernetes/templates/_persistent_volume_claim.tpl
@@ -1,8 +1,17 @@
-{{- define "powerpi.persistent-volume-claim" }}
+{{- define "powerpi.persistent-volume-claim" -}}
+
+{{- $storageClassName := .Values.storageClass | default .Values.global.storageClass -}}
+
+{{- $name := .Params.Name | default (printf "%s-volume-claim" .Chart.Name) -}}
+
+{{- if eq (empty $storageClassName) false -}}
+{{- $name = printf "%s-%s" $name $storageClassName -}}
+{{- end -}}
+
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Params.Name | default (printf "%s-volume-claim" .Chart.Name) }}
+  name: {{ $name }}
   {{- include "powerpi.labels" . }}
 spec:
   accessModes:
@@ -10,5 +19,5 @@ spec:
   resources:
     requests:
       storage: {{ .Params.Size }} 
-  storageClassName: {{ .Values.storageClass | default "powerpi-storage" }}
+  storageClassName: {{ $storageClassName | default "powerpi-storage" }}
 {{- end }}

--- a/kubernetes/templates/_template.tpl
+++ b/kubernetes/templates/_template.tpl
@@ -275,10 +275,14 @@ template:
         path: {{ $element.HostPath | default $element.Path }}
     {{- end }}
 
-    {{- if $hasVolumeClaim }}
+    {{- if $hasVolumeClaim -}}
+    {{- $claim := dict
+      "Name" (.Params.PersistentVolumeClaim.Claim | default (printf "%s-volume-claim" .Chart.Name))
+    -}}
+    {{- $claim = include "powerpi.persistent-volume-claim-name" (merge (dict "Params" $claim) .) | fromYaml }}
     - name: {{ .Params.PersistentVolumeClaim.Name }}
       persistentVolumeClaim:
-        claimName: {{ .Params.PersistentVolumeClaim.Claim | default (printf "%s-volume-claim" .Chart.Name) }}
+        claimName: {{ $claim.ClaimName }}
     {{- end }}
 
     {{- if $hasConfig }}

--- a/kubernetes/templates/storage-class.yaml
+++ b/kubernetes/templates/storage-class.yaml
@@ -1,3 +1,4 @@
+{{- if eq (empty .Values.global.storageClass) true -}}
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
@@ -8,3 +9,4 @@ reclaimPolicy: Retain
 parameters:
   pvDir: /srv/k8s-volumes
 volumeBindingMode: WaitForFirstConsumer
+{{- end -}}

--- a/kubernetes/values.schema.json
+++ b/kubernetes/values.schema.json
@@ -109,6 +109,11 @@
                 "energyMonitor": {
                     "description": "Whether to include N3rgy energy monitoring support",
                     "type": "boolean"
+                },
+
+                "storageClass": {
+                    "description": "When defined will use the specified StorageClass instead of using local storage",
+                    "type": "string"
                 }
             },
             "required": ["externalHostName"],
@@ -178,6 +183,10 @@
                 },
                 "backupSchedule": {
                     "description": "The cron schedule for when the database backup should run",
+                    "type": "string"
+                },
+                "storageClass": {
+                    "description": "When defined will use the specified StorageClass instead of using local storage",
                     "type": "string"
                 }
             },
@@ -261,6 +270,10 @@
                     "description": "The external host name to use for mosquitto when using sensors and a ClusterIssuer",
                     "type": "string",
                     "pattern": "^\\w+(\\.\\w+)+$"
+                },
+                "storageClass": {
+                    "description": "When defined will use the specified StorageClass instead of using local storage",
+                    "type": "string"
                 }
             },
             "unevaluatedProperties": false
@@ -351,6 +364,12 @@
             "description": "The configuration for the PowerPi ZigBee controller Helm chart",
             "type": "object",
             "allOf": [{ "$ref": "#/$defs/controller" }],
+            "properties": {
+                "storageClass": {
+                    "description": "When defined will use the specified StorageClass instead of using local storage",
+                    "type": "string"
+                }
+            },
             "unevaluatedProperties": false
         }
     },


### PR DESCRIPTION
- Resolves #467:
  - Add support for custom `StorageClass` globally and per service that uses them.
  - If using a global `StorageClass` don't deploy the PowerPi one.
  - Ensure claims have unique names as changing the class of an existing claim is not allowed.
  - Only apply a `nodeSelector` if the `StorageClass` is the default and using a cluster.
  - Update documentation, and fix some mistakes.
- Resolves #475:
  - Add a checksum for the collated secret file on `mosquitto` `StatefulSet` which will make it restart when they change, i.e. when new secrets are added or removed (by changing the config), or secrets are manually changed.