### PR TITLE
#119 feat: Upgrade voice-assistant so it won't restart when config changes

### DIFF
--- a/common/node/common/src/services/ConfigRetrieverService.test.ts
+++ b/common/node/common/src/services/ConfigRetrieverService.test.ts
@@ -48,34 +48,9 @@ describe("ConfigRetrieverService", () => {
     });
 
     describe("message", () => {
-        const exit = jest.spyOn(process, "exit").mockImplementation((_) => undefined as never);
         const setConfig = jest.spyOn(ConfigService.prototype, "setConfig");
 
-        beforeEach(() => {
-            exit.mockClear();
-            setConfig.mockClear();
-        });
-
-        test("required causes restart", () => {
-            jest.spyOn(ConfigService.prototype, "configIsNeeded", "get").mockReturnValue(true);
-
-            jest.spyOn(ConfigService.prototype, "getUsedConfig").mockReturnValue([
-                ConfigFileType.Devices,
-                ConfigFileType.Users,
-            ]);
-
-            jest.spyOn(ConfigService.prototype, "getConfig").mockReturnValue({
-                data: [],
-                checksum: "checky",
-            });
-
-            subject.message("config", "users", "change", {
-                payload: { users: ["tom"] },
-                checksum: "checky",
-            });
-
-            expect(exit).toHaveBeenCalledTimes(1);
-        });
+        beforeEach(() => setConfig.mockClear());
 
         [
             [true, false, false],
@@ -84,7 +59,7 @@ describe("ConfigRetrieverService", () => {
         ].forEach((options) => {
             const [isNeeded, usedConfig, hasConfig] = options;
 
-            test(`not required no restart ${isNeeded} ${usedConfig} ${hasConfig}`, () => {
+            test(`not required ${isNeeded} ${usedConfig} ${hasConfig}`, () => {
                 const listener = {
                     onConfigChange: jest.fn(),
                 };
@@ -112,8 +87,6 @@ describe("ConfigRetrieverService", () => {
                     payload: { users: ["tom"] },
                     checksum: "checky",
                 });
-
-                expect(exit).toHaveBeenCalledTimes(0);
 
                 expect(setConfig).toHaveBeenCalledTimes(1);
                 expect(setConfig).toHaveBeenCalledWith("users", { users: ["tom"] }, "checky");

--- a/common/node/common/src/services/ConfigRetrieverService.ts
+++ b/common/node/common/src/services/ConfigRetrieverService.ts
@@ -82,22 +82,11 @@ export class ConfigRetrieverService implements MqttConsumer<ConfigMessage> {
         if (type) {
             this.logger.info("Received config for", type);
 
-            if (
-                this.config.configIsNeeded &&
-                this.config.configRestart &&
-                this.config.getUsedConfig().find((config) => config === type) &&
-                this.config.getConfig(type)?.data
-            ) {
-                // this is a changed config and used, so we should restart the service
-                this.logger.info("Restarting service due to changed", type, "config");
-                process.exit(0);
-            } else {
-                // this is a new config, so just set it
-                this.config.setConfig(type, payload, checksum);
+            // this is a new config, so just set it
+            this.config.setConfig(type, payload, checksum);
 
-                // now notify the listeners if there are any
-                this.listeners[type]?.forEach((listener) => listener.onConfigChange(type));
-            }
+            // now notify the listeners if there are any
+            this.listeners[type]?.forEach((listener) => listener.onConfigChange(type));
         }
     }
 

--- a/common/node/common/src/services/ConfigService.ts
+++ b/common/node/common/src/services/ConfigService.ts
@@ -99,11 +99,6 @@ export class ConfigService {
         return !this.useConfigFile;
     }
 
-    /** Restart the service when one of the config files change. */
-    get configRestart() {
-        return true;
-    }
-
     get useConfigFile() {
         return this.getEnvBoolean("USE_CONFIG_FILE", false);
     }

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -36,7 +36,7 @@ dependencies:
   - name: ui
     version: 0.3.0
   - name: voice-assistant
-    version: 0.2.6
+    version: 0.3.0
     condition: global.voiceAssistant
   # controllers
   - name: energenie-controller

--- a/kubernetes/charts/voice-assistant/Chart.yaml
+++ b/kubernetes/charts/voice-assistant/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: voice-assistant
 description: A Helm chart for the PowerPi voice assistant service
 type: application
-version: 0.2.6
-appVersion: 2.0.9
+version: 0.3.0
+appVersion: 2.1.0

--- a/services/voice-assistant/package.json
+++ b/services/voice-assistant/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@powerpi/voice-assistant",
-    "version": "2.0.9",
+    "version": "2.1.0",
     "description": "PowerPi home automation voice assistant service",
     "private": true,
     "license": "GPL-3.0-only",


### PR DESCRIPTION
- As this is the last Javascript service, remove the restart option entirely.
- `voice-assistant` goes directly to `ConfigService` for device list so there's no direct changes needed.