### PR TITLE
#541 fix(api): HttpOnly cookie option should not be set

### DIFF
--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.7.1
 appVersion: 0.7.1
 dependencies:
   - name: api
-    version: 0.3.1
+    version: 0.3.2
   - name: config-server
     version: 0.1.19
     condition: global.config

--- a/kubernetes/charts/api/Chart.yaml
+++ b/kubernetes/charts/api/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: api
 description: A Helm chart for the PowerPi API service
 type: application
-version: 0.3.1
-appVersion: 1.1.1
+version: 0.3.2
+appVersion: 1.1.2

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@powerpi/api",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "PowerPi API",
     "private": true,
     "license": "GPL-3.0-only",

--- a/services/api/src/controllers/AuthController.ts
+++ b/services/api/src/controllers/AuthController.ts
@@ -87,7 +87,7 @@ export default class AuthController {
 
             response.cookie(JwtService.cookieKey, jwt, {
                 secure: this.config.usesHttps,
-                httpOnly: !this.config.usesHttps,
+                httpOnly: false,
                 sameSite: true,
                 expires: new Date(decoded.exp * 1000),
             });


### PR DESCRIPTION
In the API this was used as if it meant "not SSL", but that's not what it's for as it stops the cookie from being seen/used from the UI.

Fix that by setting the option to false.