### PR TITLE
#560 feat(scheduler)!: Update scheduler to use cron syntax

### DIFF
--- a/services/scheduler/poetry.lock
+++ b/services/scheduler/poetry.lock
@@ -122,6 +122,20 @@ mypy = ["mypy", "types-python-dateutil"]
 test = ["python-dateutil"]
 
 [[package]]
+name = "cron-descriptor"
+version = "1.4.5"
+description = "A Python library that converts cron expressions into human readable strings."
+optional = false
+python-versions = "*"
+files = [
+    {file = "cron_descriptor-1.4.5-py3-none-any.whl", hash = "sha256:736b3ae9d1a99bc3dbfc5b55b5e6e7c12031e7ba5de716625772f8b02dcd6013"},
+    {file = "cron_descriptor-1.4.5.tar.gz", hash = "sha256:f51ce4ffc1d1f2816939add8524f206c376a42c87a5fca3091ce26725b3b1bca"},
+]
+
+[package.extras]
+dev = ["polib"]
+
+[[package]]
 name = "dependency-injector"
 version = "4.41.0"
 description = "Dependency injection framework for Python"
@@ -449,4 +463,4 @@ devenv = ["black", "check-manifest", "flake8", "pyroma", "pytest (>=4.3)", "pyte
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "b9f061fe846b95af75c09d89b849a73001bfa32c13f8776c5bfa9751e9339756"
+content-hash = "82ff2cb6673904f6a6b04c3f2cd5c341a5af3fe9326e473a0cd3e8eb1233fd4a"

--- a/services/scheduler/poetry.lock
+++ b/services/scheduler/poetry.lock
@@ -104,6 +104,24 @@ files = [
 toml = ["tomli"]
 
 [[package]]
+name = "cron-converter"
+version = "1.2.1"
+description = "Cron string parser and scheduler for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "cron_converter-1.2.1-py3-none-any.whl", hash = "sha256:4604e356c15a8fbe76a86bb42508f611ad3cade7dd65e2d6f601c2e0d5226ffc"},
+    {file = "cron_converter-1.2.1.tar.gz", hash = "sha256:6766c6ba44b8236201ac03030f314fd655343c1c4848ce216458e8d340066c59"},
+]
+
+[package.dependencies]
+python-dateutil = "*"
+
+[package.extras]
+mypy = ["mypy", "types-python-dateutil"]
+test = ["python-dateutil"]
+
+[[package]]
 name = "dependency-injector"
 version = "4.41.0"
 description = "Dependency injection framework for Python"
@@ -354,6 +372,20 @@ pytest = ">=5.0"
 dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+files = [
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
+]
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "pytz"
 version = "2023.3"
 description = "World timezone definitions, modern and historical"
@@ -417,4 +449,4 @@ devenv = ["black", "check-manifest", "flake8", "pyroma", "pytest (>=4.3)", "pyte
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "c4f4c9410029f74763e3225462fa4525badcae3e125a466869cca8ccf0b3c862"
+content-hash = "b9f061fe846b95af75c09d89b849a73001bfa32c13f8776c5bfa9751e9339756"

--- a/services/scheduler/pyproject.toml
+++ b/services/scheduler/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.11"
 cron-converter = "~=1.2.1"
+cron-descriptor = "~=1.4.5"
 
 [tool.poetry.group.powerpi.dependencies]
 powerpi-common = {path = "../../common/python", develop = true}

--- a/services/scheduler/pyproject.toml
+++ b/services/scheduler/pyproject.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.11"
+cron-converter = "~=1.2.1"
 
 [tool.poetry.group.powerpi.dependencies]
 powerpi-common = {path = "../../common/python", develop = true}

--- a/services/scheduler/scheduler/container.py
+++ b/services/scheduler/scheduler/container.py
@@ -33,7 +33,11 @@ class ApplicationContainer(containers.DeclarativeContainer):
     )
 
     cron_factory = providers.Factory(
-        Cron
+        Cron,
+        options={
+            'output_weekday_names': True,
+            'output_month_names': True
+        }
     )
 
     device_interval_schedule = providers.Factory(

--- a/services/scheduler/scheduler/container.py
+++ b/services/scheduler/scheduler/container.py
@@ -33,11 +33,7 @@ class ApplicationContainer(containers.DeclarativeContainer):
     )
 
     cron_factory = providers.Factory(
-        Cron,
-        options={
-            'output_weekday_names': True,
-            'output_month_names': True
-        }
+        Cron
     )
 
     device_interval_schedule = providers.Factory(

--- a/services/scheduler/scheduler/container.py
+++ b/services/scheduler/scheduler/container.py
@@ -1,3 +1,4 @@
+from cron_converter import Cron
 from dependency_injector import containers, providers
 from powerpi_common.container import Container as CommonContainer
 
@@ -31,6 +32,10 @@ class ApplicationContainer(containers.DeclarativeContainer):
         config=config
     )
 
+    cron_factory = providers.Factory(
+        Cron
+    )
+
     device_interval_schedule = providers.Factory(
         DeviceIntervalSchedule,
         config=config,
@@ -38,7 +43,8 @@ class ApplicationContainer(containers.DeclarativeContainer):
         mqtt_client=common.mqtt_client,
         scheduler=common.scheduler,
         variable_manager=common.variable.variable_manager,
-        condition_parser_factory=common.condition.condition_parser.provider
+        condition_parser_factory=common.condition.condition_parser.provider,
+        cron_factory=cron_factory.provider
     )
 
     device_single_schedule = providers.Factory(
@@ -48,7 +54,8 @@ class ApplicationContainer(containers.DeclarativeContainer):
         mqtt_client=common.mqtt_client,
         scheduler=common.scheduler,
         variable_manager=common.variable.variable_manager,
-        condition_parser_factory=common.condition.condition_parser.provider
+        condition_parser_factory=common.condition.condition_parser.provider,
+        cron_factory=cron_factory.provider
     )
 
     device_schedule_factory = providers.Factory(

--- a/services/scheduler/scheduler/services/device_interval_schedule.py
+++ b/services/scheduler/scheduler/services/device_interval_schedule.py
@@ -139,7 +139,10 @@ class DeviceIntervalSchedule(DeviceSchedule):
         return end_date <= datetime.now(pytz.UTC)
 
     def __calculate_dates(self):
-        start_date = self._next_run()
+        # adjust now by the duration in case we're inside the window already
+        now = datetime.now(self._timezone) - timedelta(seconds=self.__duration)
+
+        start_date = self._next_run(now)
         end_date = start_date + timedelta(seconds=self.__duration)
 
         return (start_date, end_date)

--- a/services/scheduler/scheduler/services/device_interval_schedule.py
+++ b/services/scheduler/scheduler/services/device_interval_schedule.py
@@ -49,7 +49,6 @@ class DeviceIntervalSchedule(DeviceSchedule):
         variable_manager: VariableManager,
         condition_parser_factory: providers.Factory,
         cron_factory: providers.Factory,
-        device: str,
         duration: str,
         interval: str,
         force: bool = False,
@@ -69,7 +68,6 @@ class DeviceIntervalSchedule(DeviceSchedule):
             variable_manager,
             condition_parser_factory,
             cron_factory,
-            device,
             **kwargs
         )
 

--- a/services/scheduler/scheduler/services/device_interval_schedule.py
+++ b/services/scheduler/scheduler/services/device_interval_schedule.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import datetime, time, timedelta
+from datetime import datetime, timedelta
 from enum import StrEnum, unique
 from typing import Dict, List, Tuple
 
@@ -48,8 +48,9 @@ class DeviceIntervalSchedule(DeviceSchedule):
         scheduler: AsyncIOScheduler,
         variable_manager: VariableManager,
         condition_parser_factory: providers.Factory,
+        cron_factory: providers.Factory,
         device: str,
-        between: List[str],
+        duration: str,
         interval: str,
         force: bool = False,
         brightness: List[str] | None = None,
@@ -67,11 +68,12 @@ class DeviceIntervalSchedule(DeviceSchedule):
             scheduler,
             variable_manager,
             condition_parser_factory,
+            cron_factory,
             device,
             **kwargs
         )
 
