### PR TITLE
#333 fix: Ensure schedule changes are going in the correct direction and add force option

### DIFF
--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -28,7 +28,7 @@ dependencies:
     version: 0.1.10
     condition: global.persistence
   - name: scheduler
-    version: 0.2.11
+    version: 0.2.12
     condition: global.scheduler
   - name: smarter-device-manager
     version: 0.1.2

--- a/kubernetes/charts/scheduler/Chart.yaml
+++ b/kubernetes/charts/scheduler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: scheduler
 description: A Helm chart for the PowerPi scheduler service
 type: application
-version: 0.2.11
-appVersion: 1.3.3
+version: 0.2.12
+appVersion: 1.4.0

--- a/services/config-server/src/schema/config/schedules.schema.json
+++ b/services/config-server/src/schema/config/schedules.schema.json
@@ -99,6 +99,10 @@
                     "power": {
                         "description": "Whether to turn the device on when the schedule starts",
                         "type": "boolean"
+                    },
+                    "force": {
+                        "description": "Whether to force the values when updating, which will provide a delta to ensure the value is where we expect to start",
+                        "type": "boolean"
                     }
                 },
                 "required": ["between", "interval"],

--- a/services/config-server/src/services/tests/SchedulesConfigFile.test.ts
+++ b/services/config-server/src/services/tests/SchedulesConfigFile.test.ts
@@ -73,6 +73,7 @@ describe("Schedules", () => {
                             hue: [0, 360],
                             saturation: [0, 100],
                             power: true,
+                            force: true,
                         },
                     ],
                 };

--- a/services/scheduler/Dockerfile
+++ b/services/scheduler/Dockerfile
@@ -1,6 +1,5 @@
 # create a common base image with updated setuptools
 FROM python:3.11.8-slim-bookworm AS base-image
-RUN pip3 install --prefer-binary setuptools==69.0.3
 
 # create a base image for building
 FROM base-image AS build-base-image

--- a/services/scheduler/Dockerfile
+++ b/services/scheduler/Dockerfile
@@ -43,4 +43,4 @@ COPY --chown=powerpi services/scheduler/pyproject.toml LICENSE ./
 COPY --chown=powerpi services/scheduler/scheduler ./scheduler/
 
 # start the application once the container is ready
-CMD ["python", "-m scheduler"]
+CMD python -m scheduler

--- a/services/scheduler/Dockerfile
+++ b/services/scheduler/Dockerfile
@@ -4,8 +4,8 @@ RUN pip3 install --prefer-binary setuptools==69.0.3
 
 # create a base image for building
 FROM base-image AS build-base-image
-RUN pip3 install --prefer-binary poetry==1.7.1
-RUN poetry config virtualenvs.in-project true
+RUN pip3 install --prefer-binary poetry==1.7.1 \
+    && poetry config virtualenvs.in-project true
 
 # build the common library
 FROM build-base-image AS build-common-image
@@ -43,4 +43,4 @@ COPY --chown=powerpi services/scheduler/pyproject.toml LICENSE ./
 COPY --chown=powerpi services/scheduler/scheduler ./scheduler/
 
 # start the application once the container is ready
-CMD python -m scheduler
+CMD ["python", "-m scheduler"]

--- a/services/scheduler/Dockerfile
+++ b/services/scheduler/Dockerfile
@@ -43,4 +43,4 @@ COPY --chown=powerpi services/scheduler/pyproject.toml LICENSE ./
 COPY --chown=powerpi services/scheduler/scheduler ./scheduler/
 
 # start the application once the container is ready
-CMD python -m scheduler
+CMD ["python", "-m", "scheduler"]

--- a/services/scheduler/pyproject.toml
+++ b/services/scheduler/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scheduler"
-version = "1.3.3"
+version = "1.4.0"
 description = "PowerPi Scheduler Service"
 license = "GPL-3.0-only"
 authors = ["TWilkin <4322355+TWilkin@users.noreply.github.com>"]

--- a/services/scheduler/scheduler/services/device_schedule.py
+++ b/services/scheduler/scheduler/services/device_schedule.py
@@ -288,10 +288,10 @@ class DeviceSchedule(LogMixin):
         if self.__force:
             # when we're forcing use the value ignoring what value it already has
             delta = (delta_range.end - delta_range.start) / intervals
-            delta *= (intervals - remaining_intervals)
+            delta *= intervals - remaining_intervals
 
             # but we need to take the disparity into account
-            delta += (delta_range.start - start)
+            delta += delta_range.start - start
         else:
             delta = (delta_range.end - start) / remaining_intervals
 
