### PR TITLE
#572 feat(zigbee): Update Aqara door/window sensor to use metric config

### DIFF
--- a/controllers/zigbee/tests/sensor/aqara/test_door_window_sensor.py
+++ b/controllers/zigbee/tests/sensor/aqara/test_door_window_sensor.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Tuple
 from unittest.mock import MagicMock
 
@@ -59,7 +59,8 @@ class TestAqaraDoorWindowSensor(SensorTestBase, InitialisableMixinTestBase, Batt
         value += data.to_bytes(2, 'little')
         value = value.decode('utf8')
 
-        subject.on_attribute_updated(0xFF01, value, datetime.utcnow())
+        subject.on_attribute_updated(
+            0xFF01, value, datetime.now(timezone.utc))
 
         topic = 'event/test/battery'
         message = {'value': percent, 'unit': '%'}
@@ -79,7 +80,8 @@ class TestAqaraDoorWindowSensor(SensorTestBase, InitialisableMixinTestBase, Batt
         value += b'\x21\x00\x00'
         value = value.decode('utf8')
 
-        subject.on_attribute_updated(attribute_id, value, datetime.utcnow())
+        subject.on_attribute_updated(
+            attribute_id, value, datetime.now(timezone.utc))
 
         powerpi_mqtt_producer.assert_not_called()
 

--- a/controllers/zigbee/tests/sensor/aqara/test_door_window_sensor.py
+++ b/controllers/zigbee/tests/sensor/aqara/test_door_window_sensor.py
@@ -9,9 +9,18 @@ from powerpi_common_test.sensor.mixin import BatteryMixinTestBase
 
 from zigbee_controller.sensor.aqara.door_window_sensor import \
     AqaraDoorWindowSensor
+from zigbee_controller.sensor.metrics import Metric
 
 
 class TestAqaraDoorWindowSensor(SensorTestBase, InitialisableMixinTestBase, BatteryMixinTestBase):
+    def test_sensor_type(
+        self,
+        subject: AqaraDoorWindowSensor,
+        subject_window: AqaraDoorWindowSensor
+    ):
+        assert subject.sensor_type == Metric.DOOR
+        assert subject_window.sensor_type == Metric.WINDOW
+
     @pytest.mark.parametrize(
         'values', [(0, 'close'), (1, 'open'), (False, 'close'), (True, 'open')]
     )
@@ -92,6 +101,15 @@ class TestAqaraDoorWindowSensor(SensorTestBase, InitialisableMixinTestBase, Batt
             ieee='00:00:00:00:00:00:00:00', nwk='0xAAAA',
             name='test',
             metrics={'door': 'visible'},
+        )
+
+    @pytest.fixture
+    def subject_window(self, powerpi_logger, zigbee_controller, powerpi_mqtt_client):
+        return AqaraDoorWindowSensor(
+            powerpi_logger, zigbee_controller, powerpi_mqtt_client,
+            ieee='00:00:00:00:00:00:00:00', nwk='0xAAAA',
+            name='test',
+            metrics={'window': 'visible'},
         )
 
     def __verify_publish(self, powerpi_mqtt_producer: MagicMock, state: str):

--- a/controllers/zigbee/tests/sensor/aqara/test_door_window_sensor.py
+++ b/controllers/zigbee/tests/sensor/aqara/test_door_window_sensor.py
@@ -88,11 +88,12 @@ class TestAqaraDoorWindowSensor(SensorTestBase, InitialisableMixinTestBase, Batt
         return AqaraDoorWindowSensor(
             powerpi_logger, zigbee_controller, powerpi_mqtt_client,
             ieee='00:00:00:00:00:00:00:00', nwk='0xAAAA',
-            name='test'
+            name='test',
+            metrics={'door': 'visible'},
         )
 
     def __verify_publish(self, powerpi_mqtt_producer: MagicMock, state: str):
-        topic = 'event/test/change'
+        topic = 'event/test/door'
 
         message = {'state': state}
 

--- a/controllers/zigbee/zigbee_controller/sensor/aqara/door_window_sensor.py
+++ b/controllers/zigbee/zigbee_controller/sensor/aqara/door_window_sensor.py
@@ -58,10 +58,10 @@ class AqaraDoorWindowSensor(Sensor, ZigbeeMixin, BatteryMixin):
 
     @property
     def sensor_type(self):
-        if MetricValue.is_enabled(self.__metrics[Metric.DOOR]):
+        if MetricValue.is_enabled(self.__metrics, Metric.DOOR):
             return Metric.DOOR
 
-        if MetricValue.is_enabled(self.__metrics[Metric.WINDOW]):
+        if MetricValue.is_enabled(self.__metrics, Metric.WINDOW):
             return Metric.WINDOW
 
         return None

--- a/controllers/zigbee/zigbee_controller/sensor/aqara/door_window_sensor.py
+++ b/controllers/zigbee/zigbee_controller/sensor/aqara/door_window_sensor.py
@@ -9,6 +9,7 @@ from zigpy.zcl.clusters.general import OnOff as OnOffCluster
 from zigpy.zcl.foundation import Attribute, TypeValue
 
 from zigbee_controller.device import ZigbeeController
+from zigbee_controller.sensor.metrics import Metric, MetricValue
 from zigbee_controller.zigbee import (ClusterAttributeListener,
                                       ClusterGeneralCommandListener, OnOff,
                                       OpenClose, ZigbeeMixin)
@@ -20,10 +21,10 @@ class AqaraDoorWindowSensor(Sensor, ZigbeeMixin, BatteryMixin):
     Generates the following events on open/close.
 
     Open:
-    /event/NAME/change:{"state": "open"}
+    /event/NAME/(door|window):{"state": "open"}
 
     Close:
-    /event/NAME/change:{"state": "close"}
+    /event/NAME/(door|window):{"state": "close"}
     '''
 
     # the additional attribute id returned by this device
@@ -44,13 +45,26 @@ class AqaraDoorWindowSensor(Sensor, ZigbeeMixin, BatteryMixin):
         logger: Logger,
         controller: ZigbeeController,
         mqtt_client: MQTTClient,
+        metrics: Dict[Metric, MetricValue],
         **kwargs
     ):
         Sensor.__init__(self, mqtt_client, **kwargs)
         ZigbeeMixin.__init__(self, controller, **kwargs)
         BatteryMixin.__init__(self)
 
+        self.__metrics = metrics
+
         self._logger = logger
+
+    @property
+    def sensor_type(self):
+        if MetricValue.is_enabled(self.__metrics[Metric.DOOR]):
+            return Metric.DOOR
+
+        if MetricValue.is_enabled(self.__metrics[Metric.WINDOW]):
+            return Metric.WINDOW
+
+        return None
 
     def open_close_handler(self, on_off: OnOff):
         self.log_info(f'Received {on_off} from door/window sensor')
@@ -61,10 +75,12 @@ class AqaraDoorWindowSensor(Sensor, ZigbeeMixin, BatteryMixin):
         elif on_off == OnOff.OFF:
             state = OpenClose.CLOSE
 
-        if state:
+        action = self.sensor_type
+
+        if state and action:
             message = {'state': state}
 
-            self._broadcast('change', message)
+            self._broadcast(action, message)
 
     def on_attribute_updated(self, attribute_id: int, value: Any, _):
         if attribute_id == self.AQARA_ATTRIBUTE:

--- a/controllers/zigbee/zigbee_controller/sensor/metrics.py
+++ b/controllers/zigbee/zigbee_controller/sensor/metrics.py
@@ -3,9 +3,11 @@ from enum import StrEnum, unique
 
 @unique
 class Metric(StrEnum):
+    DOOR = 'door'
     POWER = 'power'
     CURRENT = 'current'
     VOLTAGE = 'voltage'
+    WINDOW = 'window'
 
 
 @unique

--- a/controllers/zigbee/zigbee_controller/sensor/metrics.py
+++ b/controllers/zigbee/zigbee_controller/sensor/metrics.py
@@ -1,4 +1,5 @@
 from enum import StrEnum, unique
+from typing import Dict, TypeVar
 
 
 @unique
@@ -10,6 +11,9 @@ class Metric(StrEnum):
     WINDOW = 'window'
 
 
+MetricValueT = TypeVar('MetricValueT', bound='MetricValue')
+
+
 @unique
 class MetricValue(StrEnum):
     NONE = 'none'
@@ -17,5 +21,5 @@ class MetricValue(StrEnum):
     VISIBLE = 'visible'
 
     @staticmethod
-    def is_enabled(value):
-        return value in [MetricValue.READ, MetricValue.VISIBLE]
+    def is_enabled(metrics: Dict[Metric, MetricValueT], value: MetricValueT):
+        return value in metrics and metrics[value] in [MetricValue.READ, MetricValue.VISIBLE]

--- a/controllers/zigbee/zigbee_controller/sensor/metrics.py
+++ b/controllers/zigbee/zigbee_controller/sensor/metrics.py
@@ -1,0 +1,19 @@
+from enum import StrEnum, unique
+
+
+@unique
+class Metric(StrEnum):
+    POWER = 'power'
+    CURRENT = 'current'
+    VOLTAGE = 'voltage'
+
+
+@unique
+class MetricValue(StrEnum):
+    NONE = 'none'
+    READ = 'read'
+    VISIBLE = 'visible'
+
+    @staticmethod
+    def is_enabled(value):
+        return value in [MetricValue.READ, MetricValue.VISIBLE]

--- a/controllers/zigbee/zigbee_controller/sensor/zigbee_energy_monitor.py
+++ b/controllers/zigbee/zigbee_controller/sensor/zigbee_energy_monitor.py
@@ -1,4 +1,3 @@
-from enum import StrEnum, unique
 from typing import Dict
 
 from powerpi_common.logger import Logger
@@ -9,26 +8,9 @@ from zigpy.zcl.clusters import Cluster
 from zigpy.zcl.foundation import Attribute
 
 from zigbee_controller.device import ZigbeeController
+from zigbee_controller.sensor.metrics import Metric, MetricValue
 from zigbee_controller.zigbee import ZigbeeMixin
 from zigbee_controller.zigbee.mixins import ZigbeeReportMixin
-
-
-@unique
-class Metric(StrEnum):
-    POWER = 'power'
-    CURRENT = 'current'
-    VOLTAGE = 'voltage'
-
-
-@unique
-class MetricValue(StrEnum):
-    NONE = 'none'
-    READ = 'read'
-    VISIBLE = 'visible'
-
-    @staticmethod
-    def is_enabled(value):
-        return value in [MetricValue.READ, MetricValue.VISIBLE]
 
 
 class ZigbeeEnergyMonitorSensor(Sensor, ZigbeeReportMixin, ZigbeeMixin):

--- a/controllers/zigbee/zigbee_controller/sensor/zigbee_energy_monitor.py
+++ b/controllers/zigbee/zigbee_controller/sensor/zigbee_energy_monitor.py
@@ -41,15 +41,15 @@ class ZigbeeEnergyMonitorSensor(Sensor, ZigbeeReportMixin, ZigbeeMixin):
 
     @property
     def power_enabled(self):
-        return MetricValue.is_enabled(self.__metrics[Metric.POWER])
+        return MetricValue.is_enabled(self.__metrics, Metric.POWER)
 
     @property
     def current_enabled(self):
-        return MetricValue.is_enabled(self.__metrics[Metric.CURRENT])
+        return MetricValue.is_enabled(self.__metrics, Metric.CURRENT)
 
     @property
     def voltage_enabled(self):
-        return MetricValue.is_enabled(self.__metrics[Metric.VOLTAGE])
+        return MetricValue.is_enabled(self.__metrics, Metric.VOLTAGE)
 
     def on_report(self, cluster: Cluster, attribute: Attribute):
         if cluster.cluster_id != ElectricalMeasurement.cluster_id:


### PR DESCRIPTION
Use the new metric syntax when configuring the Aqara door/window sensor.
- Uses the metrics syntax:
```json
{ "metrics": { "door": "visible", "window": "visible" } }
```
- Now outputs using the action `door` or `window` instead of `change`.
- Fix, metrics that weren't set would cause errors.