-        self.__between = between
+        self.__duration = int(duration)
         self.__interval = int(interval)
         self.__force = force
 
@@ -100,8 +102,8 @@ class DeviceIntervalSchedule(DeviceSchedule):
                     float(additional_state[delta_type][1])
                 )
 
-    def _build_trigger(self, start: datetime | None = None):
-        (start_date, end_date) = self.__calculate_dates(start)
+    def _build_trigger(self):
+        (start_date, end_date) = self.__calculate_dates()
 
         trigger = IntervalTrigger(
             start_date=start_date,
@@ -138,46 +140,9 @@ class DeviceIntervalSchedule(DeviceSchedule):
 
         return end_date <= datetime.now(pytz.UTC)
 
-    def __calculate_dates(self, start: datetime | None = None):
-        start_time = [int(part) for part in self.__between[0].split(':', 3)]
-        end_time = [int(part) for part in self.__between[1].split(':', 3)]
-
-        timezone = self._timezone
-
-        def make_dates(start: datetime):
-            start_date = timezone.localize(datetime.combine(
-                start.date(),
-                time(start_time[0], start_time[1], start_time[2], 0)
-            ))
-
-            end_date = timezone.localize(datetime.combine(
-                start.date(),
-                time(end_time[0], end_time[1], end_time[2], 0)
-            ))
-
-            # handle end_time on the next day
-            if end_date <= start_date:
-                end_date = end_date + timedelta(days=1)
-
-            # check it's not in the past
-            if end_date <= datetime.now(timezone):
-                start_date += timedelta(days=1)
-
-            return start_date, end_date
-
-        # get a first guess start_date
-        (start_date, _) = make_dates(
-            start.astimezone(timezone) if start is not None
-            else datetime.now(timezone)
-        )
-
-        # find the next appropriate day-of-week
-        start_date = self._find_valid_day(start_date)
-
-        (start_date, end_date) = make_dates(start_date)
-
-        start_date = start_date.astimezone(pytz.UTC)
-        end_date = end_date.astimezone(pytz.UTC)
+    def __calculate_dates(self):
+        start_date = self._next_run()
+        end_date = start_date + timedelta(seconds=self.__duration)
 
         return (start_date, end_date)
 
@@ -248,7 +213,7 @@ class DeviceIntervalSchedule(DeviceSchedule):
         return new_value
 
     def __str__(self):
-        builder = f'Every {self.__interval}s between {self.__between[0]} and {self.__between[1]}'
+        builder = f'Every {self.__interval}s for {self.__duration}s'
 
         builder += super().__str__()
 

--- a/services/scheduler/scheduler/services/device_interval_schedule.py
+++ b/services/scheduler/scheduler/services/device_interval_schedule.py
@@ -214,9 +214,9 @@ class DeviceIntervalSchedule(DeviceSchedule):
         return new_value
 
     def __str__(self):
-        builder = f'Every {self.__interval}s for {self.__duration}s'
+        builder = super().__str__()
 
-        builder += super().__str__()
+        builder += f', every {self.__interval}s for {self.__duration}s'
 
         for device_type, delta in self.__delta.items():
             builder += f', {device_type} between {delta.start} and {delta.end}'

--- a/services/scheduler/scheduler/services/device_schedule.py
+++ b/services/scheduler/scheduler/services/device_schedule.py
@@ -119,11 +119,11 @@ class DeviceSchedule(ABC, LogMixin):
         '''
         return self.__class__.__name__
 
-    def _next_run(self) -> datetime:
+    def _next_run(self, now: datetime | None = None) -> datetime:
         '''
         Return the time the next schedule should occur, in UTC.
         '''
-        now = datetime.now(self._timezone)
+        now = datetime.now(self._timezone) if now is None else now
 
         # get the next schedule time
         schedule = self.__cron.schedule(start_date=now)

--- a/services/scheduler/scheduler/services/device_schedule.py
+++ b/services/scheduler/scheduler/services/device_schedule.py
@@ -2,7 +2,6 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import Any, List, Tuple
 
-import pytz
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.base import BaseTrigger
 from cron_converter import Cron
@@ -14,6 +13,7 @@ from powerpi_common.device import DeviceStatus
 from powerpi_common.logger import Logger, LogMixin
 from powerpi_common.mqtt import MQTTClient, MQTTMessage
 from powerpi_common.variable import VariableManager
+from pytz import timezone, utc
 
 from scheduler.config import SchedulerConfig
 
@@ -64,7 +64,7 @@ class DeviceSchedule(ABC, LogMixin):
 
     @property
     def _timezone(self):
-        return pytz.timezone(self.__config.timezone)
+        return timezone(self.__config.timezone)
 
     def start(self):
         self.log_info(self)
@@ -142,7 +142,7 @@ class DeviceSchedule(ABC, LogMixin):
         )
 
         # ultimately we want UTC
-        next_run = next_run.astimezone(pytz.utc)
+        next_run = next_run.astimezone(utc)
 
         return next_run
 

--- a/services/scheduler/scheduler/services/device_schedule.py
+++ b/services/scheduler/scheduler/services/device_schedule.py
@@ -34,7 +34,7 @@ class DeviceSchedule(ABC, LogMixin):
         condition_parser_factory: providers.Factory,
         cron_factory: providers.Factory,
         device: str,
-        cron: str,
+        schedule: str,
         condition: Expression | None = None,
         scene: str | None = None,
         power: bool | None = None
@@ -50,7 +50,7 @@ class DeviceSchedule(ABC, LogMixin):
         self.__producer = mqtt_client.add_producer()
 
         self.__device = device
-        self.__cron: Cron = cron_factory(cron_string=cron)
+        self.__cron: Cron = cron_factory(cron_string=schedule)
         self.__condition = condition
         self.__power = power
 

--- a/services/scheduler/scheduler/services/device_schedule.py
+++ b/services/scheduler/scheduler/services/device_schedule.py
@@ -6,6 +6,7 @@ import pytz
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.base import BaseTrigger
 from cron_converter import Cron
+from cron_descriptor import get_description
 from dependency_injector import providers
 from powerpi_common.condition import (ConditionParser, Expression,
                                       ParseException)
@@ -189,7 +190,7 @@ class DeviceSchedule(ABC, LogMixin):
         )
 
     def __str__(self):
-        builder = f'Every "{str(self.__cron)}"'
+        builder = get_description(str(self.__cron))
 
         if self.__condition:
             builder += ', if the condition is true,'

--- a/services/scheduler/scheduler/services/device_schedule.py
+++ b/services/scheduler/scheduler/services/device_schedule.py
@@ -124,7 +124,18 @@ class DeviceSchedule(ABC, LogMixin):
         '''
         now = datetime.now(self._timezone)
 
-        return self.__cron.schedule(start_date=now).next().astimezone(pytz.utc)
+        schedule = self.__cron.schedule(start_date=now)
+
+        # get the next schedule time
+        next_run = schedule.next()
+
+        # the schedule time will be in the same timezone as now, even if it shouldn't be due to DST
+        next_run = next_run.replace(tzinfo=None)
+
+        # ultimately we want UTC
+        next_run = next_run.astimezone(pytz.utc)
+
+        return next_run
 
     @abstractmethod
     def _build_trigger(self) -> Tuple[BaseTrigger, List[Any]]:

--- a/services/scheduler/scheduler/services/device_schedule.py
+++ b/services/scheduler/scheduler/services/device_schedule.py
@@ -124,13 +124,21 @@ class DeviceSchedule(ABC, LogMixin):
         '''
         now = datetime.now(self._timezone)
 
-        schedule = self.__cron.schedule(start_date=now)
-
         # get the next schedule time
+        schedule = self.__cron.schedule(start_date=now)
         next_run = schedule.next()
 
-        # the schedule time will be in the same timezone as now, even if it shouldn't be due to DST
+        # the schedule time will be in the same timezone as now,
+        # even if it shouldn't be due to DST changes
         next_run = next_run.replace(tzinfo=None)
+
+        # now we've cleared the erroneous timezone, set the correct timezone
+        next_run_timezone = self._timezone.localize(next_run).tzinfo
+        next_run = datetime.combine(
+            next_run.date(),
+            next_run.time(),
+            next_run_timezone
+        )
 
         # ultimately we want UTC
         next_run = next_run.astimezone(pytz.utc)

--- a/services/scheduler/scheduler/services/device_schedule_factory.py
+++ b/services/scheduler/scheduler/services/device_schedule_factory.py
@@ -25,11 +25,8 @@ class DeviceScheduleFactory(LogMixin):
             **device_schedule
         }
 
-        if 'between' in device_schedule and 'interval' in device_schedule:
+        if 'duration' in device_schedule and 'interval' in device_schedule:
             return self.__device_interval_schedule_factory(**kwargs)
 
-        if 'at' in device_schedule:
-            return self.__device_single_schedule_factory(**kwargs)
-
-        self.log_error('Count not identify the requested schedule type')
-        return None
+        # the single schedule just uses "cron"
+        return self.__device_single_schedule_factory(**kwargs)

--- a/services/scheduler/scheduler/services/device_schedule_factory.py
+++ b/services/scheduler/scheduler/services/device_schedule_factory.py
@@ -28,5 +28,5 @@ class DeviceScheduleFactory(LogMixin):
         if 'duration' in device_schedule and 'interval' in device_schedule:
             return self.__device_interval_schedule_factory(**kwargs)
 
-        # the single schedule just uses "cron"
+        # the single schedule just uses "schedule"
         return self.__device_single_schedule_factory(**kwargs)

--- a/services/scheduler/scheduler/services/device_single_schedule.py
+++ b/services/scheduler/scheduler/services/device_single_schedule.py
@@ -1,6 +1,3 @@
-from datetime import datetime, time, timedelta
-
-import pytz
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.date import DateTrigger
 from dependency_injector import providers
@@ -26,8 +23,8 @@ class DeviceSingleSchedule(DeviceSchedule):
         scheduler: AsyncIOScheduler,
         variable_manager: VariableManager,
         condition_parser_factory: providers.Factory,
+        cron_factory: providers.Factory,
         device: str,
-        at: str,
         brightness: int | None = None,
         hue: int | None = None,
         saturation: int | None = None,
@@ -43,11 +40,10 @@ class DeviceSingleSchedule(DeviceSchedule):
             scheduler,
             variable_manager,
             condition_parser_factory,
+            cron_factory,
             device,
             **kwargs
         )
-
-        self.__at = at
 
         self.__additional_state = {}
         if brightness is not None:
@@ -59,8 +55,8 @@ class DeviceSingleSchedule(DeviceSchedule):
         if temperature is not None:
             self.__additional_state['temperature'] = temperature
 
-    def _build_trigger(self, start: datetime | None = None):
-        at = self.__calculate_date(start)
+    def _build_trigger(self):
+        at = self._next_run()
 
         trigger = DateTrigger(
             run_date=at
@@ -78,39 +74,3 @@ class DeviceSingleSchedule(DeviceSchedule):
 
     def _check_next_condition(self, **_):
         return True
-
-    def __calculate_date(self, start: datetime | None = None):
-        at = [int(part) for part in self.__at.split(':', 3)]
-
-        timezone = self._timezone
-
-        if start is not None:
-            start = start.astimezone(timezone)
-        else:
-            start = datetime.now(timezone)
-
-        start_date = timezone.localize(datetime.combine(
-            start.date(), time(at[0], at[1], at[2], 0)
-        ))
-
-        # check it's not in the past
-        if start_date <= datetime.now(timezone):
-            start_date += timedelta(days=1)
-
-        # find the next appropriate day-of-week
-        start_date = self._find_valid_day(start_date)
-
-        start_date = timezone.localize(datetime.combine(
-            start_date.date(), time(at[0], at[1], at[2], 0)
-        ))
-
-        start_date = start_date.astimezone(pytz.UTC)
-
-        return start_date
-
-    def __str__(self):
-        builder = f'Every {self.__at}'
-
-        builder += super().__str__()
-
-        return builder

--- a/services/scheduler/scheduler/services/device_single_schedule.py
+++ b/services/scheduler/scheduler/services/device_single_schedule.py
@@ -24,7 +24,6 @@ class DeviceSingleSchedule(DeviceSchedule):
         variable_manager: VariableManager,
         condition_parser_factory: providers.Factory,
         cron_factory: providers.Factory,
-        device: str,
         brightness: int | None = None,
         hue: int | None = None,
         saturation: int | None = None,
@@ -41,7 +40,6 @@ class DeviceSingleSchedule(DeviceSchedule):
             variable_manager,
             condition_parser_factory,
             cron_factory,
-            device,
             **kwargs
         )
 

--- a/services/scheduler/tests/services/test_device_schedule_factory.py
+++ b/services/scheduler/tests/services/test_device_schedule_factory.py
@@ -14,7 +14,7 @@ class TestDeviceScheduleFactory:
         single_factory: MagicMock
     ):
         result = subject.build(
-            'MyDevice', {'between': ['09:00:00', '09:10:00'], 'interval': 300})
+            'MyDevice', {'cron': '* * * * *', 'duration': 600, 'interval': 300})
 
         assert result is not None
         assert result == 'Interval'
@@ -22,7 +22,8 @@ class TestDeviceScheduleFactory:
         assert interval_factory.call_count == 1
         assert interval_factory.call_args_list[0] == call(
             device='MyDevice',
-            between=['09:00:00', '09:10:00'],
+            cron='* * * * *',
+            duration=600,
             interval=300
         )
 
@@ -35,7 +36,8 @@ class TestDeviceScheduleFactory:
         single_factory: MagicMock
     ):
         result = subject.build(
-            'MyDevice', {'at': '09:00:00'})
+            'MyDevice', {'cron': '* * * * *'}
+        )
 
         assert result is not None
         assert result == 'Single'
@@ -43,23 +45,10 @@ class TestDeviceScheduleFactory:
         assert single_factory.call_count == 1
         assert single_factory.call_args_list[0] == call(
             device='MyDevice',
-            at='09:00:00'
+            cron='* * * * *'
         )
 
         assert interval_factory.call_count == 0
-
-    def test_build_not_found(
-        self,
-        subject: DeviceScheduleFactory,
-        interval_factory: MagicMock,
-        single_factory: MagicMock
-    ):
-        result = subject.build('MyDevice', {})
-
-        assert result is None
-
-        assert interval_factory.call_count == 0
-        assert single_factory.call_count == 0
 
     @pytest.fixture
     def subject(

--- a/services/scheduler/tests/services/test_device_schedule_factory.py
+++ b/services/scheduler/tests/services/test_device_schedule_factory.py
@@ -14,7 +14,7 @@ class TestDeviceScheduleFactory:
         single_factory: MagicMock
     ):
         result = subject.build(
-            'MyDevice', {'cron': '* * * * *', 'duration': 600, 'interval': 300})
+            'MyDevice', {'schedule': '* * * * *', 'duration': 600, 'interval': 300})
 
         assert result is not None
         assert result == 'Interval'
@@ -22,7 +22,7 @@ class TestDeviceScheduleFactory:
         assert interval_factory.call_count == 1
         assert interval_factory.call_args_list[0] == call(
             device='MyDevice',
-            cron='* * * * *',
+            schedule='* * * * *',
             duration=600,
             interval=300
         )
@@ -36,7 +36,7 @@ class TestDeviceScheduleFactory:
         single_factory: MagicMock
     ):
         result = subject.build(
-            'MyDevice', {'cron': '* * * * *'}
+            'MyDevice', {'schedule': '* * * * *'}
         )
 
         assert result is not None
@@ -45,7 +45,7 @@ class TestDeviceScheduleFactory:
         assert single_factory.call_count == 1
         assert single_factory.call_args_list[0] == call(
             device='MyDevice',
-            cron='* * * * *'
+            schedule='* * * * *'
         )
 
         assert interval_factory.call_count == 0

--- a/services/scheduler/tests/services/test_device_single_schedule.py
+++ b/services/scheduler/tests/services/test_device_single_schedule.py
@@ -32,7 +32,7 @@ class ExpectedTime:
 class TestDeviceSingleSchedule:
     __expected_topic = 'device/SomeDevice/change'
 
-    @pytest.mark.parametrize('cron,now,timezone,expected', [
+    @pytest.mark.parametrize('schedule,now,timezone,expected', [
         (
             '0 9 * * *', None, None, ExpectedTime(2, 9, 0)
         ),
@@ -83,7 +83,7 @@ class TestDeviceSingleSchedule:
         self,
         subject_builder: SubjectBuilder,
         add_job: AddJobType,
-        cron: str,
+        schedule: str,
         now: datetime | None,
         timezone: str,
         expected: ExpectedTime,
@@ -97,7 +97,7 @@ class TestDeviceSingleSchedule:
 
         subject = subject_builder({
             'device': 'SomeDevice',
-            'cron': cron
+            'schedule': schedule
         })
 
         with patch_datetime(
@@ -131,7 +131,7 @@ class TestDeviceSingleSchedule:
     ):
         subject = subject_builder({
             'device': 'SomeDevice',
-            'cron': '0 9 * * *',
+            'schedule': '0 9 * * *',
             'condition': condition
         })
 
@@ -168,7 +168,7 @@ class TestDeviceSingleSchedule:
         with patch_datetime(datetime(2023, 3, 1, 9, 1, tzinfo=pytz.UTC)):
             subject = subject_builder({
                 'device': 'SomeDevice',
-                'cron': '0 9 * * *',
+                'schedule': '0 9 * * *',
                 **config
             })
 

--- a/services/scheduler/tests/services/test_device_single_schedule.py
+++ b/services/scheduler/tests/services/test_device_single_schedule.py
@@ -46,24 +46,24 @@ class TestDeviceSingleSchedule:
         # before change over (summer time)
         (
             '0 9 * * *', datetime(2023, 10, 27, 9, 0, 1), None,
-            ExpectedTime(28, 8, 0)
+            ExpectedTime(28, 9 - 1, 0)
         ),
         # after change over (summer -> winter time)
         (
             '0 9 * * *', datetime(2023, 10, 28, 9, 0, 1), None,
-            ExpectedTime(29, 9, 0)
+            ExpectedTime(29, 9 - 0, 0)
         ),
         (
             '0 9 * * *',
             datetime(2025, 11, 1, 9 + 4, 0, 1),
             'America/New_York',
-            ExpectedTime(2, 9 - 5, 0)
+            ExpectedTime(2, 9 + 5, 0)
         ),
         # other way
         # before change over(winter time)
         (
             '0 9 * * *', datetime(2024, 3, 29, 9, 0, 1), None,
-            ExpectedTime(30, 9, 0)
+            ExpectedTime(30, 9 - 0, 0)
         ),
         # after change over (winter -> summer time)
         (
@@ -76,7 +76,7 @@ class TestDeviceSingleSchedule:
             '0 9 * * *',
             datetime(2025, 3, 8, 9 + 5, 0, 1),
             'America/New_York',
-            ExpectedTime(9, 9 - 4, 0)
+            ExpectedTime(9, 9 + 4, 0)
         ),
     ])
     def test_start(
@@ -262,5 +262,6 @@ def patch_datetime(mock_now: datetime):
 
     with patch('scheduler.services.device_schedule.datetime') as mock_datetime:
         mock_datetime.now = now
+        mock_datetime.combine = datetime.combine
 
         yield mock_datetime


### PR DESCRIPTION
Resolves #560.
- Update scheduler to use cron syntax in "schedule" property.
- Update scheduler interval schedule to use "duration" property to set how long to repeat for.
- Pretty print the schedule when describing the configuration.