### PR TITLE
#479 fix: energenie-controller GPIO in Bookworm hosts

### DIFF
--- a/controllers/energenie/Dockerfile
+++ b/controllers/energenie/Dockerfile
@@ -31,7 +31,8 @@ RUN ln -s ../../common/python/.venv .venv \
 # re-compile the binary
 WORKDIR /opt/powerpi/controllers/energenie/.venv/lib/python3.11/site-packages/pyenergenie/energenie/drv
 RUN rm radio_rpi.so \
-    && gcc -Wall -shared -o radio_rpi.so -fPIC radio.c hrfm69.c spis.c gpio_rpi.c delay_posix.c
+    && gcc -Wall -shared -o radio_rpi.so -fPIC radio.c hrfm69.c spis.c gpio_rpi.c delay_posix.c \
+    && rm build* -- *.h *.c
 
 # use multi-stage build to remove compile dependencies
 FROM base-image AS run-image

--- a/controllers/energenie/Dockerfile
+++ b/controllers/energenie/Dockerfile
@@ -40,7 +40,7 @@ LABEL description="PowerPi Energenie Controller"
 ENV PATH="/usr/src/app/venv/bin:$PATH"
 ENV TZ="UTC"
 
-RUN addgroup --gid 997 gpio \
+RUN addgroup --gid 993 gpio \
     && adduser --disabled-password powerpi \
     && usermod -a -G gpio powerpi
 USER powerpi

--- a/controllers/energenie/Dockerfile
+++ b/controllers/energenie/Dockerfile
@@ -28,6 +28,9 @@ COPY controllers/energenie/poetry.lock controllers/energenie/pyproject.toml ./
 RUN ln -s ../../common/python/.venv .venv \
     && poetry install --only main --no-root --no-interaction --no-ansi
 
+# Ugly fix for #479 where RPi.GPIO isn't working on Bookworm hosts 
+RUN sed -i 's/from . import cleanup_GPIO//g' /opt/powerpi/controllers/energenie/.venv/lib/python3.11/site-packages/pyenergenie/__init__.py
+
 # re-compile the binary
 WORKDIR /opt/powerpi/controllers/energenie/.venv/lib/python3.11/site-packages/pyenergenie/energenie/drv
 RUN rm radio_rpi.so \

--- a/controllers/energenie/README.md
+++ b/controllers/energenie/README.md
@@ -4,6 +4,8 @@ PowerPi service which controls [Energenie MiHome](https://energenie4u.co.uk/cata
 
 The service is built using python, with dependencies using [poetry](https://python-poetry.org/). It is also dependant on a local common library [_powerpi_common_](../../common/python/README.md), and testing library [_powerpi_common_test_](../../common/pytest/README.md).
 
+Unfortunately at this time this service is not compatible with a Pi 5 host due to changes in the way GPIO is accessed. If/when the underlying library is updated to support it, this will be rectified.
+
 ## Supported Devices
 
 This controller requires one of the following Raspberry Pi modules to wirelessly communicate with the other Energenie devices:

--- a/controllers/energenie/energenie_controller/energenie/dummy.py
+++ b/controllers/energenie/energenie_controller/energenie/dummy.py
@@ -2,8 +2,8 @@ from .energenie import EnergenieInterface
 
 
 class DummyEnergenieInterface(EnergenieInterface):
-    async def _turn_on(self):
-        pass
+    def _turn_on(self):
+        """The DummyEnergenieInterface does not support turning on."""
 
-    async def _turn_off(self):
-        pass
+    def _turn_off(self):
+        """The DummyEnergenieInterface does not support turning off."""

--- a/controllers/energenie/pyproject.toml
+++ b/controllers/energenie/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "energenie_controller"
-version = "0.3.2"
+version = "0.3.3"
 description = "PowerPi Energenie Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -37,7 +37,7 @@ dependencies:
     condition: global.voiceAssistant
   # controllers
   - name: energenie-controller
-    version: 0.1.9
+    version: 0.1.10
     condition: global.energenie
   - name: harmony-controller
     version: 0.1.13

--- a/kubernetes/charts/energenie-controller/Chart.yaml
+++ b/kubernetes/charts/energenie-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: energenie-controller
 description: A Helm chart for the PowerPi Energenie device controller
 type: application
-version: 0.1.9
-appVersion: 0.3.2
+version: 0.1.10
+appVersion: 0.3.3


### PR DESCRIPTION
Fixes #479:
- Remove the import for `cleanup_GPIO` which includes `RPi.GPIO` which isn't working on Bookworm, but it doesn't seem to be used.
- `gpio` group id seems to have changed from 997 to 993.
- Update documentation to explain this probably won't work on a Pi 5.

Unrelated:
- Fix `async` issue with the dummy interface.
- Remove the unnecessary source files after recompiling the radio binary.