### PR TITLE
refactor(zigbee): Many code improvements to pairing and ZigBee light/socket

### DIFF
--- a/controllers/zigbee/tests/device/test_zigbee_pairing.py
+++ b/controllers/zigbee/tests/device/test_zigbee_pairing.py
@@ -1,5 +1,5 @@
 from asyncio import Future
-from unittest.mock import MagicMock, PropertyMock
+from unittest.mock import MagicMock, PropertyMock, call
 
 import pytest
 from powerpi_common_test.device import DeviceTestBase
@@ -16,7 +16,8 @@ class TestZigbeePairingDevice(DeviceTestBase):
 
         await subject.pair()
 
-        zigbee_controller.pair.assert_called_once()
+        # once to turn it on with the timeout (1), then once to turn it off (0)
+        zigbee_controller.pair.assert_has_calls([call(1), call(0)])
 
         assert subject.state == 'off'
 

--- a/controllers/zigbee/tests/device/test_zigbee_pairing.py
+++ b/controllers/zigbee/tests/device/test_zigbee_pairing.py
@@ -20,13 +20,13 @@ class TestZigbeePairingDevice(DeviceTestBase):
 
         assert subject.state == 'off'
 
-    def test_device_joined(
+    def test_on_device_join(
         self,
         subject: ZigbeePairingDevice,
         powerpi_mqtt_producer: MagicMock,
         device: DeviceType
     ):
-        subject.device_joined(device)
+        subject.on_device_join(device)
 
         topic = 'device/ZigBeePairing/join'
         message = {

--- a/controllers/zigbee/tests/zigbee/mixins/test_on_off.py
+++ b/controllers/zigbee/tests/zigbee/mixins/test_on_off.py
@@ -10,9 +10,16 @@ from zigpy.zcl.foundation import Status
 from zigbee_controller.zigbee.mixins.on_off import ZigbeeOnOffMixin
 
 
-class TestDevice(ZigbeeOnOffMixin):
-    async def read_status(self, device):
-        return await self._read_status(device)
+class ExampleDevice(ZigbeeOnOffMixin):
+    def __init__(self, device):
+        self.__device = device
+
+    @property
+    def _zigbee_device(self):
+        return self.__device
+
+    async def read_status(self):
+        return await self._read_status()
 
 
 class TestZigbeeOnOffMixin:
@@ -20,9 +27,8 @@ class TestZigbeeOnOffMixin:
     @pytest.mark.parametrize('state', [True, False])
     async def test_read_status(
         self,
-        subject: TestDevice,
+        subject: ExampleDevice,
         cluster: Cluster,
-        zigbee_device,
         mocker: MockerFixture,
         state: bool,
     ):
@@ -37,7 +43,7 @@ class TestZigbeeOnOffMixin:
             read_attributes
         )
 
-        result = await subject.read_status(zigbee_device)
+        result = await subject.read_status()
 
         expected = DeviceStatus.ON if state else DeviceStatus.OFF
         assert result == expected
@@ -45,9 +51,8 @@ class TestZigbeeOnOffMixin:
     @pytest.mark.asyncio
     async def test_read_status_fails(
         self,
-        subject: TestDevice,
+        subject: ExampleDevice,
         cluster: Cluster,
-        zigbee_device,
         mocker: MockerFixture
     ):
         async def read_attributes(_):
@@ -59,13 +64,13 @@ class TestZigbeeOnOffMixin:
             read_attributes
         )
 
-        result = await subject.read_status(zigbee_device)
+        result = await subject.read_status()
 
         assert result == DeviceStatus.UNKNOWN
 
     @pytest.fixture
-    def subject(self):
-        return TestDevice()
+    def subject(self, zigbee_device):
+        return ExampleDevice(zigbee_device)
 
     @pytest.fixture(autouse=True)
     def cluster(self, zigbee_in_cluster: Cluster):

--- a/controllers/zigbee/zigbee_controller/device/zigbee_controller.py
+++ b/controllers/zigbee/zigbee_controller/device/zigbee_controller.py
@@ -1,7 +1,7 @@
 import os
 
 import zigpy
-from powerpi_common.logger import Logger
+from powerpi_common.logger import Logger, LogMixin
 from zigpy.types import EUI64
 from zigpy.typing import DeviceType
 from zigpy_znp.zigbee.application import ControllerApplication
@@ -9,12 +9,12 @@ from zigpy_znp.zigbee.application import ControllerApplication
 from zigbee_controller.config import ZigbeeConfig
 
 
