### PR TITLE
#609 fix(k8s): Switch to using the topologySpreadConstraints syntax

### DIFF
--- a/kubernetes/templates/_template.tpl
+++ b/kubernetes/templates/_template.tpl
@@ -58,16 +58,15 @@ template:
     {{- end }}
 
     {{- if and .Values.global.useCluster (gt (.Params.Replicas | default 1) 1) }}
-    affinity:
-      podAntiAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-        - labelSelector:
-            matchExpressions:
-            - key: app.kubernetes.io/name
-              operator: In
-              values:
-              - {{ .Chart.Name }}
-          topologyKey: kubenertes.io/hostname
+    topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: {{ .Chart.Name }}
+      matchLabelKeys:
+      - pod-template-hash
     {{- end -}}
 
     {{- if eq (empty .Params.PriorityClassName) false }}


### PR DESCRIPTION
Resolves #609 
- When deploying services with replicas use the `topologySpreadConstraints` to ensure they're not running on the same node.