### PR TITLE
#653 fix(sensor): Use location for config topic

### DIFF
--- a/sensors/powerpi-sensor/powerpi-config.ino
+++ b/sensors/powerpi-sensor/powerpi-config.ino
@@ -1,44 +1,48 @@
 #include "powerpi-config.h"
 
-void setupPowerPiConfig() {
+void setupPowerPiConfig()
+{
     // initialise the PowerPi config with the default values
     powerpiConfig = PowerPiConfig_default;
 
-    // if we are using config-server
-    #ifdef POWERPI_CONFIG_SERVER
-        // generate the topic
-        char topic[TOPIC_LEN];
-        snprintf(topic, TOPIC_LEN, POWERPI_CONFIG_MQTT_TOPIC, HOSTNAME);
+// if we are using config-server
+#ifdef POWERPI_CONFIG_SERVER
+    // generate the topic
+    char topic[TOPIC_LEN];
+    snprintf(topic, TOPIC_LEN, POWERPI_CONFIG_MQTT_TOPIC, LOCATION);
 
-        // subscribe to MQTT
-        mqttClient.setCallback(configCallback);
-        connectMQTT(false);
-        mqttClient.subscribe(topic);
+    // subscribe to MQTT
+    mqttClient.setCallback(configCallback);
+    connectMQTT(false);
+    mqttClient.subscribe(topic);
 
-        // wait for the message
-        Serial.println("Waiting for configuration");
-        int counter = 0;
-        while(!powerpiConfig.received) {
-            Serial.print(".");
+    // wait for the message
+    Serial.println("Waiting for configuration");
+    int counter = 0;
+    while (!powerpiConfig.received)
+    {
+        Serial.print(".");
 
-            mqttClient.loop();
+        mqttClient.loop();
 
-            // terminate if we can't get the configuration after 60s
-            if(++counter >= CONFIG_WAIT) {
-                Serial.println("No configuration received, giving up...");
-                useDefaultConfig();
-                return;
-            }
-
-            delay(500);
+        // terminate if we can't get the configuration after 60s
+        if (++counter >= CONFIG_WAIT)
+        {
+            Serial.println("No configuration received, giving up...");
+            useDefaultConfig();
+            return;
         }
-        Serial.println();
-    #else
-        useDefaultConfig();
-    #endif
+
+        delay(500);
+    }
+    Serial.println();
+#else
+    useDefaultConfig();
+#endif
 }
 
-void useDefaultConfig() {
+void useDefaultConfig()
+{
     // we have to initialise with the default values
     Serial.println();
     configureGeneral(POLL_DELAY);
@@ -49,7 +53,8 @@ void useDefaultConfig() {
     Serial.println();
 }
 
-void configCallback(char* topic, byte* payload, unsigned int length) {
+void configCallback(char *topic, byte *payload, unsigned int length)
+{
     StaticJsonDocument<1024> doc;
     deserializeJson(doc, payload);
 
@@ -63,19 +68,22 @@ void configCallback(char* topic, byte* payload, unsigned int length) {
     powerpiConfig.received = true;
 }
 
-unsigned short secondsToInterval(unsigned int seconds) {
+unsigned short secondsToInterval(unsigned int seconds)
+{
     double intervalsPerSecond = 1000.0 / powerpiConfig.pollDelay;
 
     unsigned int intervals = ((double)seconds) * intervalsPerSecond;
 
-    if(intervals < 1) {
+    if (intervals < 1)
+    {
         intervals = 1u;
     }
 
     return intervals;
 }
 
-void configureGeneral(float pollDelay) {
+void configureGeneral(float pollDelay)
+{
     powerpiConfig.pollDelay = pollDelay * 1000u;
     Serial.print("Poll Delay: ");
     Serial.print(powerpiConfig.pollDelay);


### PR DESCRIPTION
Resolves #653.
When the sensor is retrieving the config from the message queue use the `LOCATION` variable rather than the `HOSTNAME`. This is necessary as since the metrics change the device in the sensors config uses the location as it's name, and therefore that is what the config message will also use.