### PR TITLE
#566 fix(sensors): Support both R10 and R11 certificate chain

### DIFF
--- a/sensors/Makefile.in
+++ b/sensors/Makefile.in
@@ -60,14 +60,18 @@ $(LIB_DIR)/Adafruit_Sensor-$(ADAFRUIT_SENSOR_VERSION):
 $(LIB_DIR)/DHT-sensor-library-$(DHT_SENSOR_VERSION):
 	$(call download_lib,DHT-sensor-library,$(DHT_SENSOR_VERSION),adafruit)
 
-# Download certificate
-$(LIB_DIR)/cert.pem:
+# Download certificates
+$(LIB_DIR)/r10.pem:
 	wget -O $@ https://letsencrypt.org/certs/2024/r10.pem
 
+$(LIB_DIR)/r11.pem:
+	wget -O $@ https://letsencrypt.org/certs/2024/r11.pem
+
 # Generate certificate header
-powerpi-sensor/cert.h: $(LIB_DIR)/cert.pem
+powerpi-sensor/cert.h: $(LIB_DIR)/r10.pem $(LIB_DIR)/r11.pem
 	cp powerpi-sensor/cert.h.in $@
-	sed -i -e '/@CERT@/{r $<' -e 'd}' $@
+	sed -i -e '/@R10@/{r $(LIB_DIR)/r10.pem' -e 'd}' $@
+	sed -i -e '/@R11@/{r $(LIB_DIR)/r10.pem' -e 'd}' $@
 
 # compile the sketch
 $(TARGET_DIR)/$(SKETCH).bin: powerpi-sensor/$(SKETCH) common_libraries dht22_libaries powerpi-sensor/cert.h

--- a/sensors/Makefile.in
+++ b/sensors/Makefile.in
@@ -62,7 +62,7 @@ $(LIB_DIR)/DHT-sensor-library-$(DHT_SENSOR_VERSION):
 
 # Download certificate
 $(LIB_DIR)/cert.pem:
-	wget -O $@ https://letsencrypt.org/certs/lets-encrypt-r3.pem
+	wget -O $@ https://letsencrypt.org/certs/2024/r10.pem
 
 # Generate certificate header
 powerpi-sensor/cert.h: $(LIB_DIR)/cert.pem

--- a/sensors/Makefile.in
+++ b/sensors/Makefile.in
@@ -71,7 +71,7 @@ $(LIB_DIR)/r11.pem:
 powerpi-sensor/cert.h: $(LIB_DIR)/r10.pem $(LIB_DIR)/r11.pem
 	cp powerpi-sensor/cert.h.in $@
 	sed -i -e '/@R10@/{r $(LIB_DIR)/r10.pem' -e 'd}' $@
-	sed -i -e '/@R11@/{r $(LIB_DIR)/r10.pem' -e 'd}' $@
+	sed -i -e '/@R11@/{r $(LIB_DIR)/r11.pem' -e 'd}' $@
 
 # compile the sketch
 $(TARGET_DIR)/$(SKETCH).bin: powerpi-sensor/$(SKETCH) common_libraries dht22_libaries powerpi-sensor/cert.h

--- a/sensors/configure.ac
+++ b/sensors/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([powerpi-sensor], [0.4.0])
+AC_INIT([powerpi-sensor], [0.4.1])
 
 dnl The arguments the user can override
 AC_ARG_VAR([location], [The location of this sensor])

--- a/sensors/powerpi-sensor/cert.h.in
+++ b/sensors/powerpi-sensor/cert.h.in
@@ -2,7 +2,7 @@
 #define __INCLUDED_CERT_H
 
 #ifdef MQTT_SSL
-const char cert_LetsEncrypt_R3 [] PROGMEM = R"CERT(
+const char cert_LetsEncrypt_R10[] PROGMEM = R"CERT(
 @CERT@
 )CERT";
 #endif

--- a/sensors/powerpi-sensor/cert.h.in
+++ b/sensors/powerpi-sensor/cert.h.in
@@ -3,7 +3,11 @@
 
 #ifdef MQTT_SSL
 const char cert_LetsEncrypt_R10[] PROGMEM = R"CERT(
-@CERT@
+@R10@
+)CERT";
+
+const char cert_LetsEncrypt_R11[] PROGMEM = R"CERT(
+@R11@
 )CERT";
 #endif
 

--- a/sensors/powerpi-sensor/mqtt.h
+++ b/sensors/powerpi-sensor/mqtt.h
@@ -44,7 +44,7 @@ WiFiClient espClient;
 
 #ifdef MQTT_SSL
 // the root CA
-X509List cert(cert_LetsEncrypt_R3);
+X509List cert(cert_LetsEncrypt_R10);
 #endif
 
 // the MQTT client
