### PR TITLE
#608 fix(k8s)!: Correct network policies and MQTT access for network-controller

### DIFF
--- a/kubernetes/charts/mosquitto/templates/certificate.yaml
+++ b/kubernetes/charts/mosquitto/templates/certificate.yaml
@@ -1,13 +1,9 @@
-{{- if and 
-    (eq .Values.global.useSSL true) 
-    (eq .Values.global.useSensors true) 
-    (not (eq .Values.global.clusterIssuer nil)) 
-    (not (eq .Values.hostName nil)) 
--}}
+{{- $ssl := eq (include "powerpi.mosquitto-ssl" .) "true" -}}
+{{- if $ssl -}}
 
 {{- $data := dict
   "Name" "mosquitto-cert"
-  "HostName" .Values.hostName
+  "HostName" .Values.global.mosquittoHostName
 -}}
 
 {{- include "powerpi.certificate" (merge (dict "Params" $data) . ) -}}

--- a/kubernetes/charts/mosquitto/templates/config-map.yaml
+++ b/kubernetes/charts/mosquitto/templates/config-map.yaml
@@ -6,12 +6,8 @@ metadata:
 data:
   mosquitto.conf: |- 
 {{ .Files.Get "mosquitto.conf" | indent 4 }}
-{{- if and 
-    (eq .Values.global.useSSL true) 
-    (eq .Values.global.useSensors true) 
-    (not (eq .Values.global.clusterIssuer nil)) 
-    (not (eq .Values.hostName nil)) 
-}}
+{{- $ssl := eq (include "powerpi.mosquitto-ssl" .) "true" -}}
+{{- if $ssl }}
 {{ .Files.Get "mosquitto-ssl.conf" | indent 4 }}
 {{- end }}
   acl.conf: |- 

--- a/kubernetes/charts/mosquitto/templates/service.yaml
+++ b/kubernetes/charts/mosquitto/templates/service.yaml
@@ -1,9 +1,4 @@
-{{- $ssl := and 
-  (eq .Values.global.useSSL true) 
-  (eq .Values.global.useSensors true) 
-  (not (eq .Values.global.clusterIssuer nil)) 
-  (not (eq .Values.hostName nil))
--}}
+{{- $ssl := eq (include "powerpi.mosquitto-ssl" .) "true" -}}
 
 {{- $type := ternary "LoadBalancer" "ClusterIP" (and .Values.global.useSensors (not $ssl)) -}}
 

--- a/kubernetes/charts/mosquitto/templates/stateful-set.yaml
+++ b/kubernetes/charts/mosquitto/templates/stateful-set.yaml
@@ -1,9 +1,4 @@
-{{- $ssl := and 
-  (eq .Values.global.useSSL true) 
-  (eq .Values.global.useSensors true) 
-  (not (eq .Values.global.clusterIssuer nil)) 
-  (not (eq .Values.hostName nil))
--}}
+{{- $ssl := eq (include "powerpi.mosquitto-ssl" .) "true" -}}
 
 {{- $needsNodeSelector := include "powerpi.persistent-volume-node-selector" . -}}
 {{- $nodeSelector := ternary (list

--- a/kubernetes/charts/network-controller/templates/deployment.yaml
+++ b/kubernetes/charts/network-controller/templates/deployment.yaml
@@ -1,6 +1,14 @@
+{{- $ssl := eq (include "powerpi.mosquitto-ssl" .) "true" -}}
+
 {{- 
     $data := dict
     "HostNetwork" (true | quote)
+    "Env" (list
+        (dict
+            "Name" "MQTT_ADDRESS"
+            "Value" (ternary (print "mqtts://" .Values.global.mosquittoHostName ":8883") "mqtt://mosquitto:1883" $ssl)
+        )
+    )
 -}}
 
 {{- include "powerpi.controller" (merge (dict "Params" $data) . ) -}}

--- a/kubernetes/charts/network-controller/templates/network-policy.yaml
+++ b/kubernetes/charts/network-controller/templates/network-policy.yaml
@@ -1,0 +1,11 @@
+{{- $data := dict
+    "Name" "network-controller-policy"
+    "Label" .Chart.Name
+    "Local" (dict 
+        "Direction" "egress"
+        "Cidr" .Values.localCIDR
+        "Port" 9
+        "Protocol" "UDP"
+    )
+}}
+{{- include "powerpi.network-policy" (merge (dict "Params" $data) .) -}}

--- a/kubernetes/templates/_network_policy.tpl
+++ b/kubernetes/templates/_network_policy.tpl
@@ -42,6 +42,12 @@ ports:
 {{- define "powerpi.network-policy" -}}
 {{- if .Values.global.useNetworkPolicies -}}
 
+{{- $ssl := and 
+  (eq .Values.global.useSSL true) 
+  (eq .Values.global.useSensors true) 
+  (not (eq .Values.global.clusterIssuer nil))
+-}}
+
 {{- $database := and .Params.Database .Values.global.persistence -}}
 
 {{- $ingress := .Params.Ingress | default list -}}
@@ -61,6 +67,13 @@ ports:
     "Label" "mosquitto"
     "Port" 1883
 ) -}}
