### PR TITLE
#325, #327 feat(ui): Add translation into Spanish and US English

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,38 +6,38 @@ This project was devised to utilise open, reverse engineered or free home automa
 
 ### Supported IoT Hardware
 
--   [Amazon Alexa](https://developer.amazon.com/en-GB/alexa/devices)
--   [Energenie MiHome](https://energenie4u.co.uk/catalogue/category/Raspberry-Pi-Accessories)
--   [LIFX](https://www.lifx.com/)
--   [Logitech Harmony](https://www.logitech.com/en-gb/products/harmony.html)
--   [NodeMCU](https://en.wikipedia.org/wiki/NodeMCU)
--   [ZigBee](https://en.wikipedia.org/wiki/Zigbee)
+- [Amazon Alexa](https://developer.amazon.com/en-GB/alexa/devices)
+- [Energenie MiHome](https://energenie4u.co.uk/catalogue/category/Raspberry-Pi-Accessories)
+- [LIFX](https://www.lifx.com/)
+- [Logitech Harmony](https://www.logitech.com/en-gb/products/harmony.html)
+- [NodeMCU](https://en.wikipedia.org/wiki/NodeMCU)
+- [ZigBee](https://en.wikipedia.org/wiki/Zigbee)
 
 ### Supported Services
 
--   [N3rgy](http://www.n3rgy.com/)
--   [Snapcast](https://github.com/badaix/snapcast)
+- [N3rgy](http://www.n3rgy.com/)
+- [Snapcast](https://github.com/badaix/snapcast)
 
 ## Getting Started
 
 The project is split into the following services, each of which have their own _README_ describing the configuration interface they support as well as how to modify and test them.
 
--   [**api**](services/api/README.md) - API
--   [**config-server**](services/config-server/README.md) - Retrieve configuration files from GitHub.
--   **controllers**:
-    -   [**energenie**](controllers/energenie/README.md) - Allows control of [Energenie MiHome](https://energenie4u.co.uk/catalogue/category/Raspberry-Pi-Accessories) devices using the ENER314 or ENER314-RT Pi module.
-    -   [**harmony**](controllers/harmony/README.md) - Allows control of [Logitech Harmony](https://www.logitech.com/en-gb/products/harmony.html) Smart Hub devices.
-    -   [**lifx**](controllers/lifx/README.md) - Allows control of [LIFX](https://www.lifx.com/) light devices.
-    -   [**network**](controllers/network/README.md) - Allows control of LAN (Local Area Network) devices.
-    -   [**snapcast**](controllers/snapcast/README.md) - Allows control of [Snapcast](https://github.com/badaix/snapcast) clients and servers.
-    -   [**virtual**](controllers/virtual/README.md) - Allows control of other devices by using virtual devices such as groups, delays, mutexes etc.
-    -   [**zigbee**](controllers/zigbee/README.md) - Allows control of [ZigBee](https://en.wikipedia.org/wiki/Zigbee) devices and sensors.
--   [**energy-monitor**](services/energy-monitor/README.md) - Retrieve electricity and gas consumption in 30-minute blocks from UK smart meter submissions via [N3rgy](http://www.n3rgy.com/).
--   [**event**](services/event/README.md) - Allows custom actions to be taken when events appear in the message queue.
--   [**persistence**](services/persistence/README.md) - Service for writing all the messages that appear in the MQTT message queue to a database.
--   [**scheduler**](services/scheduler/README.md) - Schedule based control of light devices, e.g. brightness, colour, temperature etc.
--   [**ui**](services/ui/README.md) - NGINX hosting the UI.
--   [**voice-assistant**](services/voice-assistant/README.md) - Integration with Amazon Alexa skill to receive voice commands.
+- [**api**](services/api/README.md) - API
+- [**config-server**](services/config-server/README.md) - Retrieve configuration files from GitHub.
+- **controllers**:
+    - [**energenie**](controllers/energenie/README.md) - Allows control of [Energenie MiHome](https://energenie4u.co.uk/catalogue/category/Raspberry-Pi-Accessories) devices using the ENER314 or ENER314-RT Pi module.
+    - [**harmony**](controllers/harmony/README.md) - Allows control of [Logitech Harmony](https://www.logitech.com/en-gb/products/harmony.html) Smart Hub devices.
+    - [**lifx**](controllers/lifx/README.md) - Allows control of [LIFX](https://www.lifx.com/) light devices.
+    - [**network**](controllers/network/README.md) - Allows control of LAN (Local Area Network) devices.
+    - [**snapcast**](controllers/snapcast/README.md) - Allows control of [Snapcast](https://github.com/badaix/snapcast) clients and servers.
+    - [**virtual**](controllers/virtual/README.md) - Allows control of other devices by using virtual devices such as groups, delays, mutexes etc.
+    - [**zigbee**](controllers/zigbee/README.md) - Allows control of [ZigBee](https://en.wikipedia.org/wiki/Zigbee) devices and sensors.
+- [**energy-monitor**](services/energy-monitor/README.md) - Retrieve electricity and gas consumption in 30-minute blocks from UK smart meter submissions via [N3rgy](http://www.n3rgy.com/).
+- [**event**](services/event/README.md) - Allows custom actions to be taken when events appear in the message queue.
+- [**persistence**](services/persistence/README.md) - Service for writing all the messages that appear in the MQTT message queue to a database.
+- [**scheduler**](services/scheduler/README.md) - Schedule based control of light devices, e.g. brightness, colour, temperature etc.
+- [**ui**](services/ui/README.md) - NGINX hosting the UI.
+- [**voice-assistant**](services/voice-assistant/README.md) - Integration with Amazon Alexa skill to receive voice commands.
 
 The project includes a [_shutdown_](services/shutdown/README.md) service which allows a computer to be remotely shutdown by message queue events generated by PowerPi.
 
@@ -67,13 +67,13 @@ Deploying the services is simply a matter of deploying the stack using Kubernete
 
 The instructions for deploying the stack using Kubernetes can be found as follows:
 
--   [Kubernetes](kubernetes/README.md)
+- [Kubernetes](kubernetes/README.md)
 
 ## Authors
 
--   **Tom Wilkin** - Most of what you see - [TWilkin](https://github.com/TWilkin)
--   **Paul Sandwell** - Testing, feedback and some excellent ideas - [peasandwell](https://github.com/peasandwell)
--   **Camila Neyra** - Some excellent ideas, specifically floorplans, and putting up with my incessant home automation talk.
+- **Tom Wilkin** - Most of what you see - [TWilkin](https://github.com/TWilkin)
+- **Paul Sandwell** - Testing, feedback and some excellent ideas - [peasandwell](https://github.com/peasandwell)
+- **Camila Neyra** - Some excellent ideas, specifically floorplans; the translation into Spanish and putting up with my incessant home automation talk.
 
 See also the list of [contributors](https://github.com/TWilkin/powerpi/contributors) who participated in this project.
 

--- a/services/ui/public/locales/en-GB/translation.json
+++ b/services/ui/public/locales/en-GB/translation.json
@@ -51,7 +51,7 @@
             }
         },
         "settings": {
-            "languages": "Languages",
+            "language": "Language",
             "units": "Units"
         }
     },

--- a/services/ui/public/locales/en-GB/translation.json
+++ b/services/ui/public/locales/en-GB/translation.json
@@ -51,6 +51,7 @@
             }
         },
         "settings": {
+            "languages": "Languages",
             "units": "Units"
         }
     },

--- a/services/ui/public/locales/en-GB/translation.json
+++ b/services/ui/public/locales/en-GB/translation.json
@@ -107,6 +107,7 @@
                 "metres cubed": "{{value, number}} m\u00B3",
                 "cubic feet": "{{value, number}} cf",
                 "hundred cubic feet": "{{value, number}} hcf",
+                "thousand cubic feet": "{{value, number}} Mcf",
                 "unrecognised": "{{value, number}} {{unit}}"
             },
             "labels": {
@@ -126,7 +127,8 @@
                 "fahrenheit": "Fahrenheit",
                 "metres cubed": "Metres Cubed",
                 "cubic feet": "Cubic Feet",
-                "hundred cubic feet": "Hundred Cubic Feet"
+                "hundred cubic feet": "Hundred Cubic Feet",
+                "thousand cubic feet": "Thousand Cubic Feet"
             }
         },
         "sensors": {

--- a/services/ui/public/locales/en-US/defaults.json
+++ b/services/ui/public/locales/en-US/defaults.json
@@ -2,7 +2,7 @@
     "units": {
         "current": "A",
         "electricalPotential": "V",
-        "gas": "cf",
+        "gas": "Mcf",
         "power": "W",
         "temperature": "F"
     }

--- a/services/ui/public/locales/en-US/defaults.json
+++ b/services/ui/public/locales/en-US/defaults.json
@@ -1,0 +1,9 @@
+{
+    "units": {
+        "current": "A",
+        "electricalPotential": "V",
+        "gas": "cf",
+        "power": "W",
+        "temperature": "F"
+    }
+}

--- a/services/ui/public/locales/en-US/translation.json
+++ b/services/ui/public/locales/en-US/translation.json
@@ -51,7 +51,7 @@
             }
         },
         "settings": {
-            "languages": "Languages",
+            "language": "Language",
             "units": "Units"
         }
     },

--- a/services/ui/public/locales/en-US/translation.json
+++ b/services/ui/public/locales/en-US/translation.json
@@ -51,6 +51,7 @@
             }
         },
         "settings": {
+            "languages": "Languages",
             "units": "Units"
         }
     },

--- a/services/ui/public/locales/en-US/translation.json
+++ b/services/ui/public/locales/en-US/translation.json
@@ -107,6 +107,7 @@
                 "metres cubed": "{{value, number}} m\u00B3",
                 "cubic feet": "{{value, number}} cf",
                 "hundred cubic feet": "{{value, number}} hcf",
+                "thousand cubic feet": "{{value, number}} Mcf",
                 "unrecognised": "{{value, number}} {{unit}}"
             },
             "labels": {
@@ -126,7 +127,8 @@
                 "fahrenheit": "Fahrenheit",
                 "metres cubed": "Metres Cubed",
                 "cubic feet": "Cubic Feet",
-                "hundred cubic feet": "Hundred Cubic Feet"
+                "hundred cubic feet": "Hundred Cubic Feet",
+                "thousand cubic feet": "Thousand Cubic Feet"
             }
         },
         "sensors": {

--- a/services/ui/public/locales/en-US/translation.json
+++ b/services/ui/public/locales/en-US/translation.json
@@ -1,0 +1,153 @@
+{
+    "navigation": {
+        "home": "Home",
+        "devices": "Devices",
+        "history": "History",
+        "settings": "Settings"
+    },
+    "pages": {
+        "error": {
+            "an unexpected error has occurred": "An unexpected error has occurred.",
+            "unknown error": "Unknown error"
+        },
+        "login": {
+            "login with": "Login with {{protocol}}"
+        },
+        "home": {
+            "unknown": "Floor \"{{value}}\" is not present in the floor plan.",
+            "empty": "No floor plan.",
+            "more devices": "There are {{count, number}} more hidden devices/sensors."
+        },
+        "devices": {
+            "search for devices": "Search for devices",
+            "empty": "No devices.",
+            "filtered_one": "Filtered {{count, number}} device.",
+            "filtered_other": "Filtered {{count, number}} devices.",
+            "filters": {
+                "types": "Types",
+                "locations": "Locations",
+                "visibility": {
+                    "label": "Visibility",
+                    "option": "Only show visible devices"
+                }
+            }
+        },
+        "history": {
+            "headings": {
+                "type": "Type",
+                "entity": "Entity",
+                "action": "Action",
+                "when": "When",
+                "message": "Message"
+            },
+            "empty": "No history.",
+            "filtered_one": "Filtered {{count, number}} record.",
+            "filtered_other": "Filtered {{count, number}} records.",
+            "filters": {
+                "path": "Path",
+                "types": "Types",
+                "entities": "Entities",
+                "actions": "Actions"
+            }
+        },
+        "settings": {
+            "units": "Units"
+        }
+    },
+    "common": {
+        "loading": "Loading",
+        "close": "Close",
+        "clear search": "Clear search",
+        "clear filters": "Clear Filters",
+        "open filter": "Open filters",
+        "close filter": "close filters",
+        "all": "All",
+        "unspecified": "Unspecified",
+        "never": "never",
+        "datetime": {
+            "date": "{{time, datetime(dateStyle: long; timeStyle: long;}}",
+            "relative": {
+                "second": "{{time, relativetime(seconds)}}",
+                "minute": "{{time, relativetime(minutes)}}",
+                "hour": "{{time, relativetime(hours)}}",
+                "day": "{{time, relativetime(days)}}",
+                "week": "{{time, relativetime(weeks)}}",
+                "month": "{{time, relativetime(months)}}",
+                "year": "{{time, relativetime(years)}}"
+            }
+        },
+        "power on": "Power {{device}} on",
+        "power off": "Power {{device}} off",
+        "lock on": "Unlock {{device}}",
+        "lock off": "Lock {{device}}",
+        "history link": "Show history for {{device}}",
+        "capability": {
+            "button": "Show capabilities for {{device}}",
+            "brightness": "Set brightness for {{device}}",
+            "colour temperature": "Set color temperature for {{device}}",
+            "stream": "Set the stream to play on {{device}}"
+        },
+        "units": {
+            "values": {
+                "percentage": "{{value, number}}%",
+                "milliampere": "{{value, number}} mA",
+                "ampere": "{{value, number}} A",
+                "millivolt": "{{value, number}} mV",
+                "volt": "{{value, number}} V",
+                "watt hours": "{{value, number}} Wh",
+                "kilowatt hours": "{{value, number}} kWh",
+                "watt": "{{value, number}} W",
+                "kilowatt": "{{value, number}} kW",
+                "joule": "{{value, number}} J",
+                "kilojoule": "{{value, number}} kJ",
+                "celsius": "{{value, number}} °C",
+                "kelvin": "{{value, number}} K",
+                "fahrenheit": "{{value, number}} F",
+                "metres cubed": "{{value, number}} m\u00B3",
+                "cubic feet": "{{value, number}} cf",
+                "hundred cubic feet": "{{value, number}} hcf",
+                "unrecognised": "{{value, number}} {{unit}}"
+            },
+            "labels": {
+                "percentage": "Percentage",
+                "milliampere": "Milliampere",
+                "ampere": "Ampere",
+                "millivolt": "Millivolt",
+                "volt": "Volt",
+                "watt hours": "Watt Hours",
+                "kilowatt hours": "Kilowatt Hours",
+                "watt": "Watt",
+                "kilowatt": "Kilowatt",
+                "joule": "Joule",
+                "kilojoule": "Kilojoule",
+                "celsius": "Celsius",
+                "kelvin": "Kelvin",
+                "fahrenheit": "Fahrenheit",
+                "metres cubed": "Metres Cubed",
+                "cubic feet": "Cubic Feet",
+                "hundred cubic feet": "Hundred Cubic Feet"
+            }
+        },
+        "sensors": {
+            "labels": {
+                "door": "Door",
+                "current": "Current",
+                "electricalPotential": "Electrical Potential",
+                "electricity": "Electricity",
+                "gas": "Gas",
+                "humidity": "Humidity",
+                "motion": "Motion",
+                "power": "Power",
+                "switch": "Switch",
+                "temperature": "Temperature",
+                "window": "Window"
+            },
+            "states": {
+                "detected": "detected",
+                "undetected": "undetected",
+                "open": "open",
+                "close": "closed"
+            }
+        }
+    }
+}

--- a/services/ui/public/locales/es-ES/defaults.json
+++ b/services/ui/public/locales/es-ES/defaults.json
@@ -1,0 +1,9 @@
+{
+    "units": {
+        "current": "A",
+        "electricalPotential": "V",
+        "gas": "m3",
+        "power": "W",
+        "temperature": "°C"
+    }
+}

--- a/services/ui/public/locales/es-ES/translation.json
+++ b/services/ui/public/locales/es-ES/translation.json
@@ -1,0 +1,156 @@
+{
+    "navigation": {
+        "home": "Casa",
+        "devices": "Aparato",
+        "history": "Historia",
+        "settings": "Ajustes"
+    },
+    "pages": {
+        "error": {
+            "an unexpected error has occurred": "Se ha producido un error inesperado.",
+            "unknown error": "Error desconocido"
+        },
+        "login": {
+            "login with": "Iniciar sesión con {{protocol}}"
+        },
+        "home": {
+            "unknown": "Piso \"{{value}}\" no existe en el plan de piso.",
+            "empty": "No hai plan de piso.",
+            "more devices": "Hai {{count, number}} mas aparatos escondidos."
+        },
+        "devices": {
+            "search for devices": "Busque aparatos",
+            "empty": "No hai aparatos.",
+            "filtered_one": "{{count, number}} aparato filtrado.",
+            "filtered_other": "{{count, number}} aparatos filtrados.",
+            "filters": {
+                "types": "Tipos",
+                "locations": "Zona",
+                "visibility": {
+                    "label": "Visiblidad",
+                    "option": "Solo muestra aparatos visibles"
+                }
+            }
+        },
+        "history": {
+            "headings": {
+                "type": "Tipo",
+                "entity": "Objeto",
+                "action": "Acción",
+                "when": "Tiempo",
+                "message": "Mensaje"
+            },
+            "empty": "No hai historia.",
+            "filtered_one": "{{count, number}} mensaje filtrado.",
+            "filtered_other": "{{count, number}} mensajes filtrados.",
+            "filters": {
+                "path": "Ruta",
+                "types": "Tipos",
+                "entities": "Objetos",
+                "actions": "Acciones"
+            }
+        },
+        "settings": {
+            "language": "Idioma",
+            "units": "Unidades"
+        }
+    },
+    "common": {
+        "loading": "Cargando",
+        "close": "Cerrar",
+        "clear search": "Borrar busqueda",
+        "clear filters": "Borrar Filtros",
+        "open filter": "abrir filtros",
+        "close filter": "cerrar filtros",
+        "all": "Todos",
+        "unspecified": "No especificado",
+        "never": "nunca",
+        "datetime": {
+            "date": "{{time, datetime(dateStyle: long; timeStyle: long;}}",
+            "relative": {
+                "second": "{{time, relativetime(seconds)}}",
+                "minute": "{{time, relativetime(minutes)}}",
+                "hour": "{{time, relativetime(hours)}}",
+                "day": "{{time, relativetime(days)}}",
+                "week": "{{time, relativetime(weeks)}}",
+                "month": "{{time, relativetime(months)}}",
+                "year": "{{time, relativetime(years)}}"
+            }
+        },
+        "power on": "Prender {{device}}",
+        "power off": "Apagar {{device}}",
+        "lock on": "Desbloquear {{device}}",
+        "lock off": "Bloquear {{device}}",
+        "history link": "Mostrar historia para {{device}}",
+        "capability": {
+            "button": "Mostrar habilidades {{device}}",
+            "brightness": "Ajustar el brillo para {{device}}",
+            "colour temperature": "Ajustar la temperature del color para {{device}}",
+            "stream": "Reproducir la transmisión en {{device}}"
+        },
+        "units": {
+            "values": {
+                "percentage": "{{value, number}}%",
+                "milliampere": "{{value, number}} mA",
+                "ampere": "{{value, number}} A",
+                "millivolt": "{{value, number}} mV",
+                "volt": "{{value, number}} V",
+                "watt hours": "{{value, number}} Wh",
+                "kilowatt hours": "{{value, number}} kWh",
+                "watt": "{{value, number}} W",
+                "kilowatt": "{{value, number}} kW",
+                "joule": "{{value, number}} J",
+                "kilojoule": "{{value, number}} kJ",
+                "celsius": "{{value, number}} °C",
+                "kelvin": "{{value, number}} K",
+                "fahrenheit": "{{value, number}} F",
+                "metres cubed": "{{value, number}} m\u00B3",
+                "cubic feet": "{{value, number}} cf",
+                "hundred cubic feet": "{{value, number}} hcf",
+                "thousand cubic feet": "{{value, number}} Mcf",
+                "unrecognised": "{{value, number}} {{unit}}"
+            },
+            "labels": {
+                "percentage": "Porcentage",
+                "milliampere": "Milliamperio",
+                "ampere": "Amperio",
+                "millivolt": "Millivoltio",
+                "volt": "Voltio",
+                "watt hours": "Vatio horas",
+                "kilowatt hours": "Kilovatio horas",
+                "watt": "Vatio",
+                "kilowatt": "Kilovatio",
+                "joule": "Julio",
+                "kilojoule": "Kilojulio",
+                "celsius": "Celsius",
+                "kelvin": "Kelvin",
+                "fahrenheit": "Fahrenheit",
+                "metres cubed": "Metros cúbicos",
+                "cubic feet": "Pies cúbicos",
+                "hundred cubic feet": "Cien pies cúbicos",
+                "thousand cubic feet": "Mil pies cúbicos"
+            }
+        },
+        "sensors": {
+            "labels": {
+                "door": "Puerta",
+                "current": "Corriente",
+                "electricalPotential": "Potencial eléctrico",
+                "electricity": "Electricidad",
+                "gas": "Gas",
+                "humidity": "Humedad",
+                "motion": "Movimiento",
+                "power": "Poder",
+                "switch": "Switch",
+                "temperature": "Temperatura",
+                "window": "Ventana"
+            },
+            "states": {
+                "detected": "detectado",
+                "undetected": "no detectado",
+                "open": "abierta",
+                "close": "cerrada"
+            }
+        }
+    }
+}

--- a/services/ui/src/@types/resources.d.ts
+++ b/services/ui/src/@types/resources.d.ts
@@ -61,7 +61,7 @@ interface Resources {
         }
       },
       "settings": {
-        "languages": "Languages",
+        "language": "Language",
         "units": "Units"
       }
     },

--- a/services/ui/src/@types/resources.d.ts
+++ b/services/ui/src/@types/resources.d.ts
@@ -117,6 +117,7 @@ interface Resources {
           "metres cubed": "{{value, number}} m³",
           "cubic feet": "{{value, number}} cf",
           "hundred cubic feet": "{{value, number}} hcf",
+          "thousand cubic feet": "{{value, number}} Mcf",
           "unrecognised": "{{value, number}} {{unit}}"
         },
         "labels": {
@@ -136,7 +137,8 @@ interface Resources {
           "fahrenheit": "Fahrenheit",
           "metres cubed": "Metres Cubed",
           "cubic feet": "Cubic Feet",
-          "hundred cubic feet": "Hundred Cubic Feet"
+          "hundred cubic feet": "Hundred Cubic Feet",
+          "thousand cubic feet": "Thousand Cubic Feet"
         }
       },
       "sensors": {

--- a/services/ui/src/@types/resources.d.ts
+++ b/services/ui/src/@types/resources.d.ts
@@ -61,6 +61,7 @@ interface Resources {
         }
       },
       "settings": {
+        "languages": "Languages",
         "units": "Units"
       }
     },

--- a/services/ui/src/components/FieldSet/FieldSet.tsx
+++ b/services/ui/src/components/FieldSet/FieldSet.tsx
@@ -1,7 +1,7 @@
 import classNames from "classnames";
 import { FieldsetHTMLAttributes } from "react";
 
-type FieldSetContentType = "label" | "checkbox";
+type FieldSetContentType = "label" | "unlabelled" | "checkbox";
 
 type FieldSetProps = {
     legend: string;

--- a/services/ui/src/hooks/useUserSettings/UserSettingsContext.ts
+++ b/services/ui/src/hooks/useUserSettings/UserSettingsContext.ts
@@ -13,8 +13,9 @@ export type UserSettingsType = {
 
 type UpdateLanguageAction = { type: "Language"; language: string };
 type UpdateUnitAction = { type: "Unit"; unitType: UnitType; unit: string };
+type ReinitialiseAction = { type: "Reinitialise"; defaults: UserSettingsType };
 
-export type UpdateSettingsAction = UpdateLanguageAction | UpdateUnitAction;
+export type UpdateSettingsAction = UpdateLanguageAction | UpdateUnitAction | ReinitialiseAction;
 
 export type UserSettingsContextType = {
     /** The user's current settings. */

--- a/services/ui/src/localisation.ts
+++ b/services/ui/src/localisation.ts
@@ -8,6 +8,7 @@ import { initReactI18next } from "react-i18next";
 export const supportedLanguages = [
     { id: "en-GB", label: "English (UK)" },
     { id: "en-US", label: "English (US)" },
+    { id: "es-ES", label: "Español" },
 ];
 
 i18n.use(initReactI18next)

--- a/services/ui/src/localisation.ts
+++ b/services/ui/src/localisation.ts
@@ -3,11 +3,13 @@ import LanguageDetector from "i18next-browser-languagedetector";
 import Backend from "i18next-http-backend";
 import { initReactI18next } from "react-i18next";
 
+export const supportedLanguages = ["en-GB", "en-US"];
+
 i18n.use(initReactI18next)
     .use(LanguageDetector)
     .use(Backend)
     .init({
-        supportedLngs: ["en-GB"],
+        supportedLngs: supportedLanguages,
         fallbackLng: "en-GB",
         debug: false,
         backend: {

--- a/services/ui/src/localisation.ts
+++ b/services/ui/src/localisation.ts
@@ -3,13 +3,18 @@ import LanguageDetector from "i18next-browser-languagedetector";
 import Backend from "i18next-http-backend";
 import { initReactI18next } from "react-i18next";
 
-export const supportedLanguages = ["en-GB", "en-US"];
+// The list of supported languages and their labels
+// Labels here should be written in the language they represent to ease user selection.
+export const supportedLanguages = [
+    { id: "en-GB", label: "English (UK)" },
+    { id: "en-US", label: "English (US)" },
+];
 
 i18n.use(initReactI18next)
     .use(LanguageDetector)
     .use(Backend)
     .init({
-        supportedLngs: supportedLanguages,
+        supportedLngs: supportedLanguages.map((language) => language.id),
         fallbackLng: "en-GB",
         debug: false,
         backend: {

--- a/services/ui/src/pages/SettingsPage/Language/LanguageSettings.test.tsx
+++ b/services/ui/src/pages/SettingsPage/Language/LanguageSettings.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import LanguageSettings from "./LanguageSettings";
+
+const mocks = vi.hoisted(() => ({
+    useUserSettings: vi.fn(),
+}));
+
+vi.mock("../../../hooks/useUserSettings", async () => ({
+    default: mocks.useUserSettings,
+}));
+
+describe("LanguageSettings", () => {
+    beforeEach(() =>
+        mocks.useUserSettings.mockReturnValue({
+            dispatch: vi.fn(),
+        }),
+    );
+
+    test("renders", async () => {
+        render(<LanguageSettings />);
+
+        const group = screen.getByRole("group");
+        expect(group).toBeInTheDocument();
+        expect(group).toHaveAccessibleName("Languages");
+
+        const combobox = within(group).getByRole("combobox");
+        expect(combobox).toBeInTheDocument();
+
+        await userEvent.type(combobox, "english");
+
+        const options = within(group).getAllByRole("option");
+        expect(options).toHaveLength(2);
+
+        expect(options[0]).toHaveAccessibleName("English (UK)");
+        expect(options[1]).toHaveAccessibleName("English (US)");
+    });
+
+    test("changes", async () => {
+        const dispatch = vi.fn();
+
+        mocks.useUserSettings.mockReturnValue({
+            dispatch,
+        });
+
+        render(<LanguageSettings />);
+
+        const combobox = screen.getByRole("combobox");
+        expect(combobox).toBeInTheDocument();
+
+        await userEvent.type(combobox, "us");
+
+        const option = screen.getByRole("option");
+        expect(option).toBeInTheDocument();
+
+        await userEvent.click(option);
+
+        expect(dispatch).toHaveBeenCalledTimes(1);
+        expect(dispatch).toHaveBeenCalledWith({
+            type: "Language",
+            language: "en-US",
+        });
+    });
+});

--- a/services/ui/src/pages/SettingsPage/Language/LanguageSettings.test.tsx
+++ b/services/ui/src/pages/SettingsPage/Language/LanguageSettings.test.tsx
@@ -23,7 +23,7 @@ describe("LanguageSettings", () => {
 
         const group = screen.getByRole("group");
         expect(group).toBeInTheDocument();
-        expect(group).toHaveAccessibleName("Languages");
+        expect(group).toHaveAccessibleName("Language");
 
         const combobox = within(group).getByRole("combobox");
         expect(combobox).toBeInTheDocument();

--- a/services/ui/src/pages/SettingsPage/Language/LanguageSettings.tsx
+++ b/services/ui/src/pages/SettingsPage/Language/LanguageSettings.tsx
@@ -37,7 +37,6 @@ const LanguageSettings = () => {
 
     return (
         <FieldSet legend={t("pages.settings.languages")}>
-            {t("common.capability.colour temperature", { device: "Blah" })}
             <Select
                 label={t("pages.settings.languages")}
                 options={options}

--- a/services/ui/src/pages/SettingsPage/Language/LanguageSettings.tsx
+++ b/services/ui/src/pages/SettingsPage/Language/LanguageSettings.tsx
@@ -16,8 +16,8 @@ const LanguageSettings = () => {
         () =>
             _(supportedLanguages)
                 .map((language) => ({
-                    label: language,
-                    value: language,
+                    label: language.label,
+                    value: language.id,
                 }))
                 .sortBy((option) => option.label)
                 .value(),
@@ -36,10 +36,10 @@ const LanguageSettings = () => {
     const currentLanguage = i18n.language ?? settings?.language ?? "en-GB";
 
     return (
-        <FieldSet legend="Language">
+        <FieldSet legend={t("pages.settings.languages")}>
             {t("common.capability.colour temperature", { device: "Blah" })}
             <Select
-                label="Language"
+                label={t("pages.settings.languages")}
                 options={options}
                 value={currentLanguage}
                 onChange={handleChange}

--- a/services/ui/src/pages/SettingsPage/Language/LanguageSettings.tsx
+++ b/services/ui/src/pages/SettingsPage/Language/LanguageSettings.tsx
@@ -1,0 +1,50 @@
+import { useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { chain as _ } from "underscore";
+import FieldSet from "../../../components/FieldSet";
+import Select from "../../../components/Select";
+import useUserSettings from "../../../hooks/useUserSettings";
+import { supportedLanguages } from "../../../localisation";
+
+/** Component to display the language selection. */
+const LanguageSettings = () => {
+    const { i18n, t } = useTranslation();
+
+    const { settings, dispatch } = useUserSettings();
+
+    const options = useMemo(
+        () =>
+            _(supportedLanguages)
+                .map((language) => ({
+                    label: language,
+                    value: language,
+                }))
+                .sortBy((option) => option.label)
+                .value(),
+        [],
+    );
+
+    const handleChange = useCallback(
+        (value: string) => {
+            if (dispatch) {
+                dispatch({ type: "Language", language: value });
+            }
+        },
+        [dispatch],
+    );
+
+    const currentLanguage = i18n.language ?? settings?.language ?? "en-GB";
+
+    return (
+        <FieldSet legend="Language">
+            {t("common.capability.colour temperature", { device: "Blah" })}
+            <Select
+                label="Language"
+                options={options}
+                value={currentLanguage}
+                onChange={handleChange}
+            />
+        </FieldSet>
+    );
+};
+export default LanguageSettings;

--- a/services/ui/src/pages/SettingsPage/Language/LanguageSettings.tsx
+++ b/services/ui/src/pages/SettingsPage/Language/LanguageSettings.tsx
@@ -36,9 +36,9 @@ const LanguageSettings = () => {
     const currentLanguage = i18n.language ?? settings?.language ?? "en-GB";
 
     return (
-        <FieldSet legend={t("pages.settings.languages")}>
+        <FieldSet legend={t("pages.settings.language")} content="unlabelled">
             <Select
-                label={t("pages.settings.languages")}
+                label={t("pages.settings.language")}
                 options={options}
                 value={currentLanguage}
                 onChange={handleChange}

--- a/services/ui/src/pages/SettingsPage/Language/index.ts
+++ b/services/ui/src/pages/SettingsPage/Language/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./LanguageSettings";

--- a/services/ui/src/pages/SettingsPage/SettingsPage.test.tsx
+++ b/services/ui/src/pages/SettingsPage/SettingsPage.test.tsx
@@ -9,8 +9,8 @@ describe("SettingsPage", () => {
         expect(groups).toHaveLength(2);
 
         const languages = groups[0];
-        expect(within(languages).getByText("Languages")).toBeInTheDocument();
-        expect(within(languages).getByLabelText("Languages")).toBeInTheDocument();
+        expect(within(languages).getByText("Language")).toBeInTheDocument();
+        expect(within(languages).getByLabelText("Language")).toBeInTheDocument();
 
         const units = groups[1];
         expect(within(units).getByText("Units")).toBeInTheDocument();

--- a/services/ui/src/pages/SettingsPage/SettingsPage.test.tsx
+++ b/services/ui/src/pages/SettingsPage/SettingsPage.test.tsx
@@ -1,12 +1,20 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import SettingsPage from "./SettingsPage";
 
 describe("SettingsPage", () => {
     test("renders", () => {
         render(<SettingsPage />);
 
-        expect(screen.getByText("Units")).toBeInTheDocument();
-        expect(screen.getByLabelText("Gas")).toBeInTheDocument();
-        expect(screen.getByLabelText("Temperature")).toBeInTheDocument();
+        const groups = screen.getAllByRole("group");
+        expect(groups).toHaveLength(2);
+
+        const languages = groups[0];
+        expect(within(languages).getByText("Languages")).toBeInTheDocument();
+        expect(within(languages).getByLabelText("Languages")).toBeInTheDocument();
+
+        const units = groups[1];
+        expect(within(units).getByText("Units")).toBeInTheDocument();
+        expect(within(units).getByLabelText("Gas")).toBeInTheDocument();
+        expect(within(units).getByLabelText("Temperature")).toBeInTheDocument();
     });
 });

--- a/services/ui/src/pages/SettingsPage/SettingsPage.tsx
+++ b/services/ui/src/pages/SettingsPage/SettingsPage.tsx
@@ -1,7 +1,9 @@
+import LanguageSettings from "./Language";
 import UnitSettings from "./Units";
 
 const SettingsPage = () => (
     <div className="flex flex-col gap">
+        <LanguageSettings />
         <UnitSettings />
     </div>
 );

--- a/services/ui/src/services/UnitConverter/UnitConverter.test.ts
+++ b/services/ui/src/services/UnitConverter/UnitConverter.test.ts
@@ -62,6 +62,7 @@ describe("UnitConverter", () => {
             expect(result).toContainEqual({ unit: "m3", key: "metres cubed" });
             expect(result).toContainEqual({ unit: "kWh", key: "kilowatt hours" });
             expect(result).toContainEqual({ unit: "hcf", key: "hundred cubic feet" });
+            expect(result).toContainEqual({ unit: "Mcf", key: "thousand cubic feet" });
             expect(result).toContainEqual({ unit: "cf", key: "cubic feet" });
         });
     });
@@ -104,16 +105,22 @@ describe("UnitConverter", () => {
         test("m3 -> hcf", () => check("volume", { value: 100, unit: "m3" }, "cf", 3531.47));
 
         test("cf -> hcf", () => check("volume", { value: 123, unit: "cf" }, "hcf", 1.23));
+        test("cf -> Mcf", () => check("volume", { value: 5_000, unit: "cf" }, "Mcf", 5));
         test("cf -> m3", () => check("volume", { value: 5_000, unit: "cf" }, "m3", 141.584));
 
         test("hcf -> cf", () => check("volume", { value: 50, unit: "hcf" }, "cf", 5_000));
+        test("hcf -> Mcf", () => check("volume", { value: 50, unit: "hcf" }, "Mcf", 5));
         test("hcf -> m3", () => check("volume", { value: 50, unit: "hcf" }, "m3", 141.584));
+
+        test("Mcf -> cf", () => check("volume", { value: 25, unit: "Mcf" }, "cf", 25_000));
+        test("Mcf -> hcf", () => check("volume", { value: 25, unit: "Mcf" }, "hcf", 250));
 
         test("getConverters", () => {
             const result = UnitConverter.getConverters("volume");
 
             expect(result).toContainEqual({ unit: "m3", key: "metres cubed" });
             expect(result).toContainEqual({ unit: "hcf", key: "hundred cubic feet" });
+            expect(result).toContainEqual({ unit: "Mcf", key: "thousand cubic feet" });
             expect(result).toContainEqual({ unit: "cf", key: "cubic feet" });
         });
     });

--- a/services/ui/src/services/UnitConverter/converters/volume.ts
+++ b/services/ui/src/services/UnitConverter/converters/volume.ts
@@ -13,6 +13,7 @@ export const volume: ConverterDefinition[] = [
         key: "cubic feet",
         convert: {
             hcf: (value: number) => value / 100,
+            Mcf: (value: number) => value / 1000,
         },
     },
     {
@@ -20,6 +21,13 @@ export const volume: ConverterDefinition[] = [
         key: "hundred cubic feet",
         convert: {
             m3: (value: number) => value * 2.8316846592,
+        },
+    },
+    {
+        unit: "Mcf",
+        key: "thousand cubic feet",
+        convert: {
+            cf: (value: number) => value * 1000,
         },
     },
 ];

--- a/services/ui/src/services/UnitConverter/getUnitType.test.ts
+++ b/services/ui/src/services/UnitConverter/getUnitType.test.ts
@@ -24,6 +24,7 @@ describe("getUnitType", () => {
         { type: "nope", unit: "m3", expected: "volume" },
         { type: "nope", unit: "cf", expected: "volume" },
         { type: "nope", unit: "hcf", expected: "volume" },
+        { type: "nope", unit: "Mcf", expected: "volume" },
         { type: "nope", unit: "nope", expected: undefined },
     ];
     test.each(cases)(

--- a/services/ui/src/services/UnitConverter/getUnitType.ts
+++ b/services/ui/src/services/UnitConverter/getUnitType.ts
@@ -37,6 +37,7 @@ export default function getUnitType(type: string, unit: string): UnitType | unde
         case "m3":
         case "cf":
         case "hcf":
+        case "Mcf":
             return "volume";
     }
 

--- a/services/ui/src/services/UnitConverter/isSupportedUnit.test.ts
+++ b/services/ui/src/services/UnitConverter/isSupportedUnit.test.ts
@@ -22,6 +22,7 @@ describe("isSupportedUnit", () => {
         { unit: "m3", expected: true },
         { unit: "cf", expected: true },
         { unit: "hcf", expected: true },
+        { unit: "Mcf", expected: true },
         { unit: "?", expected: false },
     ];
     test.each(cases)("$unit => $expected", ({ unit, expected }) => {
@@ -48,6 +49,7 @@ describe("isSupportedUnitLabel", () => {
         { label: "metres cubed", expected: true },
         { label: "cubic feet", expected: true },
         { label: "hundred cubic feet", expected: true },
+        { label: "thousand cubic feet", expected: true },
         { label: "?", expected: false },
     ];
     test.each(cases)("$label => $expected", ({ label, expected }) => {

--- a/services/ui/src/services/UnitConverter/isSupportedUnit.ts
+++ b/services/ui/src/services/UnitConverter/isSupportedUnit.ts
@@ -31,6 +31,7 @@ const supportedUnits = {
     "metres cubed": "m3",
     "cubic feet": "cf",
     "hundred cubic feet": "hcf",
+    "thousand cubic feet": "Mcf",
 } as const;
 
 /** The labels of the supported units. */

--- a/services/ui/test-setup.ts
+++ b/services/ui/test-setup.ts
@@ -9,9 +9,11 @@ beforeAll(() => {
     // setup i18next with en-GB translation
     i18n.use(initReactI18next).init({
         lng: "en-GB",
+        supportedLngs: ["en-GB", "en-US"],
         debug: false,
         resources: {
             "en-GB": { translation, defaults },
+            "en-US": { translation, defaults },
         },
         interpolation: {
             escapeValue: false,


### PR DESCRIPTION
Resolves #325 and resolves #327.
- Add translation into Spanish.
- Add translation into US English.
- Add selection of language from settings page.
- Refresh the unit selections on language change so any defaults are selected automatically.
- Add support for "thousand cubic feet" conversions as the US default gas unit.