@@ -303,15 +303,19 @@ class DeviceSchedule(LogMixin):
         new_value = delta_range.start + delta
 
         # ensure the new value is in the correct direction
-        if (new_value > delta_range.start and not delta_range.increasing) \
-                or (new_value < delta_range.start and delta_range.increasing):
+        if not self.__force and \
+                ((new_value > delta_range.start and not delta_range.increasing)
+                 or (new_value < delta_range.start and delta_range.increasing)):
             new_value = delta_range.start
 
         new_value = round_for_type(delta_range.type, new_value)
-        if delta > 0:
-            new_value = min(max(new_value, delta_range.start), delta_range.end)
-        else:
-            new_value = max(min(new_value, delta_range.start), delta_range.end)
+        if not self.__force:
+            if delta > 0:
+                new_value = min(
+                    max(new_value, delta_range.start), delta_range.end)
+            else:
+                new_value = max(
+                    min(new_value, delta_range.start), delta_range.end)
 
         return new_value
 

--- a/services/scheduler/scheduler/services/device_schedule.py
+++ b/services/scheduler/scheduler/services/device_schedule.py
@@ -135,6 +135,8 @@ class DeviceSchedule(LogMixin):
     def __parse(self, device_schedule: Dict[str, Any]):
         self.__between: List[str] = device_schedule['between']
         self.__interval = int(device_schedule['interval'])
+        self.__force = bool(
+            device_schedule['force']) if 'force' in device_schedule else False
 
         self.__days = device_schedule['days'] if 'days' in device_schedule \
             else None
@@ -274,7 +276,7 @@ class DeviceSchedule(LogMixin):
         additional_state = device.get_additional_state_for_scene(self.__scene)
 
         # do we want to overwrite start with the current value from the device
-        if delta_range.type in additional_state:
+        if not self.__force and delta_range.type in additional_state:
             start = additional_state[delta_range.type]
         else:
             start = delta_range.start

--- a/services/scheduler/scheduler/services/device_schedule.py
+++ b/services/scheduler/scheduler/services/device_schedule.py
@@ -301,8 +301,8 @@ class DeviceSchedule(LogMixin):
 
         # ensure the new value is in the correct direction
         if not self.__force and \
