### PR TITLE
#480 refactor: Improve the Dockerfile for python services

### DIFF
--- a/controllers/energenie/Dockerfile
+++ b/controllers/energenie/Dockerfile
@@ -1,5 +1,5 @@
 # create a common base image with updated setuptools
-FROM python:3.11.6-slim-bookworm AS base-image
+FROM python:3.11.8-slim-bookworm AS base-image
 RUN pip3 install --prefer-binary setuptools==68.2.2
 
 # create a base image for building

--- a/controllers/energenie/Dockerfile
+++ b/controllers/energenie/Dockerfile
@@ -11,26 +11,27 @@ RUN apt-get update \
 RUN poetry config virtualenvs.in-project true
 ENV CFLAGS=-fcommon
 
-# create a venv with the common library
+# build the common library
 FROM build-base-image AS build-common-image
 WORKDIR /opt/powerpi/common/python
-COPY common/pytest/poetry.lock common/pytest/pyproject.toml ./../pytest/
 COPY common/python/poetry.lock common/python/pyproject.toml ./
-RUN poetry install --compile --only main --no-root --no-interaction --no-ansi
+RUN poetry install --only main --no-root --no-directory --no-interaction --no-ansi
 COPY common/python/powerpi_common ./powerpi_common
-RUN poetry build \
-    && .venv/bin/pip install ./dist/*.whl
+RUN poetry build
 
-# re-use the venv and install the controller's dependencies
+# install the controller's dependencies
 FROM build-base-image AS build-image
 WORKDIR /opt/powerpi/controllers/energenie
-COPY --from=build-common-image /opt/powerpi/common ./../../common
 COPY controllers/energenie/poetry.lock controllers/energenie/pyproject.toml ./
-RUN ln -s ../../common/python/.venv .venv \
-    && poetry install --compile --only main --no-root --no-interaction --no-ansi
+RUN poetry install --compile --only main --no-root --no-directory --no-interaction --no-ansi
 
 # Ugly fix for #479 where RPi.GPIO isn't working on Bookworm hosts 
 RUN sed -i 's/from . import cleanup_GPIO//g' /opt/powerpi/controllers/energenie/.venv/lib/python3.11/site-packages/pyenergenie/__init__.py
+
+# install the common library
+COPY --from=build-common-image /opt/powerpi/common/python/dist/*.whl .
+RUN .venv/bin/pip install ./*.whl \
+    && rm -- *.whl
 
 # re-compile the binary
 WORKDIR /opt/powerpi/controllers/energenie/.venv/lib/python3.11/site-packages/pyenergenie/energenie/drv

--- a/controllers/energenie/Dockerfile
+++ b/controllers/energenie/Dockerfile
@@ -6,7 +6,6 @@ RUN pip3 install --prefer-binary setuptools==69.0.3
 FROM base-image AS build-base-image
 RUN pip3 install --prefer-binary poetry==1.7.1
 RUN poetry config virtualenvs.in-project true
-ENV CFLAGS=-fcommon
 
 FROM build-base-image AS build-base-image-gcc
 RUN apt-get update \

--- a/controllers/energenie/Dockerfile
+++ b/controllers/energenie/Dockerfile
@@ -6,7 +6,8 @@ RUN pip3 install --prefer-binary setuptools==69.0.3
 FROM base-image AS build-base-image
 RUN pip3 install --prefer-binary poetry==1.7.1
 RUN apt-get update \
-    && apt-get install -y gcc git
+    && apt-get install -y gcc git \
+    && apt-get clean -y
 RUN poetry config virtualenvs.in-project true
 ENV CFLAGS=-fcommon
 

--- a/controllers/energenie/Dockerfile
+++ b/controllers/energenie/Dockerfile
@@ -16,7 +16,7 @@ FROM build-base-image AS build-common-image
 WORKDIR /opt/powerpi/common/python
 COPY common/pytest/poetry.lock common/pytest/pyproject.toml ./../pytest/
 COPY common/python/poetry.lock common/python/pyproject.toml ./
-RUN poetry install --only main --no-root --no-interaction --no-ansi
+RUN poetry install --compile --only main --no-root --no-interaction --no-ansi
 COPY common/python/powerpi_common ./powerpi_common
 RUN poetry build \
     && .venv/bin/pip install ./dist/*.whl
@@ -27,7 +27,7 @@ WORKDIR /opt/powerpi/controllers/energenie
 COPY --from=build-common-image /opt/powerpi/common ./../../common
 COPY controllers/energenie/poetry.lock controllers/energenie/pyproject.toml ./
 RUN ln -s ../../common/python/.venv .venv \
-    && poetry install --only main --no-root --no-interaction --no-ansi
+    && poetry install --compile --only main --no-root --no-interaction --no-ansi
 
 # Ugly fix for #479 where RPi.GPIO isn't working on Bookworm hosts 
 RUN sed -i 's/from . import cleanup_GPIO//g' /opt/powerpi/controllers/energenie/.venv/lib/python3.11/site-packages/pyenergenie/__init__.py

--- a/controllers/energenie/Dockerfile
+++ b/controllers/energenie/Dockerfile
@@ -5,11 +5,13 @@ RUN pip3 install --prefer-binary setuptools==69.0.3
 # create a base image for building
 FROM base-image AS build-base-image
 RUN pip3 install --prefer-binary poetry==1.7.1
+RUN poetry config virtualenvs.in-project true
+ENV CFLAGS=-fcommon
+
+FROM build-base-image AS build-base-image-gcc
 RUN apt-get update \
     && apt-get install -y gcc git \
     && apt-get clean -y
-RUN poetry config virtualenvs.in-project true
-ENV CFLAGS=-fcommon
 
 # build the common library
 FROM build-base-image AS build-common-image
@@ -20,7 +22,7 @@ COPY common/python/powerpi_common ./powerpi_common
 RUN poetry build
 
 # install the controller's dependencies
-FROM build-base-image AS build-image
+FROM build-base-image-gcc AS build-image
 WORKDIR /opt/powerpi/controllers/energenie
 COPY controllers/energenie/poetry.lock controllers/energenie/pyproject.toml ./
 RUN poetry install --compile --only main --no-root --no-directory --no-interaction --no-ansi

--- a/controllers/energenie/Dockerfile
+++ b/controllers/energenie/Dockerfile
@@ -4,7 +4,7 @@ RUN pip3 install --prefer-binary setuptools==69.0.3
 
 # create a base image for building
 FROM base-image AS build-base-image
-RUN pip3 install --prefer-binary poetry==1.6.1
+RUN pip3 install --prefer-binary poetry==1.7.1
 RUN apt-get update \
     && apt-get install -y gcc git
 RUN poetry config virtualenvs.in-project true

--- a/controllers/energenie/Dockerfile
+++ b/controllers/energenie/Dockerfile
@@ -1,6 +1,6 @@
 # create a common base image with updated setuptools
 FROM python:3.11.8-slim-bookworm AS base-image
-RUN pip3 install --prefer-binary setuptools==68.2.2
+RUN pip3 install --prefer-binary setuptools==69.0.3
 
 # create a base image for building
 FROM base-image AS build-base-image

--- a/controllers/energenie/Dockerfile
+++ b/controllers/energenie/Dockerfile
@@ -16,7 +16,6 @@ RUN apt-get update \
 FROM build-base-image AS build-common-image
 WORKDIR /opt/powerpi/common/python
 COPY common/python/poetry.lock common/python/pyproject.toml ./
-RUN poetry install --only main --no-root --no-directory --no-interaction --no-ansi
 COPY common/python/powerpi_common ./powerpi_common
 RUN poetry build
 

--- a/controllers/harmony/Dockerfile
+++ b/controllers/harmony/Dockerfile
@@ -4,7 +4,7 @@ RUN pip3 install --prefer-binary setuptools==69.0.3
 
 # create a base image for building
 FROM base-image AS build-base-image
-RUN pip3 install --prefer-binary poetry==1.6.1
+RUN pip3 install --prefer-binary poetry==1.7.1
 RUN poetry config virtualenvs.in-project true
 ENV CFLAGS=-fcommon
 

--- a/controllers/harmony/Dockerfile
+++ b/controllers/harmony/Dockerfile
@@ -1,5 +1,5 @@
 # create a common base image with updated setuptools
-FROM python:3.11.6-slim-bookworm AS base-image
+FROM python:3.11.8-slim-bookworm AS base-image
 RUN pip3 install --prefer-binary setuptools==68.2.2
 
 # create a base image for building

--- a/controllers/harmony/Dockerfile
+++ b/controllers/harmony/Dockerfile
@@ -13,7 +13,7 @@ FROM build-base-image AS build-common-image
 WORKDIR /opt/powerpi/common/python
 COPY common/pytest/poetry.lock common/pytest/pyproject.toml ./../pytest/
 COPY common/python/poetry.lock common/python/pyproject.toml ./
-RUN poetry install --only main --no-root --no-interaction --no-ansi
+RUN poetry install --compile --only main --no-root --no-interaction --no-ansi
 COPY common/python/powerpi_common ./powerpi_common
 RUN poetry build \
     && .venv/bin/pip install ./dist/*.whl
@@ -24,7 +24,7 @@ WORKDIR /opt/powerpi/controllers/harmony
 COPY --from=build-common-image /opt/powerpi/common ./../../common
 COPY controllers/harmony/poetry.lock controllers/harmony/pyproject.toml ./
 RUN ln -s ../../common/python/.venv .venv \
-    && poetry install --only main --no-root --no-interaction --no-ansi
+    && poetry install --compile --only main --no-root --no-interaction --no-ansi
 
 # use multi-stage build to remove compile dependencies
 FROM base-image AS run-image

--- a/controllers/harmony/Dockerfile
+++ b/controllers/harmony/Dockerfile
@@ -6,7 +6,6 @@ RUN pip3 install --prefer-binary setuptools==69.0.3
 FROM base-image AS build-base-image
 RUN pip3 install --prefer-binary poetry==1.7.1
 RUN poetry config virtualenvs.in-project true
-ENV CFLAGS=-fcommon
 
 # build the common library
 FROM build-base-image AS build-common-image

--- a/controllers/harmony/Dockerfile
+++ b/controllers/harmony/Dockerfile
@@ -8,23 +8,25 @@ RUN pip3 install --prefer-binary poetry==1.7.1
 RUN poetry config virtualenvs.in-project true
 ENV CFLAGS=-fcommon
 
-# create a venv with the common library
+# build the common library
 FROM build-base-image AS build-common-image
 WORKDIR /opt/powerpi/common/python
-COPY common/pytest/poetry.lock common/pytest/pyproject.toml ./../pytest/
 COPY common/python/poetry.lock common/python/pyproject.toml ./
-RUN poetry install --compile --only main --no-root --no-interaction --no-ansi
+RUN poetry install --only main --no-root --no-directory --no-interaction --no-ansi
 COPY common/python/powerpi_common ./powerpi_common
-RUN poetry build \
-    && .venv/bin/pip install ./dist/*.whl
+RUN poetry build
 
-# re-use the venv and install the controller's dependencies
+# install the controller's dependencies
 FROM build-base-image AS build-image
 WORKDIR /opt/powerpi/controllers/harmony
 COPY --from=build-common-image /opt/powerpi/common ./../../common
 COPY controllers/harmony/poetry.lock controllers/harmony/pyproject.toml ./
-RUN ln -s ../../common/python/.venv .venv \
-    && poetry install --compile --only main --no-root --no-interaction --no-ansi
+RUN poetry install --compile --only main --no-root --no-directory --no-interaction --no-ansi
+
+# install the common library
+COPY --from=build-common-image /opt/powerpi/common/python/dist/*.whl .
+RUN .venv/bin/pip install ./*.whl \
+    && rm -- *.whl
 
 # use multi-stage build to remove compile dependencies
 FROM base-image AS run-image

--- a/controllers/harmony/Dockerfile
+++ b/controllers/harmony/Dockerfile
@@ -11,7 +11,6 @@ RUN poetry config virtualenvs.in-project true
 FROM build-base-image AS build-common-image
 WORKDIR /opt/powerpi/common/python
 COPY common/python/poetry.lock common/python/pyproject.toml ./
-RUN poetry install --only main --no-root --no-directory --no-interaction --no-ansi
 COPY common/python/powerpi_common ./powerpi_common
 RUN poetry build
 

--- a/controllers/harmony/Dockerfile
+++ b/controllers/harmony/Dockerfile
@@ -1,6 +1,6 @@
 # create a common base image with updated setuptools
 FROM python:3.11.8-slim-bookworm AS base-image
-RUN pip3 install --prefer-binary setuptools==68.2.2
+RUN pip3 install --prefer-binary setuptools==69.0.3
 
 # create a base image for building
 FROM base-image AS build-base-image

--- a/controllers/lifx/Dockerfile
+++ b/controllers/lifx/Dockerfile
@@ -4,7 +4,7 @@ RUN pip3 install --prefer-binary setuptools==69.0.3
 
 # create a base image for building
 FROM base-image AS build-base-image
-RUN pip3 install --prefer-binary poetry==1.6.1
+RUN pip3 install --prefer-binary poetry==1.7.1
 RUN poetry config virtualenvs.in-project true
 ENV CFLAGS=-fcommon
 

--- a/controllers/lifx/Dockerfile
+++ b/controllers/lifx/Dockerfile
@@ -13,7 +13,7 @@ FROM build-base-image AS build-common-image
 WORKDIR /opt/powerpi/common/python
 COPY common/pytest/poetry.lock common/pytest/pyproject.toml ./../pytest/
 COPY common/python/poetry.lock common/python/pyproject.toml ./
-RUN poetry install --only main --no-root --no-interaction --no-ansi
+RUN poetry install --compile --only main --no-root --no-interaction --no-ansi
 COPY common/python/powerpi_common ./powerpi_common
 RUN poetry build \
     && .venv/bin/pip install ./dist/*.whl
@@ -24,7 +24,7 @@ WORKDIR /opt/powerpi/controllers/lifx
 COPY --from=build-common-image /opt/powerpi/common ./../../common
 COPY controllers/lifx/poetry.lock controllers/lifx/pyproject.toml ./
 RUN ln -s ../../common/python/.venv .venv \
-    && poetry install --only main --no-root --no-interaction --no-ansi
+    && poetry install --compile --only main --no-root --no-interaction --no-ansi
 
 # use multi-stage build to remove compile dependencies
 FROM base-image AS run-image

--- a/controllers/lifx/Dockerfile
+++ b/controllers/lifx/Dockerfile
@@ -1,5 +1,5 @@
 # create a common base image with updated setuptools
-FROM python:3.11.6-slim-bookworm AS base-image
+FROM python:3.11.8-slim-bookworm AS base-image
 RUN pip3 install --prefer-binary setuptools==68.2.2
 
 # create a base image for building

--- a/controllers/lifx/Dockerfile
+++ b/controllers/lifx/Dockerfile
@@ -6,7 +6,6 @@ RUN pip3 install --prefer-binary setuptools==69.0.3
 FROM base-image AS build-base-image
 RUN pip3 install --prefer-binary poetry==1.7.1
 RUN poetry config virtualenvs.in-project true
-ENV CFLAGS=-fcommon
 
 # build the common library
 FROM build-base-image AS build-common-image

--- a/controllers/lifx/Dockerfile
+++ b/controllers/lifx/Dockerfile
@@ -11,7 +11,6 @@ RUN poetry config virtualenvs.in-project true
 FROM build-base-image AS build-common-image
 WORKDIR /opt/powerpi/common/python
 COPY common/python/poetry.lock common/python/pyproject.toml ./
-RUN poetry install --only main --no-root --no-directory --no-interaction --no-ansi
 COPY common/python/powerpi_common ./powerpi_common
 RUN poetry build
 

--- a/controllers/lifx/Dockerfile
+++ b/controllers/lifx/Dockerfile
@@ -1,6 +1,6 @@
 # create a common base image with updated setuptools
 FROM python:3.11.8-slim-bookworm AS base-image
-RUN pip3 install --prefer-binary setuptools==68.2.2
+RUN pip3 install --prefer-binary setuptools==69.0.3
 
 # create a base image for building
 FROM base-image AS build-base-image

--- a/controllers/lifx/Dockerfile
+++ b/controllers/lifx/Dockerfile
@@ -8,23 +8,25 @@ RUN pip3 install --prefer-binary poetry==1.7.1
 RUN poetry config virtualenvs.in-project true
 ENV CFLAGS=-fcommon
 
-# create a venv with the common library
+# build the common library
 FROM build-base-image AS build-common-image
 WORKDIR /opt/powerpi/common/python
-COPY common/pytest/poetry.lock common/pytest/pyproject.toml ./../pytest/
 COPY common/python/poetry.lock common/python/pyproject.toml ./
-RUN poetry install --compile --only main --no-root --no-interaction --no-ansi
+RUN poetry install --only main --no-root --no-directory --no-interaction --no-ansi
 COPY common/python/powerpi_common ./powerpi_common
-RUN poetry build \
-    && .venv/bin/pip install ./dist/*.whl
+RUN poetry build
 
-# re-use the venv and install the controller's dependencies
+# install the controller's dependencies
 FROM build-base-image AS build-image
 WORKDIR /opt/powerpi/controllers/lifx
 COPY --from=build-common-image /opt/powerpi/common ./../../common
 COPY controllers/lifx/poetry.lock controllers/lifx/pyproject.toml ./
-RUN ln -s ../../common/python/.venv .venv \
-    && poetry install --compile --only main --no-root --no-interaction --no-ansi
+RUN poetry install --compile --only main --no-root --no-directory --no-interaction --no-ansi
+
+# install the common library
+COPY --from=build-common-image /opt/powerpi/common/python/dist/*.whl .
+RUN .venv/bin/pip install ./*.whl \
+    && rm -- *.whl
 
 # use multi-stage build to remove compile dependencies
 FROM base-image AS run-image

--- a/controllers/lifx/pyproject.toml
+++ b/controllers/lifx/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lifx_controller"
-version = "0.6.1"
+version = "0.6.2"
 description = "PowerPi LIFX Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/network/Dockerfile
+++ b/controllers/network/Dockerfile
@@ -4,7 +4,7 @@ RUN pip3 install --prefer-binary setuptools==69.0.3
 
 # create a base image for building
 FROM base-image AS build-base-image
-RUN pip3 install --prefer-binary poetry==1.6.1
+RUN pip3 install --prefer-binary poetry==1.7.1
 RUN poetry config virtualenvs.in-project true
 ENV CFLAGS=-fcommon
 

--- a/controllers/network/Dockerfile
+++ b/controllers/network/Dockerfile
@@ -1,5 +1,5 @@
 # create a common base image with updated setuptools
-FROM python:3.11.6-slim-bookworm AS base-image
+FROM python:3.11.8-slim-bookworm AS base-image
 RUN pip3 install --prefer-binary setuptools==68.2.2
 
 # create a base image for building

--- a/controllers/network/Dockerfile
+++ b/controllers/network/Dockerfile
@@ -6,7 +6,6 @@ RUN pip3 install --prefer-binary setuptools==69.0.3
 FROM base-image AS build-base-image
 RUN pip3 install --prefer-binary poetry==1.7.1
 RUN poetry config virtualenvs.in-project true
-ENV CFLAGS=-fcommon
 
 # build the common library
 FROM build-base-image AS build-common-image

--- a/controllers/network/Dockerfile
+++ b/controllers/network/Dockerfile
@@ -13,7 +13,7 @@ FROM build-base-image AS build-common-image
 WORKDIR /opt/powerpi/common/python
 COPY common/pytest/poetry.lock common/pytest/pyproject.toml ./../pytest/
 COPY common/python/poetry.lock common/python/pyproject.toml ./
-RUN poetry install --only main --no-root --no-interaction --no-ansi
+RUN poetry install --compile --only main --no-root --no-interaction --no-ansi
 COPY common/python/powerpi_common ./powerpi_common
 RUN poetry build \
     && .venv/bin/pip install ./dist/*.whl
@@ -24,7 +24,7 @@ WORKDIR /opt/powerpi/controllers/network
 COPY --from=build-common-image /opt/powerpi/common ./../../common
 COPY controllers/network/poetry.lock controllers/network/pyproject.toml ./
 RUN ln -s ../../common/python/.venv .venv \
-    && poetry install --only main --no-root --no-interaction --no-ansi
+    && poetry install --compile --only main --no-root --no-interaction --no-ansi
 
 # use multi-stage build to remove compile dependencies
 FROM base-image AS run-image

--- a/controllers/network/Dockerfile
+++ b/controllers/network/Dockerfile
@@ -11,7 +11,6 @@ RUN poetry config virtualenvs.in-project true
 FROM build-base-image AS build-common-image
 WORKDIR /opt/powerpi/common/python
 COPY common/python/poetry.lock common/python/pyproject.toml ./
-RUN poetry install --only main --no-root --no-directory --no-interaction --no-ansi
 COPY common/python/powerpi_common ./powerpi_common
 RUN poetry build
 

--- a/controllers/network/Dockerfile
+++ b/controllers/network/Dockerfile
@@ -1,6 +1,6 @@
 # create a common base image with updated setuptools
 FROM python:3.11.8-slim-bookworm AS base-image
-RUN pip3 install --prefer-binary setuptools==68.2.2
+RUN pip3 install --prefer-binary setuptools==69.0.3
 
 # create a base image for building
 FROM base-image AS build-base-image

--- a/controllers/network/Dockerfile
+++ b/controllers/network/Dockerfile
@@ -8,23 +8,25 @@ RUN pip3 install --prefer-binary poetry==1.7.1
 RUN poetry config virtualenvs.in-project true
 ENV CFLAGS=-fcommon
 
-# create a venv with the common library
+# build the common library
 FROM build-base-image AS build-common-image
 WORKDIR /opt/powerpi/common/python
-COPY common/pytest/poetry.lock common/pytest/pyproject.toml ./../pytest/
 COPY common/python/poetry.lock common/python/pyproject.toml ./
-RUN poetry install --compile --only main --no-root --no-interaction --no-ansi
+RUN poetry install --only main --no-root --no-directory --no-interaction --no-ansi
 COPY common/python/powerpi_common ./powerpi_common
-RUN poetry build \
-    && .venv/bin/pip install ./dist/*.whl
+RUN poetry build
 
-# re-use the venv and install the controller's dependencies
+# install the controller's dependencies
 FROM build-base-image AS build-image
 WORKDIR /opt/powerpi/controllers/network
 COPY --from=build-common-image /opt/powerpi/common ./../../common
 COPY controllers/network/poetry.lock controllers/network/pyproject.toml ./
-RUN ln -s ../../common/python/.venv .venv \
-    && poetry install --compile --only main --no-root --no-interaction --no-ansi
+RUN poetry install --compile --only main --no-root --no-directory --no-interaction --no-ansi
+
+# install the common library
+COPY --from=build-common-image /opt/powerpi/common/python/dist/*.whl .
+RUN .venv/bin/pip install ./*.whl \
+    && rm -- *.whl
 
 # use multi-stage build to remove compile dependencies
 FROM base-image AS run-image

--- a/controllers/network/pyproject.toml
+++ b/controllers/network/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "network_controller"
-version = "0.2.1"
+version = "0.2.2"
 description = "PowerPi Network Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/snapcast/Dockerfile
+++ b/controllers/snapcast/Dockerfile
@@ -4,7 +4,7 @@ RUN pip3 install --prefer-binary setuptools==69.0.3
 
 # create a base image for building
 FROM base-image AS build-base-image
-RUN pip3 install --prefer-binary poetry==1.6.1
+RUN pip3 install --prefer-binary poetry==1.7.1
 RUN poetry config virtualenvs.in-project true
 ENV CFLAGS=-fcommon
 

--- a/controllers/snapcast/Dockerfile
+++ b/controllers/snapcast/Dockerfile
@@ -1,5 +1,5 @@
 # create a common base image with updated setuptools
-FROM python:3.11.6-slim-bookworm AS base-image
+FROM python:3.11.8-slim-bookworm AS base-image
 RUN pip3 install --prefer-binary setuptools==68.2.2
 
 # create a base image for building

--- a/controllers/snapcast/Dockerfile
+++ b/controllers/snapcast/Dockerfile
@@ -8,23 +8,25 @@ RUN pip3 install --prefer-binary poetry==1.7.1
 RUN poetry config virtualenvs.in-project true
 ENV CFLAGS=-fcommon
 
-# create a venv with the common library
+# build the common library
 FROM build-base-image AS build-common-image
 WORKDIR /opt/powerpi/common/python
-COPY common/pytest/poetry.lock common/pytest/pyproject.toml ./../pytest/
 COPY common/python/poetry.lock common/python/pyproject.toml ./
-RUN poetry install --compile --only main --no-root --no-interaction --no-ansi
+RUN poetry install --only main --no-root --no-directory --no-interaction --no-ansi
 COPY common/python/powerpi_common ./powerpi_common
-RUN poetry build \
-    && .venv/bin/pip install ./dist/*.whl
+RUN poetry build
 
-# re-use the venv and install the controller's dependencies
+# install the controller's dependencies
 FROM build-base-image AS build-image
 WORKDIR /opt/powerpi/controllers/snapcast
 COPY --from=build-common-image /opt/powerpi/common ./../../common
 COPY controllers/snapcast/poetry.lock controllers/snapcast/pyproject.toml ./
-RUN ln -s ../../common/python/.venv .venv \
-    && poetry install --compile --only main --no-root --no-interaction --no-ansi
+RUN poetry install --compile --only main --no-root --no-directory --no-interaction --no-ansi
+
+# install the common library
+COPY --from=build-common-image /opt/powerpi/common/python/dist/*.whl .
+RUN .venv/bin/pip install ./*.whl \
+    && rm -- *.whl
 
 # use multi-stage build to remove compile dependencies
 FROM base-image AS run-image

--- a/controllers/snapcast/Dockerfile
+++ b/controllers/snapcast/Dockerfile
@@ -13,7 +13,7 @@ FROM build-base-image AS build-common-image
 WORKDIR /opt/powerpi/common/python
 COPY common/pytest/poetry.lock common/pytest/pyproject.toml ./../pytest/
 COPY common/python/poetry.lock common/python/pyproject.toml ./
-RUN poetry install --only main --no-root --no-interaction --no-ansi
+RUN poetry install --compile --only main --no-root --no-interaction --no-ansi
 COPY common/python/powerpi_common ./powerpi_common
 RUN poetry build \
     && .venv/bin/pip install ./dist/*.whl
@@ -24,7 +24,7 @@ WORKDIR /opt/powerpi/controllers/snapcast
 COPY --from=build-common-image /opt/powerpi/common ./../../common
 COPY controllers/snapcast/poetry.lock controllers/snapcast/pyproject.toml ./
 RUN ln -s ../../common/python/.venv .venv \
-    && poetry install --only main --no-root --no-interaction --no-ansi
+    && poetry install --compile --only main --no-root --no-interaction --no-ansi
 
 # use multi-stage build to remove compile dependencies
 FROM base-image AS run-image

--- a/controllers/snapcast/Dockerfile
+++ b/controllers/snapcast/Dockerfile
@@ -6,7 +6,6 @@ RUN pip3 install --prefer-binary setuptools==69.0.3
 FROM base-image AS build-base-image
 RUN pip3 install --prefer-binary poetry==1.7.1
 RUN poetry config virtualenvs.in-project true
-ENV CFLAGS=-fcommon
 
 # build the common library
 FROM build-base-image AS build-common-image

--- a/controllers/snapcast/Dockerfile
+++ b/controllers/snapcast/Dockerfile
@@ -11,7 +11,6 @@ RUN poetry config virtualenvs.in-project true
 FROM build-base-image AS build-common-image
 WORKDIR /opt/powerpi/common/python
 COPY common/python/poetry.lock common/python/pyproject.toml ./
-RUN poetry install --only main --no-root --no-directory --no-interaction --no-ansi
 COPY common/python/powerpi_common ./powerpi_common
 RUN poetry build
 

--- a/controllers/snapcast/Dockerfile
+++ b/controllers/snapcast/Dockerfile
@@ -1,6 +1,6 @@
 # create a common base image with updated setuptools
 FROM python:3.11.8-slim-bookworm AS base-image
-RUN pip3 install --prefer-binary setuptools==68.2.2
+RUN pip3 install --prefer-binary setuptools==69.0.3
 
 # create a base image for building
 FROM base-image AS build-base-image

--- a/controllers/virtual/Dockerfile
+++ b/controllers/virtual/Dockerfile
@@ -4,7 +4,7 @@ RUN pip3 install --prefer-binary setuptools==69.0.3
 
 # create a base image for building
 FROM base-image AS build-base-image
-RUN pip3 install --prefer-binary poetry==1.6.1
+RUN pip3 install --prefer-binary poetry==1.7.1
 RUN poetry config virtualenvs.in-project true
 ENV CFLAGS=-fcommon
 

--- a/controllers/virtual/Dockerfile
+++ b/controllers/virtual/Dockerfile
@@ -1,5 +1,5 @@
 # create a common base image with updated setuptools
-FROM python:3.11.6-slim-bookworm AS base-image
+FROM python:3.11.8-slim-bookworm AS base-image
 RUN pip3 install --prefer-binary setuptools==68.2.2
 
 # create a base image for building

--- a/controllers/virtual/Dockerfile
+++ b/controllers/virtual/Dockerfile
@@ -13,7 +13,7 @@ FROM build-base-image AS build-common-image
 WORKDIR /opt/powerpi/common/python
 COPY common/pytest/poetry.lock common/pytest/pyproject.toml ./../pytest/
 COPY common/python/poetry.lock common/python/pyproject.toml ./
-RUN poetry install --only main --no-root --no-interaction --no-ansi
+RUN poetry install --compile --only main --no-root --no-interaction --no-ansi
 COPY common/python/powerpi_common ./powerpi_common
 RUN poetry build \
     && .venv/bin/pip install ./dist/*.whl
@@ -24,7 +24,7 @@ WORKDIR /opt/powerpi/controllers/virtual
 COPY --from=build-common-image /opt/powerpi/common ./../../common
 COPY controllers/virtual/poetry.lock controllers/virtual/pyproject.toml ./
 RUN ln -s ../../common/python/.venv .venv \
-    && poetry install --only main --no-root --no-interaction --no-ansi
+    && poetry install --compile --only main --no-root --no-interaction --no-ansi
 
 # use multi-stage build to remove compile dependencies
 FROM base-image AS run-image

--- a/controllers/virtual/Dockerfile
+++ b/controllers/virtual/Dockerfile
@@ -6,7 +6,6 @@ RUN pip3 install --prefer-binary setuptools==69.0.3
 FROM base-image AS build-base-image
 RUN pip3 install --prefer-binary poetry==1.7.1
 RUN poetry config virtualenvs.in-project true
-ENV CFLAGS=-fcommon
 
 # build the common library
 FROM build-base-image AS build-common-image

--- a/controllers/virtual/Dockerfile
+++ b/controllers/virtual/Dockerfile
@@ -8,23 +8,25 @@ RUN pip3 install --prefer-binary poetry==1.7.1
 RUN poetry config virtualenvs.in-project true
 ENV CFLAGS=-fcommon
 
-# create a venv with the common library
+# build the common library
 FROM build-base-image AS build-common-image
 WORKDIR /opt/powerpi/common/python
-COPY common/pytest/poetry.lock common/pytest/pyproject.toml ./../pytest/
 COPY common/python/poetry.lock common/python/pyproject.toml ./
-RUN poetry install --compile --only main --no-root --no-interaction --no-ansi
+RUN poetry install --only main --no-root --no-directory --no-interaction --no-ansi
 COPY common/python/powerpi_common ./powerpi_common
-RUN poetry build \
-    && .venv/bin/pip install ./dist/*.whl
+RUN poetry build
 
-# re-use the venv and install the controller's dependencies
+# install the controller's dependencies
 FROM build-base-image AS build-image
 WORKDIR /opt/powerpi/controllers/virtual
 COPY --from=build-common-image /opt/powerpi/common ./../../common
 COPY controllers/virtual/poetry.lock controllers/virtual/pyproject.toml ./
-RUN ln -s ../../common/python/.venv .venv \
-    && poetry install --compile --only main --no-root --no-interaction --no-ansi
+RUN poetry install --compile --only main --no-root --no-directory --no-interaction --no-ansi
+
+# install the common library
+COPY --from=build-common-image /opt/powerpi/common/python/dist/*.whl .
+RUN .venv/bin/pip install ./*.whl \
+    && rm -- *.whl
 
 # use multi-stage build to remove compile dependencies
 FROM base-image AS run-image

--- a/controllers/virtual/Dockerfile
+++ b/controllers/virtual/Dockerfile
@@ -11,7 +11,6 @@ RUN poetry config virtualenvs.in-project true
 FROM build-base-image AS build-common-image
 WORKDIR /opt/powerpi/common/python
 COPY common/python/poetry.lock common/python/pyproject.toml ./
-RUN poetry install --only main --no-root --no-directory --no-interaction --no-ansi
 COPY common/python/powerpi_common ./powerpi_common
 RUN poetry build
 

--- a/controllers/virtual/Dockerfile
+++ b/controllers/virtual/Dockerfile
@@ -1,6 +1,6 @@
 # create a common base image with updated setuptools
 FROM python:3.11.8-slim-bookworm AS base-image
-RUN pip3 install --prefer-binary setuptools==68.2.2
+RUN pip3 install --prefer-binary setuptools==69.0.3
 
 # create a base image for building
 FROM base-image AS build-base-image

--- a/controllers/virtual/pyproject.toml
+++ b/controllers/virtual/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "virtual_controller"
-version = "2.1.1"
+version = "2.1.2"
 description = "PowerPi Virtual Controller"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/controllers/zigbee/Dockerfile
+++ b/controllers/zigbee/Dockerfile
@@ -4,7 +4,7 @@ RUN pip3 install --prefer-binary setuptools==69.0.3
 
 # create a base image for building
 FROM base-image AS build-base-image
-RUN pip3 install --prefer-binary poetry==1.6.1
+RUN pip3 install --prefer-binary poetry==1.7.1
 RUN poetry config virtualenvs.in-project true
 ENV CFLAGS=-fcommon
 

--- a/controllers/zigbee/Dockerfile
+++ b/controllers/zigbee/Dockerfile
@@ -1,5 +1,5 @@
 # create a common base image with updated setuptools
-FROM python:3.11.6-slim-bookworm AS base-image
+FROM python:3.11.8-slim-bookworm AS base-image
 RUN pip3 install --prefer-binary setuptools==68.2.2
 
 # create a base image for building

--- a/controllers/zigbee/Dockerfile
+++ b/controllers/zigbee/Dockerfile
@@ -13,7 +13,7 @@ FROM build-base-image AS build-common-image
 WORKDIR /opt/powerpi/common/python
 COPY common/pytest/poetry.lock common/pytest/pyproject.toml ./../pytest/
 COPY common/python/poetry.lock common/python/pyproject.toml ./
-RUN poetry install --only main --no-root --no-interaction --no-ansi
+RUN poetry install --compile --only main --no-root --no-interaction --no-ansi
 COPY common/python/powerpi_common ./powerpi_common
 RUN poetry build \
     && .venv/bin/pip install ./dist/*.whl
@@ -24,7 +24,7 @@ WORKDIR /opt/powerpi/controllers/zigbee
 COPY --from=build-common-image /opt/powerpi/common ./../../common
 COPY controllers/zigbee/poetry.lock controllers/zigbee/pyproject.toml ./
 RUN ln -s ../../common/python/.venv .venv \
-    && poetry install --only main --no-root --no-interaction --no-ansi
+    && poetry install --compile --only main --no-root --no-interaction --no-ansi
 
 # use multi-stage build to remove compile dependencies
 FROM base-image AS run-image

--- a/controllers/zigbee/Dockerfile
+++ b/controllers/zigbee/Dockerfile
@@ -6,7 +6,6 @@ RUN pip3 install --prefer-binary setuptools==69.0.3
 FROM base-image AS build-base-image
 RUN pip3 install --prefer-binary poetry==1.7.1
 RUN poetry config virtualenvs.in-project true
-ENV CFLAGS=-fcommon
 
 # build the common library
 FROM build-base-image AS build-common-image

--- a/controllers/zigbee/Dockerfile
+++ b/controllers/zigbee/Dockerfile
@@ -8,23 +8,25 @@ RUN pip3 install --prefer-binary poetry==1.7.1
 RUN poetry config virtualenvs.in-project true
 ENV CFLAGS=-fcommon
 
-# create a venv with the common library
+# build the common library
 FROM build-base-image AS build-common-image
 WORKDIR /opt/powerpi/common/python
-COPY common/pytest/poetry.lock common/pytest/pyproject.toml ./../pytest/
 COPY common/python/poetry.lock common/python/pyproject.toml ./
-RUN poetry install --compile --only main --no-root --no-interaction --no-ansi
+RUN poetry install --only main --no-root --no-directory --no-interaction --no-ansi
 COPY common/python/powerpi_common ./powerpi_common
-RUN poetry build \
-    && .venv/bin/pip install ./dist/*.whl
+RUN poetry build
 
-# re-use the venv and install the controller's dependencies
+# install the controller's dependencies
 FROM build-base-image AS build-image
 WORKDIR /opt/powerpi/controllers/zigbee
 COPY --from=build-common-image /opt/powerpi/common ./../../common
 COPY controllers/zigbee/poetry.lock controllers/zigbee/pyproject.toml ./
-RUN ln -s ../../common/python/.venv .venv \
-    && poetry install --compile --only main --no-root --no-interaction --no-ansi
+RUN poetry install --compile --only main --no-root --no-directory --no-interaction --no-ansi
+
+# install the common library
+COPY --from=build-common-image /opt/powerpi/common/python/dist/*.whl .
+RUN .venv/bin/pip install ./*.whl \
+    && rm -- *.whl
 
 # use multi-stage build to remove compile dependencies
 FROM base-image AS run-image

--- a/controllers/zigbee/Dockerfile
+++ b/controllers/zigbee/Dockerfile
@@ -11,7 +11,6 @@ RUN poetry config virtualenvs.in-project true
 FROM build-base-image AS build-common-image
 WORKDIR /opt/powerpi/common/python
 COPY common/python/poetry.lock common/python/pyproject.toml ./
-RUN poetry install --only main --no-root --no-directory --no-interaction --no-ansi
 COPY common/python/powerpi_common ./powerpi_common
 RUN poetry build
 

--- a/controllers/zigbee/Dockerfile
+++ b/controllers/zigbee/Dockerfile
@@ -1,6 +1,6 @@
 # create a common base image with updated setuptools
 FROM python:3.11.8-slim-bookworm AS base-image
-RUN pip3 install --prefer-binary setuptools==68.2.2
+RUN pip3 install --prefer-binary setuptools==69.0.3
 
 # create a base image for building
 FROM base-image AS build-base-image

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     version: 0.1.7
     condition: global.persistence
   - name: scheduler
-    version: 0.2.9
+    version: 0.2.10
     condition: global.scheduler
   - name: smarter-device-manager
     version: 0.1.2
@@ -43,16 +43,16 @@ dependencies:
     version: 0.1.13
     condition: global.harmony
   - name: lifx-controller
-    version: 0.1.9
+    version: 0.1.10
     condition: global.lifx
   - name: network-controller
-    version: 0.1.7
+    version: 0.1.8
     condition: global.network
   - name: snapcast-controller
     version: 0.0.4
     condition: global.snapcast
   - name: virtual-controller
-    version: 0.2.4
+    version: 0.2.5
   - name: zigbee-controller
     version: 0.1.14
     condition: global.zigbee

--- a/kubernetes/charts/lifx-controller/Chart.yaml
+++ b/kubernetes/charts/lifx-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lifx-controller
 description: A Helm chart for the PowerPi LIFX device controller
 type: application
-version: 0.1.9
-appVersion: 0.6.1
+version: 0.1.10
+appVersion: 0.6.2

--- a/kubernetes/charts/network-controller/Chart.yaml
+++ b/kubernetes/charts/network-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: network-controller
 description: A Helm chart for the PowerPi Network device controller
 type: application
-version: 0.1.7
-appVersion: 0.2.1
+version: 0.1.8
+appVersion: 0.2.2

--- a/kubernetes/charts/scheduler/Chart.yaml
+++ b/kubernetes/charts/scheduler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: scheduler
 description: A Helm chart for the PowerPi scheduler service
 type: application
-version: 0.2.9
-appVersion: 1.3.1
+version: 0.2.10
+appVersion: 1.3.2

--- a/kubernetes/charts/virtual-controller/Chart.yaml
+++ b/kubernetes/charts/virtual-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: virtual-controller
 description: A Helm chart for the PowerPi virtual device controller
 type: application
-version: 0.2.4
-appVersion: 2.1.1
+version: 0.2.5
+appVersion: 2.1.2

--- a/services/scheduler/Dockerfile
+++ b/services/scheduler/Dockerfile
@@ -4,7 +4,7 @@ RUN pip3 install --prefer-binary setuptools==69.0.3
 
 # create a base image for building
 FROM base-image AS build-base-image
-RUN pip3 install --prefer-binary poetry==1.6.1
+RUN pip3 install --prefer-binary poetry==1.7.1
 RUN poetry config virtualenvs.in-project true
 ENV CFLAGS=-fcommon
 

--- a/services/scheduler/Dockerfile
+++ b/services/scheduler/Dockerfile
@@ -13,7 +13,7 @@ FROM build-base-image AS build-common-image
 WORKDIR /opt/powerpi/common/python
 COPY common/pytest/poetry.lock common/pytest/pyproject.toml ./../pytest/
 COPY common/python/poetry.lock common/python/pyproject.toml ./
-RUN poetry install --only main --no-root --no-interaction --no-ansi
+RUN poetry install --compile --only main --no-root --no-interaction --no-ansi
 COPY common/python/powerpi_common ./powerpi_common
 RUN poetry build \
     && .venv/bin/pip install ./dist/*.whl
@@ -24,7 +24,7 @@ WORKDIR /opt/powerpi/services/scheduler
 COPY --from=build-common-image /opt/powerpi/common ./../../common
 COPY services/scheduler/poetry.lock services/scheduler/pyproject.toml ./
 RUN ln -s ../../common/python/.venv .venv \
-    && poetry install --only main --no-root --no-interaction --no-ansi
+    && poetry install --compile --only main --no-root --no-interaction --no-ansi
 
 # use multi-stage build to remove compile dependencies
 FROM base-image AS run-image

--- a/services/scheduler/Dockerfile
+++ b/services/scheduler/Dockerfile
@@ -8,23 +8,24 @@ RUN pip3 install --prefer-binary poetry==1.7.1
 RUN poetry config virtualenvs.in-project true
 ENV CFLAGS=-fcommon
 
-# create a venv with the common library
+# build the common library
 FROM build-base-image AS build-common-image
 WORKDIR /opt/powerpi/common/python
-COPY common/pytest/poetry.lock common/pytest/pyproject.toml ./../pytest/
 COPY common/python/poetry.lock common/python/pyproject.toml ./
-RUN poetry install --compile --only main --no-root --no-interaction --no-ansi
+RUN poetry install --only main --no-root --no-directory --no-interaction --no-ansi
 COPY common/python/powerpi_common ./powerpi_common
-RUN poetry build \
-    && .venv/bin/pip install ./dist/*.whl
+RUN poetry build
 
-# re-use the venv and install the service's dependencies
+# install the service's dependencies
 FROM build-base-image AS build-image
 WORKDIR /opt/powerpi/services/scheduler
-COPY --from=build-common-image /opt/powerpi/common ./../../common
 COPY services/scheduler/poetry.lock services/scheduler/pyproject.toml ./
-RUN ln -s ../../common/python/.venv .venv \
-    && poetry install --compile --only main --no-root --no-interaction --no-ansi
+RUN poetry install --compile --only main --no-root --no-directory --no-interaction --no-ansi
+
+# install the common library
+COPY --from=build-common-image /opt/powerpi/common/python/dist/*.whl .
+RUN .venv/bin/pip install ./*.whl \
+    && rm -- *.whl
 
 # use multi-stage build to remove compile dependencies
 FROM base-image AS run-image

--- a/services/scheduler/Dockerfile
+++ b/services/scheduler/Dockerfile
@@ -1,5 +1,5 @@
 # create a common base image with updated setuptools
-FROM python:3.11.6-slim-bookworm AS base-image
+FROM python:3.11.8-slim-bookworm AS base-image
 RUN pip3 install --prefer-binary setuptools==68.2.2
 
 # create a base image for building

--- a/services/scheduler/Dockerfile
+++ b/services/scheduler/Dockerfile
@@ -6,7 +6,6 @@ RUN pip3 install --prefer-binary setuptools==69.0.3
 FROM base-image AS build-base-image
 RUN pip3 install --prefer-binary poetry==1.7.1
 RUN poetry config virtualenvs.in-project true
-ENV CFLAGS=-fcommon
 
 # build the common library
 FROM build-base-image AS build-common-image

--- a/services/scheduler/Dockerfile
+++ b/services/scheduler/Dockerfile
@@ -11,7 +11,6 @@ RUN poetry config virtualenvs.in-project true
 FROM build-base-image AS build-common-image
 WORKDIR /opt/powerpi/common/python
 COPY common/python/poetry.lock common/python/pyproject.toml ./
-RUN poetry install --only main --no-root --no-directory --no-interaction --no-ansi
 COPY common/python/powerpi_common ./powerpi_common
 RUN poetry build
 

--- a/services/scheduler/Dockerfile
+++ b/services/scheduler/Dockerfile
@@ -1,6 +1,6 @@
 # create a common base image with updated setuptools
 FROM python:3.11.8-slim-bookworm AS base-image
-RUN pip3 install --prefer-binary setuptools==68.2.2
+RUN pip3 install --prefer-binary setuptools==69.0.3
 
 # create a base image for building
 FROM base-image AS build-base-image

--- a/services/scheduler/pyproject.toml
+++ b/services/scheduler/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scheduler"
-version = "1.3.1"
+version = "1.3.2"
 description = "PowerPi Scheduler Service"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]


### PR DESCRIPTION
Resolves #480:
- Add `--compile` option to support pre-compiling dependencies so it's already done when the pod starts.
- Use `--no-directory` option so we don't need the common library built before we install the main dependencies. Which also means we don't need to copy the virtual environment that was used for building the common library, nor install the common libraries dependencies when we build it!
- Make `energenie-controller` also use cached layers for the common library by installing the compilation dependencies into a separate base.
- Update python base image to v3.11.8.
- Update setuptools to v69.0.3.
- Update poetry to v1.7.1.