-class ZigbeeController:
+class ZigbeeController(LogMixin):
     def __init__(self, config: ZigbeeConfig, logger: Logger):
         self.__config = config
-        self.__logger = logger
+        self._logger = logger
 
-        self.__logger.add_logger(zigpy.__name__)
+        self._logger.add_logger(zigpy.__name__)
 
         self.__controller: ControllerApplication | None = None
 
@@ -33,12 +33,12 @@ class ZigbeeController:
         try:
             self.__controller = await ControllerApplication.new(config, auto_form=True)
         except Exception as ex:
-            self.__logger.error('Could not initialise ZigBee device')
-            self.__logger.exception(ex)
+            self.log_error('Could not initialise ZigBee device')
+            self.log_exception(ex)
             os._exit(-1)
 
     async def shutdown(self):
-        self.__logger.info('Shutting down ZigBee device')
+        self.log_info('Shutting down ZigBee device')
         await self.__controller.shutdown()
 
     async def pair(self, time: int):

--- a/controllers/zigbee/zigbee_controller/device/zigbee_controller.py
+++ b/controllers/zigbee/zigbee_controller/device/zigbee_controller.py
@@ -25,7 +25,7 @@ class ZigbeeController:
         config = {
             'database_path': self.__config.database_path,
             'device': {
-                "path": self.__config.zigbee_device
+                'path': self.__config.zigbee_device
             }
         }
 