-                ((new_value > delta_range.start and not delta_range.increasing)
-                 or (new_value < delta_range.start and delta_range.increasing)
+                ((new_value > start and not delta_range.increasing)
+                 or (new_value < start and delta_range.increasing)
                  or (new_value > delta_range.end and delta_range.increasing)
                  or (new_value < delta_range.end and not delta_range.increasing)):
             new_value = start

--- a/services/scheduler/scheduler/services/device_schedule.py
+++ b/services/scheduler/scheduler/services/device_schedule.py
@@ -262,16 +262,13 @@ class DeviceSchedule(LogMixin):
         seconds = end_date.timestamp() - schedule_start_date.timestamp()
 
         # how many intervals will there be
-        intervals = seconds / self.__interval
+        intervals = seconds / self.__interval + 1
 
         # work out how many more intervals need to be acted on
         elapsed_seconds = datetime.now(pytz.UTC).timestamp() \
             - start_date.timestamp()
-        remaining_intervals = intervals - \
-            (elapsed_seconds / self.__interval) + 1
-
-        if remaining_intervals <= 0:
-            remaining_intervals = 1
+        remaining_intervals = max(
+            min(intervals - (elapsed_seconds / self.__interval), intervals), 1)
 
         device = self.__variable_manager.get_device(
             self.__device
@@ -288,7 +285,7 @@ class DeviceSchedule(LogMixin):
         if self.__force:
             # when we're forcing use the range ignoring what value it already has
             delta = (delta_range.end - delta_range.start) / intervals
-            delta *= intervals - remaining_intervals
+            delta *= (intervals - remaining_intervals + 1)
 
             # but we need to take the disparity into account
             delta += delta_range.start - start

--- a/services/scheduler/scheduler/services/device_schedule.py
+++ b/services/scheduler/scheduler/services/device_schedule.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from datetime import datetime, time, timedelta
 from enum import IntEnum, StrEnum, unique
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 import pytz
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -149,7 +149,7 @@ class DeviceSchedule(LogMixin):
                     delta_type,
                     int(device_schedule[delta_type][0]),
                     int(device_schedule[delta_type][1]),
-                    int(device_schedule[delta_type][0]) > int(
+                    int(device_schedule[delta_type][0]) < int(
                         device_schedule[delta_type][1])
                 )
 
@@ -159,7 +159,7 @@ class DeviceSchedule(LogMixin):
                     delta_type,
                     float(device_schedule[delta_type][0]),
                     float(device_schedule[delta_type][1]),
-                    float(device_schedule[delta_type][0]) > float(
+                    float(device_schedule[delta_type][0]) < float(
                         device_schedule[delta_type][1])
                 )
 
@@ -252,7 +252,11 @@ class DeviceSchedule(LogMixin):
 
         return (start_date, end_date)
 
-    def __calculate_delta(self, start_date: datetime, delta_range: DeltaRange):
+    def __calculate_delta(
+        self,
+        start_date: datetime,
+        delta_range: DeltaRange
+    ) -> Tuple[DeltaRange, float]:
         (schedule_start_date, end_date) = self.__calculate_dates()
 
         # how many seconds between the dates
@@ -281,9 +285,6 @@ class DeviceSchedule(LogMixin):
         else:
             start = delta_range.start
 
-        # check which direction we're going in
-        increasing = delta_range.start <= delta_range.end
-
         # what is the delta
         if self.__force:
             # when we're forcing use the value ignoring what value it already has
@@ -295,7 +296,7 @@ class DeviceSchedule(LogMixin):
         else:
             delta = (delta_range.end - start) / remaining_intervals
 
-        return (DeltaRange(delta_range.type, start, delta_range.end, increasing), delta)
+        return (DeltaRange(delta_range.type, start, delta_range.end, delta_range.increasing), delta)
 
     def __calculate_new_value(self, start_date: datetime, delta_range: DeltaRange):
         (delta_range, delta) = self.__calculate_delta(start_date, delta_range)

--- a/services/scheduler/tests/services/test_device_schedule.py
+++ b/services/scheduler/tests/services/test_device_schedule.py
@@ -342,17 +342,18 @@ class TestDeviceSchedule:
         assert job[2][1] == job[1].end_date
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize('brightness,current,expected,next_expected', [
-        ([0, 100], 50, 50 + 1.67, 50 + 1.67 * 2),
-        ([100, 0], 50, 50 - 1.67, 50 - 1.67 * 2),
-        ([0, 100], 0, 3.33, 3.33 * 2),
-        ([100, 0], 100, 100 - 3.33, 100 - 3.33 * 2),
-        ([0, 100], 100, 100, 100),
-        ([100, 0], 0, 0, 0),
-        ([10, 60], 10 + 20, 10 + 21, 10 + 22),
-        ([60, 10], 60 - 20, 60 - 21, 60 - 22),
-        ([20, 30], 31, 31, 31),  # not increasing
-        ([30, 20], 19, 19, 19)  # not decreasing
+    @pytest.mark.parametrize('brightness,current,expected,next_expected,force', [
+        ([0, 100], 50, 50 + 1.67, 50 + 1.67 * 2, False),
+        ([100, 0], 50, 50 - 1.67, 50 - 1.67 * 2, False),
+        ([0, 100], 0, 3.33, 3.33 * 2, False),
+        ([100, 0], 100, 100 - 3.33, 100 - 3.33 * 2, False),
+        ([0, 100], 100, 100, 100, False),
+        ([100, 0], 0, 0, 0, False),
+        ([10, 60], 10 + 20, 10 + 21, 10 + 22, False),
+        ([60, 10], 60 - 20, 60 - 21, 60 - 22, False),
+        ([20, 30], 31, 31, 31, False),  # not increasing
+        ([30, 20], 19, 19, 19, False),  # not decreasing
+        ([60, 10], 100, 60 - 20, 60 - 21, True)  # force
     ])
     async def test_execute_current_value(
         self,
@@ -363,7 +364,8 @@ class TestDeviceSchedule:
         brightness: List[int],
         current: float,
         expected: float,
-        next_expected: float
+        next_expected: float,
+        force: bool
     ):
         # pylint: disable=too-many-arguments,too-many-locals
 
@@ -374,7 +376,8 @@ class TestDeviceSchedule:
             'device': 'SomeDevice',
             'between': ['09:10:00', '10:00:00'],
             'interval': 60,
-            'brightness': brightness
+            'brightness': brightness,
+            'force': force
         })
 
         async def execute(minutes: float, current: float, expected: float):

--- a/services/scheduler/tests/services/test_device_schedule.py
+++ b/services/scheduler/tests/services/test_device_schedule.py
@@ -350,7 +350,9 @@ class TestDeviceSchedule:
         ([0, 100], 100, 100, 100),
         ([100, 0], 0, 0, 0),
         ([10, 60], 10 + 20, 10 + 21, 10 + 22),
-        ([60, 10], 60 - 20, 60 - 21, 60 - 22)
+        ([60, 10], 60 - 20, 60 - 21, 60 - 22),
+        ([20, 30], 31, 31, 31),  # not increasing
+        ([20, 30], 19, 19, 19)  # not decreasing
     ])
     async def test_execute_current_value(
         self,

--- a/services/scheduler/tests/services/test_device_schedule.py
+++ b/services/scheduler/tests/services/test_device_schedule.py
@@ -355,7 +355,8 @@ class TestDeviceSchedule:
         ([30, 20], 19, 19, 19, False),  # not decreasing
         # force
         ([60, 10], 100, 60 - 20, 60 - 21, True),
-        ([0, 50], 50, 0 + 20, 0 + 21, True)
+        ([0, 50], 50, 0 + 20, 0 + 21, True),
+        ([50, 0], 0, 50 - 20, 50 - 21, True),
     ])
     async def test_execute_current_value(
         self,

--- a/services/scheduler/tests/services/test_device_schedule.py
+++ b/services/scheduler/tests/services/test_device_schedule.py
@@ -213,8 +213,8 @@ class TestDeviceSchedule:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize('brightness,current,expected', [
-        ([0, 100], 1.111, 1.11 + 1.65),
-        ([100, 0], 100 - 1.111, 100 - 1.11 - 1.65)
+        ([0, 100], 1.111, 1.11 + 1.94),
+        ([100, 0], 100 - 1.111, 100 - 1.11 - 1.94)
     ])
     async def test_execute_round2dp(
         self,
@@ -258,8 +258,8 @@ class TestDeviceSchedule:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize('hue,current,expected', [
-        ([0, 360], 1.111, 1 + 6),
-        ([360, 0], 360 - 1.111, 360 - 1 - 6)
+        ([0, 360], 1.111, 2 + 6),
+        ([360, 0], 360 - 1.111, 360 - 2 - 6)
     ])
     async def test_execute_round0dp(
         self,
@@ -354,9 +354,9 @@ class TestDeviceSchedule:
         ([20, 30], 31, [31, 31, 31, 31, 31], False),  # not increasing
         ([30, 20], 19, [19, 19, 19, 19, 19], False),  # not decreasing
         # force
-        ([60, 20], 100, [60, 50, 40, 30, 20], True),
-        ([0, 40], 40, [0, 10, 20, 30], True),
-        ([40, 0], 0, [40, 30, 20, 10, 0], True),
+        ([70, 20], 100, [60, 50, 40, 30, 20], True),
+        ([0, 50], 50, [10, 20, 30, 40, 50], True),
+        ([50, 0], 0, [40, 30, 20, 10, 0], True),
     ])
     async def test_execute_current_value(
         self,

--- a/services/scheduler/tests/services/test_device_schedule.py
+++ b/services/scheduler/tests/services/test_device_schedule.py
@@ -353,7 +353,9 @@ class TestDeviceSchedule:
         ([60, 10], 60 - 20, 60 - 21, 60 - 22, False),
         ([20, 30], 31, 31, 31, False),  # not increasing
         ([30, 20], 19, 19, 19, False),  # not decreasing
-        ([60, 10], 100, 60 - 20, 60 - 21, True)  # force
+        # force
+        ([60, 10], 100, 60 - 20, 60 - 21, True),
+        ([0, 50], 50, 0 + 20, 0 + 21, True)
     ])
     async def test_execute_current_value(
         self,

--- a/services/scheduler/tests/services/test_device_schedule.py
+++ b/services/scheduler/tests/services/test_device_schedule.py
@@ -352,7 +352,7 @@ class TestDeviceSchedule:
         ([10, 60], 10 + 20, 10 + 21, 10 + 22),
         ([60, 10], 60 - 20, 60 - 21, 60 - 22),
         ([20, 30], 31, 31, 31),  # not increasing
-        ([20, 30], 19, 19, 19)  # not decreasing
+        ([30, 20], 19, 19, 19)  # not decreasing
     ])
     async def test_execute_current_value(
         self,


### PR DESCRIPTION
Resolves #333.
- Ensure when making a change to one of the additional state fields in the `scheduler` ensure the change it will make after taking the current value into account is going in the correct direction. This is to ensure that, say when changing the brightness between 50 and 60, if it's already 70 it won't start dimming the light.
- Add "force" option which will provide a delta to ensure the light is starting at the start value, ignoring whatever value it may already have. Then on subsequent runs it applies the delta for where it expects to be in the chain, not where it actually is.