### PR TITLE
#557 feat(api+ui): Show device state as loading when a change message is broadcast

### DIFF
--- a/common/node/common-api/src/DeviceChangeMessage.ts
+++ b/common/node/common-api/src/DeviceChangeMessage.ts
@@ -7,6 +7,7 @@ export default interface ChangeMessage extends AdditionalState {
 
 export type DeviceChangeMessage = {
     device: string;
+    timestamp: number;
 } & ChangeMessage;
 
 export type DeviceChangeCallback = (message: DeviceChangeMessage) => void;

--- a/common/node/common-api/src/DeviceChangeMessage.ts
+++ b/common/node/common-api/src/DeviceChangeMessage.ts
@@ -4,3 +4,9 @@ import DeviceState from "./DeviceState";
 export default interface ChangeMessage extends AdditionalState {
     state?: DeviceState;
 }
+
+export type DeviceChangeMessage = {
+    device: string;
+} & ChangeMessage;
+
+export type DeviceChangeCallback = (message: DeviceChangeMessage) => void;

--- a/common/node/common-api/src/PowerPiApi.ts
+++ b/common/node/common-api/src/PowerPiApi.ts
@@ -6,7 +6,7 @@ import { CapabilityStatusCallback, CapabilityStatusMessage } from "./CapabilityS
 import Config from "./Config";
 import { ConfigStatusCallback, ConfigStatusMessage } from "./ConfigStatus";
 import Device from "./Device";
-import DeviceChangeMessage, { DeviceChangeCallback } from "./DeviceChangeMessage";
+import ChangeMessage, { DeviceChangeCallback, DeviceChangeMessage } from "./DeviceChangeMessage";
 import DeviceState from "./DeviceState";
 import { DeviceStatusCallback, DeviceStatusMessage } from "./DeviceStatus";
 import { Floorplan } from "./Floorplan";
@@ -97,7 +97,7 @@ export default class PowerPiApi {
         state?: DeviceState,
         additionalState?: AdditionalState,
     ) {
-        let message: DeviceChangeMessage = {};
+        let message: ChangeMessage = {};
 
         if (state) {
             message["state"] = state;
@@ -186,6 +186,11 @@ export default class PowerPiApi {
     private readonly onCapabilityMessage = (message: CapabilityStatusMessage) =>
         this.listeners.capability.forEach((listener) => listener(message));
 
+    private readonly onDeviceChangeMessage = (message: DeviceChangeMessage) => {
+        console.log("here");
+        this.listeners.change.forEach((listener) => listener(message));
+    };
+
     private readonly onConfigMessage = (message: ConfigStatusMessage) =>
         this.listeners.config.forEach((listener) => listener(message));
 
@@ -222,6 +227,7 @@ export default class PowerPiApi {
             this.socket.on(SocketIONamespace.Sensor, this.onSensorMessage);
             this.socket.on(SocketIONamespace.Battery, this.onBatteryMessage);
             this.socket.on(SocketIONamespace.Capability, this.onCapabilityMessage);
+            this.socket.on(SocketIONamespace.Change, this.onDeviceChangeMessage);
             this.socket.on(SocketIONamespace.Config, this.onConfigMessage);
         }
     }

--- a/common/node/common-api/src/PowerPiApi.ts
+++ b/common/node/common-api/src/PowerPiApi.ts
@@ -6,7 +6,7 @@ import { CapabilityStatusCallback, CapabilityStatusMessage } from "./CapabilityS
 import Config from "./Config";
 import { ConfigStatusCallback, ConfigStatusMessage } from "./ConfigStatus";
 import Device from "./Device";
-import DeviceChangeMessage from "./DeviceChangeMessage";
+import DeviceChangeMessage, { DeviceChangeCallback } from "./DeviceChangeMessage";
 import DeviceState from "./DeviceState";
 import { DeviceStatusCallback, DeviceStatusMessage } from "./DeviceStatus";
 import { Floorplan } from "./Floorplan";
@@ -28,6 +28,7 @@ export default class PowerPiApi {
         sensor: SensorStatusCallback[];
         battery: BatteryStatusCallback[];
         capability: CapabilityStatusCallback[];
+        change: DeviceChangeCallback[];
         config: ConfigStatusCallback[];
     };
 
@@ -43,6 +44,7 @@ export default class PowerPiApi {
             sensor: [],
             battery: [],
             capability: [],
+            change: [],
             config: [],
         };
 
@@ -128,6 +130,11 @@ export default class PowerPiApi {
         this.listeners.capability.push(callback);
     }
 
+    public addDeviceChangeListener(callback: DeviceChangeCallback) {
+        this.connectSocketIO();
+        this.listeners.change.push(callback);
+    }
+
     public addConfigChangeListener(callback: ConfigStatusCallback) {
         this.connectSocketIO();
         this.listeners.config.push(callback);
@@ -149,6 +156,10 @@ export default class PowerPiApi {
         this.listeners.capability = this.listeners.capability.filter(
             (listener) => listener === callback,
         );
+    }
+
+    public removeDeviceChangeListener(callback: DeviceChangeCallback) {
+        this.listeners.change = this.listeners.change.filter((listener) => listener === callback);
     }
 
     public removeConfigChangeListener(callback: ConfigStatusCallback) {

--- a/common/node/common-api/src/PowerPiApi.ts
+++ b/common/node/common-api/src/PowerPiApi.ts
@@ -186,10 +186,8 @@ export default class PowerPiApi {
     private readonly onCapabilityMessage = (message: CapabilityStatusMessage) =>
         this.listeners.capability.forEach((listener) => listener(message));
 
-    private readonly onDeviceChangeMessage = (message: DeviceChangeMessage) => {
-        console.log("here");
+    private readonly onDeviceChangeMessage = (message: DeviceChangeMessage) =>
         this.listeners.change.forEach((listener) => listener(message));
-    };
 
     private readonly onConfigMessage = (message: ConfigStatusMessage) =>
         this.listeners.config.forEach((listener) => listener(message));

--- a/common/node/common-api/src/SocketIONamespace.ts
+++ b/common/node/common-api/src/SocketIONamespace.ts
@@ -4,5 +4,6 @@ enum SocketIONamespace {
     Battery = "battery",
     Capability = "capability",
     Config = "config",
+    Change = "change",
 }
 export default SocketIONamespace;

--- a/common/node/common-api/src/index.ts
+++ b/common/node/common-api/src/index.ts
@@ -7,7 +7,7 @@ import { CapabilityStatusCallback, CapabilityStatusMessage } from "./CapabilityS
 import Config from "./Config";
 import { ConfigFileType, ConfigStatusCallback, ConfigStatusMessage } from "./ConfigStatus";
 import Device from "./Device";
-import { DeviceChangeCallback, DeviceChangeMessage } from "./DeviceChangeMessage";
+import ChangeMessage, { DeviceChangeCallback, DeviceChangeMessage } from "./DeviceChangeMessage";
 import DeviceState from "./DeviceState";
 import { DeviceStatusCallback, DeviceStatusMessage } from "./DeviceStatus";
 import { Floor, Floorplan, Point, PolygonRoom, RectangleRoom, Room } from "./Floorplan";
@@ -33,6 +33,7 @@ export {
     Capability,
     CapabilityStatusCallback,
     CapabilityStatusMessage,
+    ChangeMessage,
     Config,
     ConfigFileType,
     ConfigStatusCallback,

--- a/common/node/common-api/src/index.ts
+++ b/common/node/common-api/src/index.ts
@@ -7,7 +7,7 @@ import { CapabilityStatusCallback, CapabilityStatusMessage } from "./CapabilityS
 import Config from "./Config";
 import { ConfigFileType, ConfigStatusCallback, ConfigStatusMessage } from "./ConfigStatus";
 import Device from "./Device";
-import DeviceChangeMessage from "./DeviceChangeMessage";
+import { DeviceChangeCallback, DeviceChangeMessage } from "./DeviceChangeMessage";
 import DeviceState from "./DeviceState";
 import { DeviceStatusCallback, DeviceStatusMessage } from "./DeviceStatus";
 import { Floor, Floorplan, Point, PolygonRoom, RectangleRoom, Room } from "./Floorplan";
@@ -38,6 +38,7 @@ export {
     ConfigStatusCallback,
     ConfigStatusMessage,
     Device,
+    DeviceChangeCallback,
     DeviceChangeMessage,
     DeviceState,
     DeviceStatusCallback,

--- a/services/api/src/controllers/DeviceController.test.ts
+++ b/services/api/src/controllers/DeviceController.test.ts
@@ -1,5 +1,5 @@
 import { MqttService } from "@powerpi/common";
-import { Device, DeviceChangeMessage, DeviceState } from "@powerpi/common-api";
+import { ChangeMessage, Device, DeviceState } from "@powerpi/common-api";
 import { Response } from "express";
 import { anything, capture, instance, mock, resetCalls, verify, when } from "ts-mockito";
 import { DeviceStateService } from "../services";
@@ -60,12 +60,8 @@ describe("DeviceController", () => {
         );
 
         [undefined, { nope: true, state: DeviceState.Off }].forEach((data) =>
-            test(`bad data: ${data}`, async () => {
-                await subject?.change(
-                    "thing",
-                    data as DeviceChangeMessage,
-                    instance(mockedResponse),
-                );
+            test(`bad data: ${JSON.stringify(data)}`, async () => {
+                await subject?.change("thing", data as ChangeMessage, instance(mockedResponse));
 
                 verify(
                     mockedMqttService.publish(anything(), anything(), anything(), anything()),

--- a/services/api/src/controllers/DeviceController.ts
+++ b/services/api/src/controllers/DeviceController.ts
@@ -1,5 +1,5 @@
 import { MqttService, OutgoingMessage } from "@powerpi/common";
-import { DeviceChangeMessage } from "@powerpi/common-api";
+import { ChangeMessage } from "@powerpi/common-api";
 import { BodyParams, Controller, Get, PathParams, Post, Res } from "@tsed/common";
 import { Required } from "@tsed/schema";
 import { Response } from "express";
@@ -36,7 +36,7 @@ export default class DeviceController {
     @Authorize()
     async change(
         @PathParams("device") device: string,
-        @Required() @BodyParams() body: DeviceChangeMessage,
+        @Required() @BodyParams() body: ChangeMessage,
         @Res() response: Response,
     ) {
         // fail if there is no message or it contains disallowed keys

--- a/services/api/src/services/ApiSocketService.test.ts
+++ b/services/api/src/services/ApiSocketService.test.ts
@@ -45,6 +45,36 @@ describe("ApiSocketService", () => {
         });
     });
 
+    describe("onDeviceChangeMessage", () => {
+        test("success", () => {
+            subject?.$onNamespaceInit(instance(mockedNamespace));
+
+            subject?.onDeviceChangeMessage(
+                "HallwayLight",
+                DeviceState.On,
+                { brightness: 50 },
+                1234,
+            );
+
+            verify(mockedNamespace.emit("change", anything())).once();
+
+            const payload = capture(mockedNamespace.emit<"change">);
+
+            expect(payload.first()[1]).toStrictEqual({
+                device: "HallwayLight",
+                state: "on",
+                additionalState: { brightness: 50 },
+                timestamp: 1234,
+            });
+        });
+
+        test("no namespace", () => {
+            subject?.onDeviceChangeMessage("HallwayLight", DeviceState.On, {}, 1234);
+
+            verify(mockedNamespace.emit(anyString(), anything())).never();
+        });
+    });
+
     describe("onEventMessage", () => {
         test("motion", () => {
             subject?.$onNamespaceInit(instance(mockedNamespace));

--- a/services/api/src/services/ApiSocketService.ts
+++ b/services/api/src/services/ApiSocketService.ts
@@ -38,13 +38,15 @@ export default class ApiSocketService implements ConfigChangeListener {
 
     onDeviceChangeMessage(
         deviceName: string,
-        state: DeviceState,
-        additionalState?: AdditionalState,
+        state: DeviceState | undefined,
+        additionalState: AdditionalState | undefined,
+        timestamp: number | undefined,
     ) {
         this.namespace?.emit(SocketIONamespace.Change, {
             device: deviceName,
             state,
             additionalState,
+            timestamp,
         });
     }
 

--- a/services/api/src/services/ApiSocketService.ts
+++ b/services/api/src/services/ApiSocketService.ts
@@ -36,6 +36,18 @@ export default class ApiSocketService implements ConfigChangeListener {
         });
     }
 
+    onDeviceChangeMessage(
+        deviceName: string,
+        state: DeviceState,
+        additionalState?: AdditionalState,
+    ) {
+        this.namespace?.emit(SocketIONamespace.Change, {
+            device: deviceName,
+            state,
+            additionalState,
+        });
+    }
+
     onEventMessage(
         sensorName: string,
         action?: string,

--- a/services/api/src/services/DeviceStateService.ts
+++ b/services/api/src/services/DeviceStateService.ts
@@ -93,7 +93,6 @@ export default class DeviceStateService extends DeviceStateListener {
     }
 
     onDeviceChangeMessage(deviceName: string, message: ChangeMessage) {
-        console.log("received", deviceName, message);
         const device = this.getDevice(deviceName);
 
         if (device) {

--- a/services/api/src/services/DeviceStateService.ts
+++ b/services/api/src/services/DeviceStateService.ts
@@ -1,9 +1,11 @@
 import { ConfigRetrieverService, IDevice, MqttService, isDefined } from "@powerpi/common";
 import { AdditionalState, Device, DeviceState } from "@powerpi/common-api";
 import { Service } from "@tsed/common";
+import { omit } from "underscore";
 import ApiSocketService from "./ApiSocketService";
 import ConfigService from "./ConfigService";
 import { CapabilityMessage } from "./listeners/CapabilityStateListener";
+import { ChangeMessage } from "./listeners/DeviceChangeListener";
 import DeviceStateListener from "./listeners/DeviceStateListener";
 
 @Service()
@@ -90,11 +92,17 @@ export default class DeviceStateService extends DeviceStateListener {
         }
     }
 
-    onChangeMessage(deviceName: string, state: DeviceState, additionalState?: AdditionalState) {
+    onDeviceChangeMessage(deviceName: string, message: ChangeMessage) {
+        console.log("received", deviceName, message);
         const device = this.getDevice(deviceName);
 
         if (device) {
-            this.socket.onDeviceChangeMessage(device.name, state, additionalState);
+            this.socket.onDeviceChangeMessage(
+                device.name,
+                message.state,
+                omit(message, "state", "timestamp"),
+                message.timestamp,
+            );
         }
     }
 

--- a/services/api/src/services/DeviceStateService.ts
+++ b/services/api/src/services/DeviceStateService.ts
@@ -90,6 +90,14 @@ export default class DeviceStateService extends DeviceStateListener {
         }
     }
 
+    onChangeMessage(deviceName: string, state: DeviceState, additionalState?: AdditionalState) {
+        const device = this.getDevice(deviceName);
+
+        if (device) {
+            this.socket.onDeviceChangeMessage(device.name, state, additionalState);
+        }
+    }
+
     protected onConfigChange() {
         // get the new list of devices
         const devices = this.config.devices;
@@ -131,7 +139,7 @@ export default class DeviceStateService extends DeviceStateListener {
     }
 
     /** The options a device should have when it's first loaded. */
-    private initialiseDevice = (device: IDevice): Device => ({
+    private readonly initialiseDevice = (device: IDevice): Device => ({
         ...this.defaultDevice(device),
         display_name: device.displayName,
         state: DeviceState.Unknown,
@@ -142,7 +150,7 @@ export default class DeviceStateService extends DeviceStateListener {
     });
 
     /** The device options with values for any that have defaults. */
-    private defaultDevice = (device: IDevice) => ({
+    private readonly defaultDevice = (device: IDevice) => ({
         ...device,
         visible: device.visible ?? true,
     });

--- a/services/api/src/services/DeviceStateService.ts
+++ b/services/api/src/services/DeviceStateService.ts
@@ -57,6 +57,19 @@ export default class DeviceStateService extends DeviceStateListener {
         }
     }
 
+    onDeviceChangeMessage(deviceName: string, message: ChangeMessage) {
+        const device = this.getDevice(deviceName);
+
+        if (device) {
+            this.socket.onDeviceChangeMessage(
+                device.name,
+                message.state,
+                omit(message, "state", "timestamp"),
+                message.timestamp,
+            );
+        }
+    }
+
     protected onDeviceBatteryMessage(
         deviceName: string,
         value: number,
@@ -89,19 +102,6 @@ export default class DeviceStateService extends DeviceStateListener {
             device.capability = capability;
 
             this.socket.onCapabilityMessage(device.name, device.capability, message.timestamp);
-        }
-    }
-
-    onDeviceChangeMessage(deviceName: string, message: ChangeMessage) {
-        const device = this.getDevice(deviceName);
-
-        if (device) {
-            this.socket.onDeviceChangeMessage(
-                device.name,
-                message.state,
-                omit(message, "state", "timestamp"),
-                message.timestamp,
-            );
         }
     }
 

--- a/services/api/src/services/listeners/DeviceChangeListener.ts
+++ b/services/api/src/services/listeners/DeviceChangeListener.ts
@@ -1,0 +1,11 @@
+import { Message } from "@powerpi/common";
+import { AdditionalState, DeviceState } from "@powerpi/common-api";
+
+export type ChangeMessage = Message &
+    AdditionalState & {
+        state?: DeviceState;
+    };
+
+export default interface DeviceChangeListener {
+    onDeviceChangeMessage(entity: string, message: ChangeMessage): void;
+}

--- a/services/api/src/services/listeners/DeviceStateListener.ts
+++ b/services/api/src/services/listeners/DeviceStateListener.ts
@@ -8,6 +8,7 @@ import {
 import { AdditionalState, DeviceState } from "@powerpi/common-api";
 import BatteryStateListener, { BatteryMessage } from "./BatteryStateListener";
 import CapabilityStateListener, { CapabilityMessage } from "./CapabilityStateListener";
+import DeviceChangeListener, { ChangeMessage } from "./DeviceChangeListener";
 
 export interface StateMessage extends Message, AdditionalState {
     state: DeviceState;
@@ -15,7 +16,7 @@ export interface StateMessage extends Message, AdditionalState {
 
 export default abstract class DeviceStateListener
     extends BatteryStateListener
-    implements MqttConsumer<StateMessage>, CapabilityStateListener
+    implements MqttConsumer<StateMessage>, CapabilityStateListener, DeviceChangeListener
 {
     constructor(
         private readonly configRetriever: ConfigRetrieverService,
@@ -37,6 +38,11 @@ export default abstract class DeviceStateListener
                 this.onCapabilityMessage(entity, message),
         });
 
+        await this.mqttService.subscribe("device", "+", "change", {
+            message: (_: string, entity: string, __: string, message: ChangeMessage) =>
+                this.onDeviceChangeMessage(entity, message),
+        });
+
         this.configRetriever.addListener(ConfigFileType.Devices, {
             onConfigChange: (type: ConfigFileType) => {
                 if (type === ConfigFileType.Devices) {
@@ -56,6 +62,8 @@ export default abstract class DeviceStateListener
     }
 
     abstract onCapabilityMessage(entity: string, message: CapabilityMessage): void;
+
+    abstract onDeviceChangeMessage(entity: string, message: ChangeMessage): void;
 
     protected onBatteryMessage = (
         entity: string,

--- a/services/ui/src/components/DevicePowerToggle/DevicePowerToggle.tsx
+++ b/services/ui/src/components/DevicePowerToggle/DevicePowerToggle.tsx
@@ -63,15 +63,9 @@ const DevicePowerToggle = ({ device, ...props }: DevicePowerToggleProps) => {
                 };
 
             case DeviceState.Off:
+            case DeviceState.Unknown:
                 return {
                     checked: false,
-                    label: t(`common.${key} on`, { device: device.display_name }),
-                };
-
-            case DeviceState.Unknown:
-            default:
-                return {
-                    checked: undefined,
                     label: t(`common.${key} on`, { device: device.display_name }),
                 };
         }

--- a/services/ui/src/queries/notifications/NotificationContext.tsx
+++ b/services/ui/src/queries/notifications/NotificationContext.tsx
@@ -13,9 +13,9 @@ type NotificationContextType = {
 
 export const NotificationContext = createContext<NotificationContextType>({});
 
-type NotificationContextProvider = PropsWithChildren<unknown>;
+type NotificationContextProviderProps = PropsWithChildren<unknown>;
 
-export const NotificationContextProvider = ({ children }: NotificationContextProvider) => {
+export const NotificationContextProvider = ({ children }: NotificationContextProviderProps) => {
     const [changingState, setChangingState] = useState<ChangingStateType>({});
 
     const handleChangingState = useCallback((device: string, changing: boolean) => {

--- a/services/ui/src/queries/notifications/useNotification.test.tsx
+++ b/services/ui/src/queries/notifications/useNotification.test.tsx
@@ -3,6 +3,7 @@ import {
     CapabilityStatusMessage,
     ConfigFileType,
     ConfigStatusMessage,
+    DeviceChangeMessage,
     DeviceState,
     DeviceStatusMessage,
     SensorStatusMessage,
@@ -15,11 +16,13 @@ const mocks = vi.hoisted(() => ({
     api: {
         addConfigChangeListener: vi.fn(),
         addDeviceListener: vi.fn(),
+        addDeviceChangeListener: vi.fn(),
         addSensorListener: vi.fn(),
         addBatteryListener: vi.fn(),
         addCapabilityListener: vi.fn(),
         removeConfigChangeListener: vi.fn(),
         removeDeviceListener: vi.fn(),
+        removeDeviceChangeListener: vi.fn(),
         removeSensorListener: vi.fn(),
         removeBatteryListener: vi.fn(),
         removeCapabilityListener: vi.fn(),
@@ -63,12 +66,14 @@ describe("useNotification", () => {
 
         expect(mocks.api.addConfigChangeListener).not.toHaveBeenCalledTimes(1);
         expect(mocks.api.addDeviceListener).not.toHaveBeenCalledTimes(1);
+        expect(mocks.api.addDeviceChangeListener).not.toHaveBeenCalledTimes(1);
         expect(mocks.api.addSensorListener).not.toHaveBeenCalledTimes(1);
         expect(mocks.api.addBatteryListener).not.toHaveBeenCalledTimes(1);
         expect(mocks.api.addCapabilityListener).not.toHaveBeenCalledTimes(1);
 
         expect(mocks.api.removeConfigChangeListener).not.toHaveBeenCalled();
         expect(mocks.api.removeDeviceListener).not.toHaveBeenCalled();
+        expect(mocks.api.removeDeviceChangeListener).not.toHaveBeenCalled();
         expect(mocks.api.removeSensorListener).not.toHaveBeenCalled();
         expect(mocks.api.removeBatteryListener).not.toHaveBeenCalled();
         expect(mocks.api.removeCapabilityListener).not.toHaveBeenCalled();
@@ -77,6 +82,7 @@ describe("useNotification", () => {
 
         expect(mocks.api.removeConfigChangeListener).not.toHaveBeenCalled();
         expect(mocks.api.removeDeviceListener).not.toHaveBeenCalled();
+        expect(mocks.api.removeDeviceChangeListener).not.toHaveBeenCalled();
         expect(mocks.api.removeSensorListener).not.toHaveBeenCalled();
         expect(mocks.api.removeBatteryListener).not.toHaveBeenCalled();
         expect(mocks.api.removeCapabilityListener).not.toHaveBeenCalled();
@@ -89,12 +95,14 @@ describe("useNotification", () => {
 
         expect(mocks.api.addConfigChangeListener).toHaveBeenCalledTimes(1);
         expect(mocks.api.addDeviceListener).toHaveBeenCalledTimes(1);
+        expect(mocks.api.addDeviceChangeListener).toHaveBeenCalledTimes(1);
         expect(mocks.api.addSensorListener).toHaveBeenCalledTimes(1);
         expect(mocks.api.addBatteryListener).toHaveBeenCalledTimes(1);
         expect(mocks.api.addCapabilityListener).toHaveBeenCalledTimes(1);
 
         expect(mocks.api.removeConfigChangeListener).not.toHaveBeenCalled();
         expect(mocks.api.removeDeviceListener).not.toHaveBeenCalled();
+        expect(mocks.api.removeDeviceChangeListener).not.toHaveBeenCalled();
         expect(mocks.api.removeSensorListener).not.toHaveBeenCalled();
         expect(mocks.api.removeBatteryListener).not.toHaveBeenCalled();
         expect(mocks.api.removeCapabilityListener).not.toHaveBeenCalled();
@@ -103,6 +111,7 @@ describe("useNotification", () => {
 
         expect(mocks.api.removeConfigChangeListener).toHaveBeenCalledTimes(1);
         expect(mocks.api.removeDeviceListener).toHaveBeenCalledTimes(1);
+        expect(mocks.api.removeDeviceChangeListener).toHaveBeenCalledTimes(1);
         expect(mocks.api.removeSensorListener).toHaveBeenCalledTimes(1);
         expect(mocks.api.removeBatteryListener).toHaveBeenCalledTimes(1);
         expect(mocks.api.removeCapabilityListener).toHaveBeenCalledTimes(1);
@@ -174,6 +183,35 @@ describe("useNotification", () => {
 
         expect(mocks.setChangingState).toHaveBeenCalledTimes(1);
         expect(mocks.setChangingState).toHaveBeenCalledWith("MyDevice", false);
+    });
+
+    test("handleDeviceChange", async () => {
+        renderHook(useNotification);
+
+        expect(mocks.api.addDeviceChangeListener).toHaveBeenCalledTimes(1);
+
+        const now = new Date().getTime();
+        const event: DeviceChangeMessage = {
+            device: "MyDevice",
+            state: DeviceState.On,
+
+            brightness: 100,
+
+            timestamp: now,
+        };
+
+        const handleDeviceChange = mocks.api.addDeviceChangeListener.mock.calls[0][0];
+        await act(() => handleDeviceChange(event));
+
+        expect(mocks.patchDevice).toHaveBeenCalledTimes(1);
+        expect(mocks.patchDevice).toHaveBeenCalledWith("MyDevice", {
+            type: "State",
+            state: DeviceState.Unknown,
+            since: now,
+        });
+
+        expect(mocks.setChangingState).toHaveBeenCalledTimes(1);
+        expect(mocks.setChangingState).toHaveBeenCalledWith("MyDevice", true);
     });
 
     describe("handleSensorStatusChange", () => {

--- a/services/ui/src/queries/notifications/useNotification.ts
+++ b/services/ui/src/queries/notifications/useNotification.ts
@@ -3,6 +3,7 @@ import {
     CapabilityStatusMessage,
     ConfigFileType,
     ConfigStatusMessage,
+    DeviceChangeMessage,
     DeviceStatusMessage,
     SensorStatusMessage,
 } from "@powerpi/common-api";
@@ -94,6 +95,12 @@ export default function useNotification() {
             }
         }
 
+        async function handleDeviceChange(message: DeviceChangeMessage) {
+            if (setChangingState) {
+                setChangingState(message.device, true);
+            }
+        }
+
         async function handleCapabilityChange(message: CapabilityStatusMessage) {
             patchDevice(message.device, {
                 type: "Capability",
@@ -109,6 +116,7 @@ export default function useNotification() {
             api.addSensorListener(handleSensorStatusChange);
             api.addBatteryListener(handleBatteryChange);
             api.addCapabilityListener(handleCapabilityChange);
+            api.addDeviceChangeListener(handleDeviceChange);
 
             // remove the listeners
             return () => {
@@ -117,6 +125,7 @@ export default function useNotification() {
                 api.removeSensorListener(handleSensorStatusChange);
                 api.removeBatteryListener(handleBatteryChange);
                 api.removeCapabilityListener(handleCapabilityChange);
+                api.removeDeviceChangeListener(handleDeviceChange);
             };
         }
     }, [api, patchDevice, patchSensor, queryClient, setChangingState, user]);

--- a/services/ui/src/queries/notifications/useNotification.ts
+++ b/services/ui/src/queries/notifications/useNotification.ts
@@ -39,7 +39,7 @@ export default function useNotification() {
             }
         }
 
-        async function handleDeviceStatusChange(message: DeviceStatusMessage) {
+        function handleDeviceStatusChange(message: DeviceStatusMessage) {
             patchDevice(message.device, {
                 type: "State",
                 state: message.state,
@@ -52,7 +52,7 @@ export default function useNotification() {
             }
         }
 
-        async function handleSensorStatusChange(message: SensorStatusMessage) {
+        function handleSensorStatusChange(message: SensorStatusMessage) {
             if ("state" in message) {
                 patchSensor(message.sensor, {
                     type: "State",
@@ -77,7 +77,7 @@ export default function useNotification() {
             }
         }
 
-        async function handleBatteryChange(message: BatteryStatusMessage) {
+        function handleBatteryChange(message: BatteryStatusMessage) {
             if ("device" in message) {
                 patchDevice(message.device, {
                     type: "Battery",
@@ -95,13 +95,14 @@ export default function useNotification() {
             }
         }
 
-        async function handleDeviceChange(message: DeviceChangeMessage) {
+        function handleDeviceChange(message: DeviceChangeMessage) {
+            console.log(message);
             if (setChangingState) {
                 setChangingState(message.device, true);
             }
         }
 
-        async function handleCapabilityChange(message: CapabilityStatusMessage) {
+        function handleCapabilityChange(message: CapabilityStatusMessage) {
             patchDevice(message.device, {
                 type: "Capability",
                 capability: message.capability,
@@ -109,14 +110,16 @@ export default function useNotification() {
             });
         }
 
+        console.log("register");
+
         // add the listeners
         if (user) {
             api.addConfigChangeListener(handleConfigChange);
             api.addDeviceListener(handleDeviceStatusChange);
             api.addSensorListener(handleSensorStatusChange);
             api.addBatteryListener(handleBatteryChange);
-            api.addCapabilityListener(handleCapabilityChange);
             api.addDeviceChangeListener(handleDeviceChange);
+            api.addCapabilityListener(handleCapabilityChange);
 
             // remove the listeners
             return () => {
@@ -124,8 +127,8 @@ export default function useNotification() {
                 api.removeDeviceListener(handleDeviceStatusChange);
                 api.removeSensorListener(handleSensorStatusChange);
                 api.removeBatteryListener(handleBatteryChange);
-                api.removeCapabilityListener(handleCapabilityChange);
                 api.removeDeviceChangeListener(handleDeviceChange);
+                api.removeCapabilityListener(handleCapabilityChange);
             };
         }
     }, [api, patchDevice, patchSensor, queryClient, setChangingState, user]);

--- a/services/ui/src/queries/notifications/useNotification.ts
+++ b/services/ui/src/queries/notifications/useNotification.ts
@@ -4,6 +4,7 @@ import {
     ConfigFileType,
     ConfigStatusMessage,
     DeviceChangeMessage,
+    DeviceState,
     DeviceStatusMessage,
     SensorStatusMessage,
 } from "@powerpi/common-api";
@@ -96,8 +97,12 @@ export default function useNotification() {
         }
 
         function handleDeviceChange(message: DeviceChangeMessage) {
-            console.log(message);
             if (setChangingState) {
+                patchDevice(message.device, {
+                    type: "State",
+                    state: DeviceState.Unknown,
+                    since: message.timestamp,
+                });
                 setChangingState(message.device, true);
             }
         }
@@ -109,8 +114,6 @@ export default function useNotification() {
                 since: message.timestamp,
             });
         }
-
-        console.log("register");
 
         // add the listeners
         if (user) {

--- a/services/ui/src/queries/notifications/useNotification.ts
+++ b/services/ui/src/queries/notifications/useNotification.ts
@@ -53,6 +53,17 @@ export default function useNotification() {
             }
         }
 
+        function handleDeviceChange(message: DeviceChangeMessage) {
+            if (setChangingState) {
+                patchDevice(message.device, {
+                    type: "State",
+                    state: DeviceState.Unknown,
+                    since: message.timestamp,
+                });
+                setChangingState(message.device, true);
+            }
+        }
+
         function handleSensorStatusChange(message: SensorStatusMessage) {
             if ("state" in message) {
                 patchSensor(message.sensor, {
@@ -96,17 +107,6 @@ export default function useNotification() {
             }
         }
 
-        function handleDeviceChange(message: DeviceChangeMessage) {
-            if (setChangingState) {
-                patchDevice(message.device, {
-                    type: "State",
-                    state: DeviceState.Unknown,
-                    since: message.timestamp,
-                });
-                setChangingState(message.device, true);
-            }
-        }
-
         function handleCapabilityChange(message: CapabilityStatusMessage) {
             patchDevice(message.device, {
                 type: "Capability",
@@ -119,18 +119,18 @@ export default function useNotification() {
         if (user) {
             api.addConfigChangeListener(handleConfigChange);
             api.addDeviceListener(handleDeviceStatusChange);
+            api.addDeviceChangeListener(handleDeviceChange);
             api.addSensorListener(handleSensorStatusChange);
             api.addBatteryListener(handleBatteryChange);
-            api.addDeviceChangeListener(handleDeviceChange);
             api.addCapabilityListener(handleCapabilityChange);
 
             // remove the listeners
             return () => {
                 api.removeConfigChangeListener(handleConfigChange);
                 api.removeDeviceListener(handleDeviceStatusChange);
+                api.removeDeviceChangeListener(handleDeviceChange);
                 api.removeSensorListener(handleSensorStatusChange);
                 api.removeBatteryListener(handleBatteryChange);
-                api.removeDeviceChangeListener(handleDeviceChange);
                 api.removeCapabilityListener(handleCapabilityChange);
             };
         }

--- a/services/ui/src/queries/notifications/useNotification.ts
+++ b/services/ui/src/queries/notifications/useNotification.ts
@@ -54,12 +54,13 @@ export default function useNotification() {
         }
 
         function handleDeviceChange(message: DeviceChangeMessage) {
+            patchDevice(message.device, {
+                type: "State",
+                state: DeviceState.Unknown,
+                since: message.timestamp,
+            });
+
             if (setChangingState) {
-                patchDevice(message.device, {
-                    type: "State",
-                    state: DeviceState.Unknown,
-                    since: message.timestamp,
-                });
                 setChangingState(message.device, true);
             }
         }


### PR DESCRIPTION
Resolves #557.

`api`:
- Broadcast change messages to the UI through socket.io.

`ui`:
- Set the device loading state to true when receiving a change event.