### PR TITLE
#594 feat(shutdown): Add support for brightness additional state in shutdown service

### DIFF
--- a/kubernetes/charts/mosquitto/acl.conf
+++ b/kubernetes/charts/mosquitto/acl.conf
@@ -15,6 +15,7 @@ topic readwrite powerpi/event/#
 user device
 topic read powerpi/device/+/change
 topic readwrite powerpi/device/+/status
+topic readwrite powerpi/device/+/capability
 
 user event
 topic read powerpi/config/devices/change

--- a/services/shutdown/Makefile
+++ b/services/shutdown/Makefile
@@ -7,7 +7,7 @@ TARGET_OS?=linux
 TARGET_ARCH?=arm64
 
 # the version of the shutdown service
-VERSION=0.1.2
+VERSION=0.2.0
 
 all: compile
 

--- a/services/shutdown/README.md
+++ b/services/shutdown/README.md
@@ -2,6 +2,10 @@
 
 PowerPi shutdown service runs on a computer which you would like PowerPi to be able to control, (like those that can be started with wake-on-LAN using the [_network_controller_](../../controllers/network/README.md)).
 
+The service also supports limited additional state as follows.
+
+- Writing a brightness value to a file to adjust the brightness of an LED/Display (e.g. [Raspberry Pi Touch Display 2](https://www.raspberrypi.com/products/touch-display-2/))
+
 The service is built using Go.
 
 ## Building
@@ -73,6 +77,12 @@ The service takes the following command line arguments:
 ```
   -allowQuickShutdown
     	If true allow a message within 2 minutes of service starting to initiate a shutdown
+  -brightnessDevice string
+    	The path to the device to use for controller brightness, e.g. "/sys/class/backlight/10-0045/brightness" for a Pi Touch Display 2
+  -brightnessMax float
+    	The maximum value supported for the brightness setting, e.g. 31 for a Pi Touch Display 2 (default 100)
+  -brightnessMin float
+    	The minimum value supported for the brightness setting, e.g. 0 for a Pi Touch Display 2
   -host string
     	The hostname of the MQTT broker (default "localhost")
   -mock

--- a/services/shutdown/src/additional/additional.go
+++ b/services/shutdown/src/additional/additional.go
@@ -4,18 +4,35 @@ import (
 	"powerpi/shutdown/additional/brightness"
 )
 
+type AdditionalStateDevice struct {
+	Brightness *string
+}
+
 type AdditionalState struct {
 	Brightness *int
 }
 
-func GetAdditionalState(brightnessDevice *brightness.BrightnessDevice) AdditionalState {
+func GetAdditionalState(device AdditionalStateDevice) AdditionalState {
 	var additionalState AdditionalState
 
-	if brightnessDevice != nil {
+	if device.Brightness != nil {
 		var brightnessValue *int = new(int)
-		*brightnessValue = brightness.GetBrightness(*brightnessDevice)
-		additionalState.Brightness = brightnessValue
+		*brightnessValue = brightness.GetBrightness(*device.Brightness)
+
+		if *brightnessValue >= 0 {
+			additionalState.Brightness = brightnessValue
+		}
 	}
 
 	return additionalState
+}
+
+func SetAdditionalState(device AdditionalStateDevice, state AdditionalState) {
+	if device.Brightness != nil && state.Brightness != nil && *state.Brightness >= 0 {
+		brightness.SetBrightness(*device.Brightness, *state.Brightness)
+	}
+}
+
+func CompareAdditionalState(state1 AdditionalState, state2 AdditionalState) bool {
+	return state1.Brightness == state2.Brightness
 }

--- a/services/shutdown/src/additional/additional.go
+++ b/services/shutdown/src/additional/additional.go
@@ -2,22 +2,19 @@ package additional
 
 import (
 	"powerpi/shutdown/additional/brightness"
+	"powerpi/shutdown/flags"
 )
-
-type AdditionalStateDevice struct {
-	Brightness *string
-}
 
 type AdditionalState struct {
 	Brightness *int
 }
 
-func GetAdditionalState(device AdditionalStateDevice) AdditionalState {
+func GetAdditionalState(config flags.AdditionalStateConfig) AdditionalState {
 	var additionalState AdditionalState
 
-	if device.Brightness != nil {
+	if len(config.Brightness.Device) > 0 {
 		var brightnessValue *int = new(int)
-		*brightnessValue = brightness.GetBrightness(*device.Brightness)
+		*brightnessValue = brightness.GetBrightness(config.Brightness)
 
 		if *brightnessValue >= 0 {
 			additionalState.Brightness = brightnessValue
@@ -27,9 +24,9 @@ func GetAdditionalState(device AdditionalStateDevice) AdditionalState {
 	return additionalState
 }
 
-func SetAdditionalState(device AdditionalStateDevice, state AdditionalState) {
-	if device.Brightness != nil && state.Brightness != nil && *state.Brightness >= 0 {
-		brightness.SetBrightness(*device.Brightness, *state.Brightness)
+func SetAdditionalState(config flags.AdditionalStateConfig, state AdditionalState) {
+	if len(config.Brightness.Device) > 0 && state.Brightness != nil && *state.Brightness >= 0 {
+		brightness.SetBrightness(config.Brightness, *state.Brightness)
 	}
 }
 

--- a/services/shutdown/src/additional/additional.go
+++ b/services/shutdown/src/additional/additional.go
@@ -1,0 +1,21 @@
+package additional
+
+import (
+	"powerpi/shutdown/additional/brightness"
+)
+
+type AdditionalState struct {
+	Brightness *int
+}
+
+func GetAdditionalState(brightnessDevice *brightness.BrightnessDevice) AdditionalState {
+	var additionalState AdditionalState
+
+	if brightnessDevice != nil {
+		var brightnessValue *int = new(int)
+		*brightnessValue = brightness.GetBrightness(*brightnessDevice)
+		additionalState.Brightness = brightnessValue
+	}
+
+	return additionalState
+}

--- a/services/shutdown/src/additional/brightness/brightness.go
+++ b/services/shutdown/src/additional/brightness/brightness.go
@@ -14,7 +14,7 @@ func GetBrightness(device string) int {
 	brightnessFile := getBrightnessFile(device)
 	brightnessRange := getBrightnessRange(device)
 	if brightnessFile == "" || brightnessRange.min == -1 || brightnessRange.max == -1 {
-		fmt.Printf("Unrecognised brightness device %s", device)
+		fmt.Printf("Unrecognised brightness device %s\n", device)
 		return -1
 	}
 
@@ -30,8 +30,8 @@ func GetBrightness(device string) int {
 		panic(err)
 	}
 
-	brightness := int((value - brightnessRange.min) / brightnessRange.max * 100)
-	fmt.Printf("Read brightness %d (%d%%)", value, brightness)
+	brightness := int(float64(value - brightnessRange.min) / float64(brightnessRange.max) * 100.0)
+	fmt.Printf("Read brightness %d (%d%%)\n", value, brightness)
 	return brightness
 }
 
@@ -39,12 +39,12 @@ func SetBrightness(device string, value int) {
 	brightnessFile := getBrightnessFile(device)
 	brightnessRange := getBrightnessRange(device)
 	if brightnessFile == "" || brightnessRange.min == -1 || brightnessRange.max == -1 {
-		fmt.Printf("Unrecognised brightness device %s", device)
+		fmt.Printf("Unrecognised brightness device %s\n", device)
 		return
 	}
 
-	brightness := int((value / 100) * (brightnessRange.max - brightnessRange.min))
-	fmt.Printf("Wrote brightness %d (%d%%)", brightness, value)
+	brightness := int(((float64(value) / 100.0) * brightnessRange.max) + brightnessRange.min)
+	fmt.Printf("Wrote brightness %d (%d%%)\n", brightness, value)
 
 	err := os.WriteFile(brightnessFile, []byte(string(brightness)), 0777)
 	if err != nil {

--- a/services/shutdown/src/additional/brightness/brightness.go
+++ b/services/shutdown/src/additional/brightness/brightness.go
@@ -1,0 +1,68 @@
+package brightness
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+type BrightnessDevice string
+const (
+	PiTouchDisplay2 BrightnessDevice = "pi-touch-display-2"
+)
+
+func GetBrightness(device BrightnessDevice) int {
+	brightnessFile := getBrightnessFile(device)
+	brightnessRange := getBrightnessRange(device)
+	if brightnessFile == "" || brightnessRange.min == -1 || brightnessRange.max == -1 {
+		fmt.Printf("Unrecognised brightness device %s", device)
+		return -1
+	}
+
+	data, err := os.ReadFile(brightnessFile)
+	if err != nil {
+		panic(err)
+	}
+
+	value, err := strconv.Atoi(string(data))
+	if err != nil {
+		panic(err)
+	}
+
+	brightness := (value - brightnessRange.min) / brightnessRange.max * 100
+	return brightness
+}
+
+func SetBrightness(device BrightnessDevice, brightness int) {
+	brightnessFile := getBrightnessFile(device)
+	brightnessRange := getBrightnessRange(device)
+	if brightnessFile == "" || brightnessRange.min == -1 || brightnessRange.max == -1 {
+		fmt.Printf("Unrecognised brightness device %s", device)
+		return
+	}
+
+	err := os.WriteFile(brightnessFile, []byte(string(brightness)), 0777)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func getBrightnessFile(device BrightnessDevice) string {
+	switch device {
+		case PiTouchDisplay2:
+			return "/sys/class/backlight/10-0045"
+
+		default:
+			return ""
+	}
+}
+
+func getBrightnessRange(device BrightnessDevice) struct {min int; max int} {
+	switch device {
+		case PiTouchDisplay2:
+			return struct {min int; max int} { 0, 31 }
+
+		default:
+			return struct {min int; max int} { -1, -1 }
+	}
+}

--- a/services/shutdown/src/additional/brightness/brightness.go
+++ b/services/shutdown/src/additional/brightness/brightness.go
@@ -5,20 +5,12 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"powerpi/shutdown/flags"
 )
 
-const PiTouchDisplay2 = "pi-touch-display-2"
-
-
-func GetBrightness(device string) int {
-	brightnessFile := getBrightnessFile(device)
-	brightnessRange := getBrightnessRange(device)
-	if brightnessFile == "" || brightnessRange.min == -1 || brightnessRange.max == -1 {
-		fmt.Printf("Unrecognised brightness device %s\n", device)
-		return -1
-	}
-
-	data, err := os.ReadFile(brightnessFile)
+func GetBrightness(config flags.BrightnessConfig) int {
+	data, err := os.ReadFile(config.Device)
 	if err != nil {
 		panic(err)
 	}
@@ -30,45 +22,18 @@ func GetBrightness(device string) int {
 		panic(err)
 	}
 
-	brightness := int((float64(value) - brightnessRange.min) / brightnessRange.max * 100.0)
+	brightness := int((float64(value) - config.Min) / config.Max * 100.0)
 	fmt.Printf("Read brightness %d (%d%%)\n", value, brightness)
 	return brightness
 }
 
-func SetBrightness(device string, value int) {
-	brightnessFile := getBrightnessFile(device)
-	brightnessRange := getBrightnessRange(device)
-	if brightnessFile == "" || brightnessRange.min == -1 || brightnessRange.max == -1 {
-		fmt.Printf("Unrecognised brightness device %s\n", device)
-		return
-	}
-
-	brightness := int(((float64(value) / 100.0) * brightnessRange.max) + brightnessRange.min)
+func SetBrightness(config flags.BrightnessConfig, value int) {
+	brightness := int(((float64(value) / 100.0) * config.Max) + config.Min)
 	fmt.Printf("Wrote brightness %d (%d%%)\n", brightness, value)
 
 	data := fmt.Sprintf("%d\n", brightness)
-	err := os.WriteFile(brightnessFile, []byte(data), 0777)
+	err := os.WriteFile(config.Device, []byte(data), 0777)
 	if err != nil {
 		panic(err)
-	}
-}
-
-func getBrightnessFile(device string) string {
-	switch device {
-		case PiTouchDisplay2:
-			return "/sys/class/backlight/10-0045/brightness"
-
-		default:
-			return ""
-	}
-}
-
-func getBrightnessRange(device string) struct {min float64; max float64} {
-	switch device {
-		case PiTouchDisplay2:
-			return struct {min float64; max float64} { 0, 31 }
-
-		default:
-			return struct {min float64; max float64} { -1, -1 }
 	}
 }

--- a/services/shutdown/src/additional/brightness/brightness.go
+++ b/services/shutdown/src/additional/brightness/brightness.go
@@ -30,7 +30,7 @@ func GetBrightness(device string) int {
 		panic(err)
 	}
 
-	brightness := int(float64(value - brightnessRange.min) / float64(brightnessRange.max) * 100.0)
+	brightness := int((float64(value) - brightnessRange.min) / brightnessRange.max * 100.0)
 	fmt.Printf("Read brightness %d (%d%%)\n", value, brightness)
 	return brightness
 }
@@ -46,7 +46,8 @@ func SetBrightness(device string, value int) {
 	brightness := int(((float64(value) / 100.0) * brightnessRange.max) + brightnessRange.min)
 	fmt.Printf("Wrote brightness %d (%d%%)\n", brightness, value)
 
-	err := os.WriteFile(brightnessFile, []byte(string(brightness)), 0777)
+	data := fmt.Sprintf("%d\n", brightness)
+	err := os.WriteFile(brightnessFile, []byte(data), 0777)
 	if err != nil {
 		panic(err)
 	}
@@ -62,12 +63,12 @@ func getBrightnessFile(device string) string {
 	}
 }
 
-func getBrightnessRange(device string) struct {min int; max int} {
+func getBrightnessRange(device string) struct {min float64; max float64} {
 	switch device {
 		case PiTouchDisplay2:
-			return struct {min int; max int} { 0, 31 }
+			return struct {min float64; max float64} { 0, 31 }
 
 		default:
-			return struct {min int; max int} { -1, -1 }
+			return struct {min float64; max float64} { -1, -1 }
 	}
 }

--- a/services/shutdown/src/additional/brightness/brightness.go
+++ b/services/shutdown/src/additional/brightness/brightness.go
@@ -6,12 +6,10 @@ import (
 	"strconv"
 )
 
-type BrightnessDevice string
-const (
-	PiTouchDisplay2 BrightnessDevice = "pi-touch-display-2"
-)
+const PiTouchDisplay2 = "pi-touch-display-2"
 
-func GetBrightness(device BrightnessDevice) int {
+
+func GetBrightness(device string) int {
 	brightnessFile := getBrightnessFile(device)
 	brightnessRange := getBrightnessRange(device)
 	if brightnessFile == "" || brightnessRange.min == -1 || brightnessRange.max == -1 {
@@ -33,7 +31,7 @@ func GetBrightness(device BrightnessDevice) int {
 	return brightness
 }
 
-func SetBrightness(device BrightnessDevice, brightness int) {
+func SetBrightness(device string, brightness int) {
 	brightnessFile := getBrightnessFile(device)
 	brightnessRange := getBrightnessRange(device)
 	if brightnessFile == "" || brightnessRange.min == -1 || brightnessRange.max == -1 {
@@ -47,7 +45,7 @@ func SetBrightness(device BrightnessDevice, brightness int) {
 	}
 }
 
-func getBrightnessFile(device BrightnessDevice) string {
+func getBrightnessFile(device string) string {
 	switch device {
 		case PiTouchDisplay2:
 			return "/sys/class/backlight/10-0045"
@@ -57,7 +55,7 @@ func getBrightnessFile(device BrightnessDevice) string {
 	}
 }
 
-func getBrightnessRange(device BrightnessDevice) struct {min int; max int} {
+func getBrightnessRange(device string) struct {min int; max int} {
 	switch device {
 		case PiTouchDisplay2:
 			return struct {min int; max int} { 0, 31 }

--- a/services/shutdown/src/flags/flags.go
+++ b/services/shutdown/src/flags/flags.go
@@ -1,0 +1,56 @@
+package flags
+
+import (
+	"flag"
+)
+
+type Config struct {
+	Mqtt MqttConfig
+	AdditionalState AdditionalStateConfig
+
+	AllowQuickShutdown bool
+	Mock bool
+}
+
+type MqttConfig struct {
+	Host string
+	Port int
+	User string
+	PasswordFile string
+	TopicBase string
+}
+
+type AdditionalStateConfig struct {
+	Brightness BrightnessConfig
+}
+
+type BrightnessConfig struct {
+	Device string
+	Min float64
+	Max float64
+}
+
+func ParseFlags() Config {
+	var config Config
+
+	// MQTT
+	flag.StringVar(&config.Mqtt.Host, "host", "localhost", "The hostname of the MQTT broker")
+	flag.IntVar(&config.Mqtt.Port, "port", 1883, "The port number for the MQTT broker")
+	flag.StringVar(&config.Mqtt.User, "user", "device", "The username for the MQTT broker")
+	flag.StringVar(&config.Mqtt.PasswordFile, "password", "undefined", "The path to the password file")
+	flag.StringVar(&config.Mqtt.TopicBase, "topic", "powerpi", "The topic base for the MQTT broker")
+
+	// additional state
+	// brightness
+	flag.StringVar(&config.AdditionalState.Brightness.Device, "brightnessDevice", "", "The path to the device to use for controller brightness")
+	flag.Float64Var(&config.AdditionalState.Brightness.Min, "brightnessMin", 0.0, "The minimum value supported for the brightness setting")
+	flag.Float64Var(&config.AdditionalState.Brightness.Max, "brightnessMax", 100.0, "The maximum value supported for the brightness setting")
+	
+	// others
+	flag.BoolVar(&config.AllowQuickShutdown, "allowQuickShutdown", false, "If true allow a message within 2 minutes of service starting to initiate a shutdown")
+	flag.BoolVar(&config.Mock, "mock", false, "Whether to actually shutdown or not")
+	
+	flag.Parse()
+
+	return config
+}

--- a/services/shutdown/src/flags/flags.go
+++ b/services/shutdown/src/flags/flags.go
@@ -42,9 +42,9 @@ func ParseFlags() Config {
 
 	// additional state
 	// brightness
-	flag.StringVar(&config.AdditionalState.Brightness.Device, "brightnessDevice", "", "The path to the device to use for controller brightness")
-	flag.Float64Var(&config.AdditionalState.Brightness.Min, "brightnessMin", 0.0, "The minimum value supported for the brightness setting")
-	flag.Float64Var(&config.AdditionalState.Brightness.Max, "brightnessMax", 100.0, "The maximum value supported for the brightness setting")
+	flag.StringVar(&config.AdditionalState.Brightness.Device, "brightnessDevice", "", "The path to the device to use for controller brightness, e.g. \"/sys/class/backlight/10-0045/brightness\" for a Pi Touch Display 2")
+	flag.Float64Var(&config.AdditionalState.Brightness.Min, "brightnessMin", 0.0, "The minimum value supported for the brightness setting, e.g. 0 for a Pi Touch Display 2")
+	flag.Float64Var(&config.AdditionalState.Brightness.Max, "brightnessMax", 100.0, "The maximum value supported for the brightness setting, e.g. 31 for a Pi Touch Display 2")
 	
 	// others
 	flag.BoolVar(&config.AllowQuickShutdown, "allowQuickShutdown", false, "If true allow a message within 2 minutes of service starting to initiate a shutdown")

--- a/services/shutdown/src/main.go
+++ b/services/shutdown/src/main.go
@@ -49,8 +49,8 @@ func main() {
 	signal.Notify(channel, os.Interrupt, syscall.SIGTERM)
 
 	// connect to MQTT
-	callback := func(client mqtt.MqttClient, state mqtt.DeviceState) {
-		updateState(client, state, *mock, startTime)
+	callback := func(client mqtt.MqttClient, state mqtt.DeviceState, additionalState mqtt.AdditionalState) {
+		updateState(client, state, additionalState, *mock, startTime)
 	} 
 	client := mqtt.New(hostname, *topicBase, callback)
 	client.Connect(*host, *port, user, password)
@@ -59,7 +59,7 @@ func main() {
 	<-channel
 }
 
-func updateState(client mqtt.MqttClient, state mqtt.DeviceState, mock bool, startTime time.Time) {
+func updateState(client mqtt.MqttClient, state mqtt.DeviceState, additionalState mqtt.AdditionalState, mock bool, startTime time.Time) {
 	// don't shutdown if the service has only just started
 	if (time.Now().Unix() - startTime.Unix()) <= 2 * 60 {
 		fmt.Println("Ignoring message as service recently started")
@@ -70,7 +70,7 @@ func updateState(client mqtt.MqttClient, state mqtt.DeviceState, mock bool, star
 		fmt.Println("Initiating shutdown")
 
 		// publish the off message and wait to make sure it's sent
-		client.PublishState(mqtt.Off)
+		client.PublishState(mqtt.Off, nil)
 		time.Sleep(time.Second)
 
 		// turn off the computer if we're not mocking

--- a/services/shutdown/src/main.go
+++ b/services/shutdown/src/main.go
@@ -69,12 +69,6 @@ func main() {
 }
 
 func updateState(client mqtt.MqttClient, state mqtt.DeviceState, additionalState additional.AdditionalState, mock bool, device additional.AdditionalStateDevice, startTime time.Time) {
-	// don't shutdown if the service has only just started
-	if (time.Now().Unix() - startTime.Unix()) <= 2 * 60 {
-		fmt.Println("Ignoring message as service recently started")
-		return
-	}
-
 	// update any additional state
 	currentAdditionalState := additional.GetAdditionalState(device)
 	additional.SetAdditionalState(device, additionalState)
@@ -90,6 +84,12 @@ func updateState(client mqtt.MqttClient, state mqtt.DeviceState, additionalState
 	}
 
 	if (state == "off") {
+		// don't shutdown if the service has only just started
+		if (time.Now().Unix() - startTime.Unix()) <= 2 * 60 {
+			fmt.Println("Ignoring message as service recently started")
+			return
+		}
+
 		// wait to make sure the publish message is sent
 		time.Sleep(time.Second)
 

--- a/services/shutdown/src/main.go
+++ b/services/shutdown/src/main.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 	"time"
 
+	"powerpi/shutdown/additional"
 	"powerpi/shutdown/mqtt"
 )
 
@@ -49,7 +50,7 @@ func main() {
 	signal.Notify(channel, os.Interrupt, syscall.SIGTERM)
 
 	// connect to MQTT
-	callback := func(client mqtt.MqttClient, state mqtt.DeviceState, additionalState mqtt.AdditionalState) {
+	callback := func(client mqtt.MqttClient, state mqtt.DeviceState, additionalState additional.AdditionalState) {
 		updateState(client, state, additionalState, *mock, startTime)
 	} 
 	client := mqtt.New(hostname, *topicBase, callback)
@@ -59,7 +60,7 @@ func main() {
 	<-channel
 }
 
-func updateState(client mqtt.MqttClient, state mqtt.DeviceState, additionalState mqtt.AdditionalState, mock bool, startTime time.Time) {
+func updateState(client mqtt.MqttClient, state mqtt.DeviceState, additionalState additional.AdditionalState, mock bool, startTime time.Time) {
 	// don't shutdown if the service has only just started
 	if (time.Now().Unix() - startTime.Unix()) <= 2 * 60 {
 		fmt.Println("Ignoring message as service recently started")

--- a/services/shutdown/src/main.go
+++ b/services/shutdown/src/main.go
@@ -50,7 +50,7 @@ func main() {
 
 	// connect to MQTT
 	callback := func(client mqtt.MqttClient, state mqtt.DeviceState) {
-		shutdown(client, state, *mock, startTime)
+		updateState(client, state, *mock, startTime)
 	} 
 	client := mqtt.New(hostname, *topicBase, callback)
 	client.Connect(*host, *port, user, password)
@@ -59,7 +59,7 @@ func main() {
 	<-channel
 }
 
-func shutdown(client mqtt.MqttClient, state mqtt.DeviceState, mock bool, startTime time.Time) {
+func updateState(client mqtt.MqttClient, state mqtt.DeviceState, mock bool, startTime time.Time) {
 	// don't shutdown if the service has only just started
 	if (time.Now().Unix() - startTime.Unix()) <= 2 * 60 {
 		fmt.Println("Ignoring message as service recently started")

--- a/services/shutdown/src/mqtt/mqtt.go
+++ b/services/shutdown/src/mqtt/mqtt.go
@@ -78,15 +78,10 @@ func (client MqttClient) Connect(host string, port int, user *string, password *
 	}
 }
 
-func (client MqttClient) PublishState(state DeviceState, additionalState *additional.AdditionalState) {
+func (client MqttClient) PublishState(state DeviceState, additionalState additional.AdditionalState) {
 	topic := client.topic("status")
 
-	var brightness *int = nil
-	if additionalState != nil {
-		brightness = additionalState.Brightness
-	}
-
-	message := &DeviceMessage{state, brightness, time.Now().Unix() * 1000}
+	message := &DeviceMessage{state, additionalState.Brightness, time.Now().Unix() * 1000}
 
 	payload, err := json.Marshal(message)
 	if err != nil {
@@ -126,7 +121,7 @@ func (client MqttClient) onConnect() {
 	fmt.Println("Connected to MQTT")
 
 	// publish that this device is now on
-	client.PublishState(On, nil)
+	client.PublishState(On, additional.AdditionalState{})
 	client.PublishCapability(false)
 
 	// subscribe to the shutdown event for this device

--- a/services/shutdown/src/mqtt/mqtt.go
+++ b/services/shutdown/src/mqtt/mqtt.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	MQTT "github.com/eclipse/paho.mqtt.golang"
+
+	"powerpi/shutdown/additional"
 )
 
 type DeviceState string
@@ -14,11 +16,8 @@ const (
 	Off = "off"
 )
 
-type AdditionalState struct {
-	brightness *int
-}
 
-type MqttMessageAction func(MqttClient, DeviceState, AdditionalState)
+type MqttMessageAction func(MqttClient, DeviceState, additional.AdditionalState)
 
 type MqttClient struct {
 	client MQTT.Client
@@ -79,12 +78,12 @@ func (client MqttClient) Connect(host string, port int, user *string, password *
 	}
 }
 
-func (client MqttClient) PublishState(state DeviceState, additionalState *AdditionalState) {
+func (client MqttClient) PublishState(state DeviceState, additionalState *additional.AdditionalState) {
 	topic := client.topic("status")
 
 	var brightness *int = nil
 	if additionalState != nil {
-		brightness = additionalState.brightness
+		brightness = additionalState.Brightness
 	}
 
 	message := &DeviceMessage{state, brightness, time.Now().Unix() * 1000}
@@ -162,8 +161,8 @@ func (client MqttClient) onMessageReceived(message MQTT.Message) {
 	}
 
 	// retrieve any supported additional state
-	var additionalState AdditionalState
-	additionalState.brightness = payload.Brightness
+	var additionalState additional.AdditionalState
+	additionalState.Brightness = payload.Brightness
 
 	// call the action
 	client.action(client, payload.State, additionalState)

--- a/services/shutdown/src/mqtt/mqtt.go
+++ b/services/shutdown/src/mqtt/mqtt.go
@@ -100,7 +100,7 @@ func (client MqttClient) PublishState(state DeviceState, additionalState additio
 	client.publish(topic, message)
 }
 
-func (client MqttClient) PublishCapability(config flags.AdditionalStateConfig) {
+func (client MqttClient) publishCapability(config flags.AdditionalStateConfig) {
 	if len(config.Brightness.Device) > 0 {
 		topic := client.topic("capability")
 
@@ -120,7 +120,7 @@ func (client MqttClient) onConnect(config flags.Config) {
 
 	// publish that this device is now on
 	client.PublishState(On, additional.GetAdditionalState(config.AdditionalState))
-	client.PublishCapability(config.AdditionalState)
+	client.publishCapability(config.AdditionalState)
 
 	// subscribe to the shutdown event for this device
 	topic := client.topic("change")


### PR DESCRIPTION
Resolves #594
- Refactor flag handling to make it easier to pass the configuration around.
- Add support for broadcasting capabilities.
- Add support for broadcasting additional state (if enabled).
- Add support for handling additional state change messages.