### PR TITLE
Release 0.7.0

### DIFF
--- a/.github/scripts/docker_tag.sh
+++ b/.github/scripts/docker_tag.sh
@@ -5,7 +5,7 @@ scriptPath=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 get_version() {
     local path=$scriptPath/../../kubernetes/charts/$1/Chart.yaml
 
-    appVersion=`yq .appVersion $path`
+    appVersion=`yq .appVersion $path | tr -d \"`
 }
 
 registry=$1

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -2,10 +2,9 @@ apiVersion: v2
 name: powerpi
 description: A Helm chart for deploying the PowerPi home automation stack
 type: application
-version: 0.6.1
-appVersion: 0.6.1
+version: 0.7.0
+appVersion: 0.7.0
 dependencies:
-  # services
   - name: api
     version: 0.3.0
   - name: config-server
@@ -38,7 +37,6 @@ dependencies:
   - name: voice-assistant
     version: 0.3.0
     condition: global.voiceAssistant
-  # controllers
   - name: energenie-controller
     version: 0.1.11
     condition: global.energenie


### PR DESCRIPTION
- Bump to v0.7.0.
- Fix `docker_tag` script after breaking changes to `yq`.