@@ -52,6 +52,6 @@ PubSubClient mqttClient(espClient);
 
 void setupMQTT();
 void connectMQTT(bool waitForNTP);
-void publish(const char action[], ArduinoJson::JsonDocument& message);
+void publish(const char action[], ArduinoJson::JsonDocument &message);
 
 #endif

--- a/sensors/powerpi-sensor/mqtt.h
+++ b/sensors/powerpi-sensor/mqtt.h
@@ -44,7 +44,8 @@ WiFiClient espClient;
 
 #ifdef MQTT_SSL
 // the root CA
-X509List cert(cert_LetsEncrypt_R10);
+X509List certR10(cert_LetsEncrypt_R10);
+X509List certR11(cert_LetsEncrypt_R11);
 #endif
 
 // the MQTT client

--- a/sensors/powerpi-sensor/mqtt.ino
+++ b/sensors/powerpi-sensor/mqtt.ino
@@ -1,6 +1,7 @@
 #include "mqtt.h"
 
-void setupMQTT() {
+void setupMQTT()
+{
     mqttClient.setServer(MQTT_SERVER, MQTT_PORT);
 
     Serial.print("Using MQTT: ");
@@ -8,40 +9,46 @@ void setupMQTT() {
     Serial.print(":");
     Serial.print(MQTT_PORT);
 
-    #ifdef MQTT_USER
-        Serial.print(" as ");
-        Serial.print(MQTT_USER);
-    #endif
+#ifdef MQTT_USER
+    Serial.print(" as ");
+    Serial.print(MQTT_USER);
+#endif
 
     Serial.println();
 }
 
-void connectMQTT(bool waitForNTP) {
-    #ifdef MQTT_SSL
-    espClient.setTrustAnchors(&cert);
-    #endif
+void connectMQTT(bool waitForNTP)
+{
+#ifdef MQTT_SSL
+    espClient.setTrustAnchors(&certR10);
+    espClient.setTrustAnchors(&certR11);
+#endif
 
     // wait until it's connected
-    while(!mqttClient.connected()) {
-        #ifdef MQTT_USER
-            bool connected = mqttClient.connect(HOSTNAME, MQTT_USER, MQTT_PASSWORD);
-        #else
-            bool connected = mqttClient.connect(HOSTNAME);
-        #endif
+    while (!mqttClient.connected())
+    {
+#ifdef MQTT_USER
+        bool connected = mqttClient.connect(HOSTNAME, MQTT_USER, MQTT_PASSWORD);
+#else
+        bool connected = mqttClient.connect(HOSTNAME);
+#endif
 
-        if(!connected) {
+        if (!connected)
+        {
             Serial.print("MQTT connection failed ");
             Serial.println(mqttClient.state());
-            
+
             delay(MQTT_ACTION_DELAY);
         }
     }
 
     // check NTP update has run
-    if(waitForNTP) {
+    if (waitForNTP)
+    {
         unsigned short retries = 0;
 
-        while(retries < MAX_NTP_RETRIES && timeClient.getEpochTime() < 24 * 60 * 60 * 1000) {
+        while (retries < MAX_NTP_RETRIES && timeClient.getEpochTime() < 24 * 60 * 60 * 1000)
+        {
             retries++;
 
             Serial.println("Waiting for NTP update");
@@ -50,13 +57,15 @@ void connectMQTT(bool waitForNTP) {
         }
 
         // restart the device if NTP isn't working
-        if(retries >= MAX_NTP_RETRIES) {
+        if (retries >= MAX_NTP_RETRIES)
+        {
             ESP.restart();
         }
     }
 }
 
-void publish(const char action[], ArduinoJson::JsonDocument& message) {
+void publish(const char action[], ArduinoJson::JsonDocument &message)
+{
     // retrieve the timestamp
     unsigned long long timestamp = timeClient.getEpochTime();
 
@@ -73,8 +82,8 @@ void publish(const char action[], ArduinoJson::JsonDocument& message) {
     connectMQTT(true);
     mqttClient.publish(topic, messageStr, true);
 
-    // wait for a moment if we're planning to deep sleep to ensure it sends
-    #ifdef DEEP_SLEEP
-        delay(MQTT_ACTION_DELAY);
-    #endif
+// wait for a moment if we're planning to deep sleep to ensure it sends
+#ifdef DEEP_SLEEP
+    delay(MQTT_ACTION_DELAY);
+#endif
 }


### PR DESCRIPTION
Fixes #566.
When new MQTT certificates are generated some times they have a different certificate chain; if that chain isn't in the sensor binary they won't be able to connect so include both R10 and R11 in the binary.