--- a/controllers/zigbee/zigbee_controller/device/zigbee_controller.py
+++ b/controllers/zigbee/zigbee_controller/device/zigbee_controller.py
@@ -23,8 +23,8 @@ class ZigbeeController:
 
     async def startup(self):
         config = {
-            "database_path": self.__config.database_path,
-            "device": {
+            'database_path': self.__config.database_path,
+            'device': {
                 "path": self.__config.zigbee_device
             }
         }

--- a/controllers/zigbee/zigbee_controller/device/zigbee_light.py
+++ b/controllers/zigbee/zigbee_controller/device/zigbee_light.py
@@ -22,7 +22,13 @@ from zigbee_controller.zigbee.mixins import ZigbeeOnOffMixin
 
 
 # pylint: disable=too-many-ancestors
-class ZigbeeLight(AdditionalStateDevice, PollableMixin, CapabilityMixin, ZigbeeMixin, ZigbeeOnOffMixin):
+class ZigbeeLight(
+    AdditionalStateDevice,
+    PollableMixin,
+    CapabilityMixin,
+    ZigbeeMixin,
+    ZigbeeOnOffMixin
+):
     '''
     Adds support for ZigBee RGB/temperature/brightness lights.
     '''

--- a/controllers/zigbee/zigbee_controller/device/zigbee_light.py
+++ b/controllers/zigbee/zigbee_controller/device/zigbee_light.py
@@ -124,7 +124,7 @@ class ZigbeeLight(AdditionalStateDevice, PollableMixin, CapabilityMixin, ZigbeeM
 
         try:
             # get the power state
-            new_state = await self._read_status(device)
+            new_state = await self._read_status()
             changed = new_state != self.state
 
             # get the additional state

--- a/controllers/zigbee/zigbee_controller/device/zigbee_light.py
+++ b/controllers/zigbee/zigbee_controller/device/zigbee_light.py
@@ -5,7 +5,7 @@ from typing import List, Tuple
 from powerpi_common.config import Config
 from powerpi_common.device import AdditionalStateDevice, DeviceStatus
 from powerpi_common.device.mixin import (AdditionalState, CapabilityMixin,
-                                         PollableMixin)
+                                         NewPollableMixin)
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
 from powerpi_common.util.data import DataType, Range, Ranges, Standardiser
@@ -24,7 +24,7 @@ from zigbee_controller.zigbee.mixins import ZigbeeOnOffMixin
 # pylint: disable=too-many-ancestors
 class ZigbeeLight(
     AdditionalStateDevice,
-    PollableMixin,
+    NewPollableMixin,
     CapabilityMixin,
     ZigbeeMixin,
     ZigbeeOnOffMixin
@@ -80,7 +80,7 @@ class ZigbeeLight(
         AdditionalStateDevice.__init__(
             self, config, logger, mqtt_client, **kwargs
         )
-        PollableMixin.__init__(self, config, **kwargs)
+        NewPollableMixin.__init__(self, config, **kwargs)
         ZigbeeMixin.__init__(self, controller, **kwargs)
 
         self.__duration = duration
@@ -121,7 +121,7 @@ class ZigbeeLight(
 
         return False
 
-    async def poll(self):
+    async def _poll(self):
         # we need the device to be initialised
         await self.__initialise()
 

--- a/controllers/zigbee/zigbee_controller/device/zigbee_pairing.py
+++ b/controllers/zigbee/zigbee_controller/device/zigbee_pairing.py
@@ -12,6 +12,7 @@ from zigbee_controller.device.zigbee_controller import ZigbeeController
 from zigbee_controller.zigbee import DeviceJoinListener
 
 
+# pylint: disable=too-many-ancestors
 class ZigbeePairingDevice(Device, InitialisableMixin):
     '''
     Device to allow new devices to be paired to the ZigBee controller managed by this service.

--- a/controllers/zigbee/zigbee_controller/device/zigbee_pairing.py
+++ b/controllers/zigbee/zigbee_controller/device/zigbee_pairing.py
@@ -49,7 +49,7 @@ class ZigbeePairingDevice(Device, InitialisableMixin):
         await self.__zigbee_controller.pair(self.__timeout)
         await asyncio.sleep(self.__timeout)
 
-        self.state = DeviceStatus.OFF
+        await self.turn_off()
 
     def on_device_join(self, device: DeviceType):
         self.log_info('New device joined network')

--- a/controllers/zigbee/zigbee_controller/device/zigbee_pairing.py
+++ b/controllers/zigbee/zigbee_controller/device/zigbee_pairing.py
@@ -40,11 +40,10 @@ class ZigbeePairingDevice(Device, InitialisableMixin):
 
     async def _turn_on(self):
         # run in a separate task so the off state happens after the on
-        task = self.pair()
-        asyncio.create_task(task)
+        asyncio.create_task(self.pair())
 
     async def _turn_off(self):
-        '''Pairing is automatically stopped after 120s.'''
+        await self.__zigbee_controller.pair(0)
 
     async def pair(self):
         await self.__zigbee_controller.pair(self.__timeout)

--- a/controllers/zigbee/zigbee_controller/device/zigbee_pairing.py
+++ b/controllers/zigbee/zigbee_controller/device/zigbee_pairing.py
@@ -11,6 +11,11 @@ from .zigbee_controller import ZigbeeController
 
 
 class ZigbeePairingDevice(Device):
+    '''
+    Device to allow new devices to be paired to the ZigBee controller managed by this service.
+    '''
+
+    # pylint: disable=too-many-arguments
     def __init__(
         self,
         config: Config,
@@ -33,7 +38,7 @@ class ZigbeePairingDevice(Device):
         loop.create_task(self.pair())
 
     async def _turn_off(self):
-        pass
+        '''Pairing is automatically stopped after 120s.'''
 
     async def pair(self):
         await self.__zigbee_controller.pair(self.__timeout)

--- a/controllers/zigbee/zigbee_controller/device/zigbee_socket.py
+++ b/controllers/zigbee/zigbee_controller/device/zigbee_socket.py
@@ -30,9 +30,7 @@ class ZigbeeSocket(Device, PollableMixin, ZigbeeMixin, ZigbeeOnOffMixin):
         ZigbeeMixin.__init__(self, controller, **kwargs)
 
     async def poll(self):
-        device = self._zigbee_device
-
-        new_state = await self._read_status(device)
+        new_state = await self._read_status()
 
         if new_state != self.state:
             await self.set_new_state(new_state)

--- a/controllers/zigbee/zigbee_controller/device/zigbee_socket.py
+++ b/controllers/zigbee/zigbee_controller/device/zigbee_socket.py
@@ -11,8 +11,8 @@ from zigbee_controller.zigbee.mixins import ZigbeeOnOffMixin
 from zigbee_controller.zigbee.constants import OnOff
 
 
+# pylint: disable=too-many-ancestors
 class ZigbeeSocket(Device, PollableMixin, ZigbeeMixin, ZigbeeOnOffMixin):
-    # pylint: disable=too-many-ancestors
     '''
     Add support for ZigBee sockets.
     '''

--- a/controllers/zigbee/zigbee_controller/device/zigbee_socket.py
+++ b/controllers/zigbee/zigbee_controller/device/zigbee_socket.py
@@ -1,6 +1,6 @@
 from powerpi_common.config import Config
 from powerpi_common.device import Device, DeviceStatus
-from powerpi_common.device.mixin import PollableMixin
+from powerpi_common.device.mixin import NewPollableMixin
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
 from zigpy.zcl.clusters.general import OnOff as OnOffCluster
@@ -12,7 +12,7 @@ from zigbee_controller.zigbee.constants import OnOff
 
 
 # pylint: disable=too-many-ancestors
-class ZigbeeSocket(Device, PollableMixin, ZigbeeMixin, ZigbeeOnOffMixin):
+class ZigbeeSocket(Device, NewPollableMixin, ZigbeeMixin, ZigbeeOnOffMixin):
     '''
     Add support for ZigBee sockets.
     '''
@@ -26,10 +26,10 @@ class ZigbeeSocket(Device, PollableMixin, ZigbeeMixin, ZigbeeOnOffMixin):
         **kwargs
     ):
         Device.__init__(self, config, logger, mqtt_client, **kwargs)
-        PollableMixin.__init__(self, config, **kwargs)
+        NewPollableMixin.__init__(self, config, **kwargs)
         ZigbeeMixin.__init__(self, controller, **kwargs)
 
-    async def poll(self):
+    async def _poll(self):
         new_state = await self._read_status()
 
         if new_state != self.state:

--- a/controllers/zigbee/zigbee_controller/zigbee/__init__.py
+++ b/controllers/zigbee/zigbee_controller/zigbee/__init__.py
@@ -3,4 +3,4 @@ from .cluster_listener import (ClusterAttributeListener,
                                ClusterGeneralCommandListener)
 from .constants import OnOff, OpenClose
 from .device import ZigbeeMixin
-from .zigbee_listener import DeviceAnnounceListener
+from .zigbee_listener import DeviceAnnounceListener, DeviceJoinListener

--- a/controllers/zigbee/zigbee_controller/zigbee/device.py
+++ b/controllers/zigbee/zigbee_controller/zigbee/device.py
@@ -13,13 +13,13 @@ class ZigbeeMixin(InitialisableMixin):
     def __init__(
         self,
         controller: ZigbeeController,
-        ieee: str,
-        nwk: str,
+        ieee: str | EUI64,
+        nwk: str | NWK,
         **_
     ):
         self.__controller = controller
-        self.__ieee = EUI64.convert(ieee)
-        self.__nwk = NWK.convert(nwk[2:])
+        self.__ieee = ieee if isinstance(ieee, EUI64) else EUI64.convert(ieee)
+        self.__nwk = nwk if isinstance(nwk, NWK) else NWK.convert(nwk[2:])
 
     @property
     def ieee(self):

--- a/controllers/zigbee/zigbee_controller/zigbee/mixins/on_off.py
+++ b/controllers/zigbee/zigbee_controller/zigbee/mixins/on_off.py
@@ -7,10 +7,14 @@ from zigpy.zcl.clusters.general import OnOff as OnOffCluster
 class ZigbeeOnOffMixin:
     '''
     Mixin to be used to provide utility methods when a device supports the OnOffCluster.
+    Expected to be used alongside ZigbeeMixin.
     '''
 
-    async def _read_status(self, device: DeviceType):
-        '''Retrieve the current status of the supplied device'''
+    async def _read_status(self):
+        '''Retrieve the current status of the ZigBee device.'''
+
+        device: DeviceType = self._zigbee_device
+
         try:
             cluster: OnOffCluster = device[1].in_clusters[OnOffCluster.cluster_id]
             values, _ = await cluster.read_attributes(['on_off'])

--- a/controllers/zigbee/zigbee_controller/zigbee/zigbee_listener.py
+++ b/controllers/zigbee/zigbee_controller/zigbee/zigbee_listener.py
@@ -15,3 +15,11 @@ class DeviceAnnounceListener(ZigBeeListener):
 
     def device_announce(self, device: DeviceType):
         self._listener(device)
+
+
+class DeviceJoinListener(ZigBeeListener):
+    def __init__(self, method: Callable[[DeviceType], None]):
+        ZigBeeListener.__init__(self, method)
+
+    def device_joined(self, device: DeviceType):
+        self._listener(device)


### PR DESCRIPTION
Doesn't fix the issue in #553, but worthy improvements.
- Use `NewPollableMixin` in `ZigbeeLight` and `ZigbeeSocket`.
- Make cluster mixin retrieve the device rather than passing it.
- Support being passed actual IEEE and NWK in `ZigbeeMixin`.
- Improvements to pairing so pressing the off button actually works.