+
+{{- if and .Values.global.network $ssl -}}
+{{- $egress = append $egress (dict
+    "Label" "mosquitto"
+    "Port" 8883
+) -}}
+{{- end -}}
 {{- end -}}
 
 {{- if $database -}}

--- a/kubernetes/templates/_vars.tpl
+++ b/kubernetes/templates/_vars.tpl
@@ -1,0 +1,9 @@
+{{- define "powerpi.mosquitto-ssl" -}}
+{{- $ssl := and 
+  (eq .Values.global.useSSL true) 
+  (eq .Values.global.useSensors true) 
+  (not (eq .Values.global.clusterIssuer nil)) 
+  (not (eq .Values.global.mosquittoHostName nil))
+-}}
+{{ $ssl }}
+{{- end -}}

--- a/kubernetes/values.schema.json
+++ b/kubernetes/values.schema.json
@@ -119,6 +119,12 @@
                 "storageClass": {
                     "description": "When defined will use the specified StorageClass instead of using local storage",
                     "type": "string"
+                },
+
+                "mosquittoHostName": {
+                    "description": "The external host name to use for mosquitto when using sensors and a ClusterIssuer",
+                    "type": "string",
+                    "pattern": "^\\w+(\\.\\w+)+$"
                 }
             },
             "required": ["externalHostName"],
@@ -266,11 +272,6 @@
             "properties": {
                 "component": {
                     "const": "message-queue"
-                },
-                "hostName": {
-                    "description": "The external host name to use for mosquitto when using sensors and a ClusterIssuer",
-                    "type": "string",
-                    "pattern": "^\\w+(\\.\\w+)+$"
                 },
                 "storageClass": {
                     "description": "When defined will use the specified StorageClass instead of using local storage",

--- a/kubernetes/values.schema.json
+++ b/kubernetes/values.schema.json
@@ -283,7 +283,7 @@
         "network-controller": {
             "description": "The configuration for the PowerPi Network controller Helm chart",
             "type": "object",
-            "allOf": [{ "$ref": "#/$defs/controller" }],
+            "allOf": [{ "$ref": "#/$defs/controller" }, { "$ref": "#/$defs/local-network" }],
             "unevaluatedProperties": false
         },
 

--- a/kubernetes/values.yaml
+++ b/kubernetes/values.yaml
@@ -65,26 +65,33 @@ mosquitto:
   # the IP address range of internal networks, used to restrict access from outside to mosquitto
   localCIDR:
     - 10.0.0.0/8
-    - 192.168.0.0/16
     - 172.16.0.0/20
+    - 192.168.0.0/16
 
 harmony-controller:
   # the IP address range of internal networks, used to restrict access only to the Harmony Hub(s)
   localCIDR:
     - 10.0.0.0/8
-    - 192.168.0.0/16
     - 172.16.0.0/20
+    - 192.168.0.0/16
 
 lifx-controller:
   # the IP address range of internal networks, used to restrict access only to the LIFX device(s)
   localCIDR:
     - 10.0.0.0/8
-    - 192.168.0.0/16
     - 172.16.0.0/20
+    - 192.168.0.0/16
+
+network-controller:
+  # the IP of internal networks, used to restrict access only to the internal broadcast address
+  localCIDR:
+    - 10.0.0.0/8
+    - 172.16.0.0/20
+    - 192.168.0.0/16
 
 snapcast-controller:
   # the IP address range of internal networks, used to restrict access only to the Snapcast server(s)
   localCIDR:
     - 10.0.0.0/8
-    - 192.168.0.0/16
     - 172.16.0.0/20
+    - 192.168.0.0/16


### PR DESCRIPTION
Resolves #608.
- Add the network policies for `network-controller` as with Calico they are applied for host network.
- Use the external MQTT address for `network-controller` when it's enabled.