### PR TITLE
#566 fix(sensors): Use both LetsEncrypt root certificates in sensors

### DIFF
--- a/sensors/Makefile.in
+++ b/sensors/Makefile.in
@@ -61,17 +61,17 @@ $(LIB_DIR)/DHT-sensor-library-$(DHT_SENSOR_VERSION):
 	$(call download_lib,DHT-sensor-library,$(DHT_SENSOR_VERSION),adafruit)
 
 # Download certificates
-$(LIB_DIR)/r10.pem:
-	wget -O $@ https://letsencrypt.org/certs/2024/r10.pem
+$(LIB_DIR)/x1.pem:
+	wget -O $@ https://letsencrypt.org/certs/isrgrootx1.pem
 
-$(LIB_DIR)/r11.pem:
-	wget -O $@ https://letsencrypt.org/certs/2024/r11.pem
+$(LIB_DIR)/x2.pem:
+	wget -O $@ https://letsencrypt.org/certs/isrg-root-x2.pem
 
 # Generate certificate header
-powerpi-sensor/cert.h: $(LIB_DIR)/r10.pem $(LIB_DIR)/r11.pem
+powerpi-sensor/cert.h: $(LIB_DIR)/x1.pem $(LIB_DIR)/x2.pem
 	cp powerpi-sensor/cert.h.in $@
-	sed -i -e '/@R10@/{r $(LIB_DIR)/r10.pem' -e 'd}' $@
-	sed -i -e '/@R11@/{r $(LIB_DIR)/r11.pem' -e 'd}' $@
+	sed -i -e '/@X1@/{r $(LIB_DIR)/x1.pem' -e 'd}' $@
+	sed -i -e '/@X2@/{r $(LIB_DIR)/x2.pem' -e 'd}' $@
 
 # compile the sketch
 $(TARGET_DIR)/$(SKETCH).bin: powerpi-sensor/$(SKETCH) common_libraries dht22_libaries powerpi-sensor/cert.h

--- a/sensors/powerpi-sensor/cert.h.in
+++ b/sensors/powerpi-sensor/cert.h.in
@@ -2,12 +2,12 @@
 #define __INCLUDED_CERT_H
 
 #ifdef MQTT_SSL
-const char cert_LetsEncrypt_R10[] PROGMEM = R"CERT(
-@R10@
+const char cert_LetsEncrypt_X1[] PROGMEM = R"CERT(
+@X1@
 )CERT";
 
-const char cert_LetsEncrypt_R11[] PROGMEM = R"CERT(
-@R11@
+const char cert_LetsEncrypt_X2[] PROGMEM = R"CERT(
+@X2@
 )CERT";
 #endif
 

--- a/sensors/powerpi-sensor/cert.h.in
+++ b/sensors/powerpi-sensor/cert.h.in
@@ -2,11 +2,8 @@
 #define __INCLUDED_CERT_H
 
 #ifdef MQTT_SSL
-const char cert_LetsEncrypt_X1[] PROGMEM = R"CERT(
+const char certs_LetsEncrypt[] PROGMEM = R"CERT(
 @X1@
-)CERT";
-
-const char cert_LetsEncrypt_X2[] PROGMEM = R"CERT(
 @X2@
 )CERT";
 #endif

--- a/sensors/powerpi-sensor/mqtt.h
+++ b/sensors/powerpi-sensor/mqtt.h
@@ -43,9 +43,8 @@ WiFiClient espClient;
 #endif
 
 #ifdef MQTT_SSL
-// the root CA
-X509List certX1(cert_LetsEncrypt_X1);
-X509List certX2(cert_LetsEncrypt_X2);
+// the root CAs
+X509List certs(certs_LetsEncrypt);
 #endif
 
 // the MQTT client

--- a/sensors/powerpi-sensor/mqtt.h
+++ b/sensors/powerpi-sensor/mqtt.h
@@ -44,8 +44,8 @@ WiFiClient espClient;
 
 #ifdef MQTT_SSL
 // the root CA
-X509List certR10(cert_LetsEncrypt_R10);
-X509List certR11(cert_LetsEncrypt_R11);
+X509List certX1(cert_LetsEncrypt_X1);
+X509List certX2(cert_LetsEncrypt_X2);
 #endif
 
 // the MQTT client

--- a/sensors/powerpi-sensor/mqtt.ino
+++ b/sensors/powerpi-sensor/mqtt.ino
@@ -20,8 +20,7 @@ void setupMQTT()
 void connectMQTT(bool waitForNTP)
 {
 #ifdef MQTT_SSL
-    espClient.setTrustAnchors(&certX1);
-    espClient.setTrustAnchors(&certX2);
+    espClient.setTrustAnchors(&certs);
 #endif
 
     // wait until it's connected

--- a/sensors/powerpi-sensor/mqtt.ino
+++ b/sensors/powerpi-sensor/mqtt.ino
@@ -20,8 +20,8 @@ void setupMQTT()
 void connectMQTT(bool waitForNTP)
 {
 #ifdef MQTT_SSL
-    espClient.setTrustAnchors(&certR10);
-    espClient.setTrustAnchors(&certR11);
+    espClient.setTrustAnchors(&certX1);
+    espClient.setTrustAnchors(&certX2);
 #endif
 
     // wait until it's connected

--- a/sensors/powerpi-sensor/wifi.h
+++ b/sensors/powerpi-sensor/wifi.h
@@ -3,6 +3,8 @@
 
 #include <ESP8266WiFi.h>
 
+#include "config.h"
+
 void connectWiFi();
 
 #endif


### PR DESCRIPTION
Fixes #566 