### PR TITLE
#551 feat(ui): Add support for the new gas/electricity meter usage output

### DIFF
--- a/services/ui/src/pages/HomePage/Floorplan/useSensors.ts
+++ b/services/ui/src/pages/HomePage/Floorplan/useSensors.ts
@@ -28,6 +28,8 @@ function* expandMetrics(sensor: Sensor, t: ReturnType<typeof useTranslation>["t"
                 switch (metric) {
                     case "current":
                     case "door":
+                    case "electricity":
+                    case "gas":
                     case "humidity":
                     case "motion":
                     case "power":

--- a/services/ui/src/services/UnitConverter/UnitConverter.test.ts
+++ b/services/ui/src/services/UnitConverter/UnitConverter.test.ts
@@ -56,6 +56,8 @@ describe("UnitConverter", () => {
 
         test("hcf -> kWh", () => check("gas", { value: 50, unit: "hcf" }, "kWh", 1_528.335));
 
+        test("kWh -> m3", () => check("gas", { value: 1_079.45, unit: "kWh" }, "m3", 100));
+
         test("getConverters", () => {
             const result = UnitConverter.getConverters("gas");
 

--- a/services/ui/src/services/UnitConverter/converters/gas.ts
+++ b/services/ui/src/services/UnitConverter/converters/gas.ts
@@ -4,7 +4,22 @@ import { volume } from "./volume";
 
 const calorific = 38; // MJ/m3
 
-const gas: ConverterDefinition[] = [
+const modifiedEnergy = energy.map((converter) => {
+    // Add a conversion from kWh to m3, but only for the gas energy converter
+    if (converter.unit === "kWh") {
+        return {
+            ...converter,
+            convert: {
+                ...converter.convert,
+                m3: (value: number) => (value * 3.6) / (calorific * 1.02264),
+            },
+        };
+    }
+
+    return converter;
+});
+
+export const gas: ConverterDefinition[] = [
     {
         unit: "m3",
         key: "metres cubed",
@@ -15,22 +30,5 @@ const gas: ConverterDefinition[] = [
     // we need the volume converters too
     ...volume,
     // and the energy converters
-    ...energy,
+    ...modifiedEnergy,
 ];
-
-// add a conversion from kWh to m3, but only for the gas energy converter
-const kWhIndex = energy.findIndex((energy) => energy.unit === "kWh");
-
-if (kWhIndex !== -1) {
-    const kWh = energy[kWhIndex];
-
-    gas[kWhIndex] = {
-        ...kWh,
-        convert: {
-            ...kWh.convert,
-            m3: (value: number) => (value * 3.6) / (calorific * 1.02264),
-        },
-    };
-}
-
-export { gas };

--- a/services/ui/src/services/UnitConverter/converters/gas.ts
+++ b/services/ui/src/services/UnitConverter/converters/gas.ts
@@ -4,7 +4,7 @@ import { volume } from "./volume";
 
 const calorific = 38; // MJ/m3
 
-export const gas: ConverterDefinition[] = [
+const gas: ConverterDefinition[] = [
     {
         unit: "m3",
         key: "metres cubed",
@@ -17,3 +17,20 @@ export const gas: ConverterDefinition[] = [
     // and the energy converters
     ...energy,
 ];
+
+// add a conversion from kWh to m3, but only for the gas energy converter
+const kWhIndex = energy.findIndex((energy) => energy.unit === "kWh");
+
+if (kWhIndex !== -1) {
+    const kWh = energy[kWhIndex];
+
+    gas[kWhIndex] = {
+        ...kWh,
+        convert: {
+            ...kWh.convert,
+            m3: (value: number) => (value * 3.6) / (calorific * 1.02264),
+        },
+    };
+}
+
+export { gas };


### PR DESCRIPTION
- Use the gas/electricity metrics to display them in the UI.
- Add a conversion from `kWh` -> `m3` for gas, in case that is the user's selection as Octopus can output `kWh`.