### PR TITLE
#651 fix(ui): Multi-story floorplan options were not working

### DIFF
--- a/services/ui/src/components/Header/Header.test.tsx
+++ b/services/ui/src/components/Header/Header.test.tsx
@@ -13,6 +13,23 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("../../routing/useOptionalRoute", () => ({ default: mocks.useOptionalRoute }));
 
+// Mock HomeHeaderLink's useQueryFloorplan
+vi.mock("../../queries/useQueryFloorPlan", () => ({
+    default: () => ({
+        data: {
+            floors: [
+                { name: "ground", display_name: "Ground Floor" },
+                { name: "first", display_name: "First Floor" },
+            ],
+        },
+    }),
+}));
+
+// Mock the click outside hook
+vi.mock("../../hooks/useOnClickOutside", () => ({
+    default: vi.fn(() => ({ current: null })),
+}));
+
 describe("Header", () => {
     test("renders with no optional links", () => {
         mocks.useOptionalRoute.mockReturnValue({ home: false });
@@ -44,6 +61,22 @@ describe("Header", () => {
         expectHome(links[0]);
         expectDevices(links[1]);
         expectSettings(links[2]);
+
+        // Check Home has submenu functionality
+        expect(links[0]).toHaveAttribute("aria-haspopup", "menu");
+        expect(links[0]).toHaveAttribute("aria-expanded", "false");
+
+        // Check submenu items are rendered
+        const menuItems = screen.getAllByRole("menuitem");
+        expect(menuItems).toHaveLength(2);
+        expect(menuItems[0]).toBeInTheDocument();
+        expect(menuItems[0]).toHaveTextContent("Ground Floor");
+        expect(menuItems[1]).toBeInTheDocument();
+        expect(menuItems[1]).toHaveTextContent("First Floor");
+
+        // Check menu container exists
+        const menu = screen.getByRole("menu");
+        expect(menu).toBeInTheDocument();
     });
 
     test("renders with History", () => {

--- a/services/ui/src/components/Header/Header.tsx
+++ b/services/ui/src/components/Header/Header.tsx
@@ -3,6 +3,7 @@ import Route from "../../routing/Route";
 import useOptionalRoute from "../../routing/useOptionalRoute";
 import HeaderLink from "../HeaderLink";
 import Logo from "../Logo";
+import HomeHeaderLink from "./HomeHeaderLink";
 
 const Header = () => {
     const enabled = useOptionalRoute();
@@ -14,9 +15,7 @@ const Header = () => {
             <nav className="flex flex-row items-center border-b-2 border-border divide-x-2 divide-border">
                 <Logo />
 
-                {enabled?.home && (
-                    <HeaderLink route={Route.Home} icon="home" text={t("navigation.home")} />
-                )}
+                {enabled?.home && <HomeHeaderLink />}
 
                 <HeaderLink route={Route.Device} icon="device" text={t("navigation.devices")} />
 

--- a/services/ui/src/components/Header/HomeHeaderLink.test.tsx
+++ b/services/ui/src/components/Header/HomeHeaderLink.test.tsx
@@ -25,8 +25,8 @@ describe("HomeHeaderLink", () => {
         const link = screen.getByRole("link");
         expect(link).toBeInTheDocument();
         expect(link).toHaveTextContent("Home");
-        expect(link).toHaveAttribute("aria-haspopup", "menu");
-        expect(link).toHaveAttribute("aria-expanded", "false");
+        expect(link).not.toHaveAttribute("aria-haspopup", "menu");
+        expect(link).not.toHaveAttribute("aria-expanded", "false");
 
         const icon = within(link).getByRole("img", { hidden: true });
         expect(icon).toBeInTheDocument();
@@ -49,10 +49,8 @@ describe("HomeHeaderLink", () => {
         expect(link).toBeInTheDocument();
         expect(link).toHaveTextContent("Home");
 
-        const subLinks = screen.getAllByRole("menuitem");
-        expect(subLinks).toHaveLength(1);
-        expect(subLinks[0]).toBeInTheDocument();
-        expect(subLinks[0]).toHaveTextContent("ground");
+        const subLinks = screen.queryAllByRole("menuitem");
+        expect(subLinks).toHaveLength(0);
     });
 
     test("renders with multiple floors", () => {
@@ -66,6 +64,12 @@ describe("HomeHeaderLink", () => {
         });
 
         render(<HomeHeaderLink />, { wrapper: MemoryRouter });
+
+        const link = screen.getByRole("link");
+        expect(link).toBeInTheDocument();
+        expect(link).toHaveTextContent("Home");
+        expect(link).toHaveAttribute("aria-haspopup", "menu");
+        expect(link).toHaveAttribute("aria-expanded", "false");
 
         const subLinks = screen.getAllByRole("menuitem");
         expect(subLinks).toHaveLength(2);

--- a/services/ui/src/components/Header/HomeHeaderLink.test.tsx
+++ b/services/ui/src/components/Header/HomeHeaderLink.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { vi } from "vitest";
+import HomeHeaderLink from "./HomeHeaderLink";
+
+const mocks = vi.hoisted(() => ({
+    useQueryFloorplan: vi.fn(),
+}));
+
+vi.mock("../../queries/useQueryFloorPlan", () => ({ default: mocks.useQueryFloorplan }));
+
+// Mock the click outside hook
+vi.mock("../../hooks/useOnClickOutside", () => ({
+    default: vi.fn(() => ({ current: null })),
+}));
+
+describe("HomeHeaderLink", () => {
+    test("renders with no floors", () => {
+        mocks.useQueryFloorplan.mockReturnValue({
+            data: { floors: [] },
+        });
+
+        render(<HomeHeaderLink />, { wrapper: MemoryRouter });
+
+        const link = screen.getByRole("link");
+        expect(link).toBeInTheDocument();
+        expect(link).toHaveTextContent("Home");
+        expect(link).toHaveAttribute("aria-haspopup", "menu");
+        expect(link).toHaveAttribute("aria-expanded", "false");
+
+        const icon = within(link).getByRole("img", { hidden: true });
+        expect(icon).toBeInTheDocument();
+        expect(icon).toHaveAttribute("data-icon", "house");
+
+        // No submenu items should be rendered
+        expect(screen.queryAllByRole("menuitem")).toHaveLength(0);
+    });
+
+    test("renders with single floor using name", () => {
+        mocks.useQueryFloorplan.mockReturnValue({
+            data: {
+                floors: [{ name: "ground" }],
+            },
+        });
+
+        render(<HomeHeaderLink />, { wrapper: MemoryRouter });
+
+        const link = screen.getByRole("link");
+        expect(link).toBeInTheDocument();
+        expect(link).toHaveTextContent("Home");
+
+        const subLinks = screen.getAllByRole("menuitem");
+        expect(subLinks).toHaveLength(1);
+        expect(subLinks[0]).toBeInTheDocument();
+        expect(subLinks[0]).toHaveTextContent("ground");
+    });
+
+    test("renders with multiple floors", () => {
+        mocks.useQueryFloorplan.mockReturnValue({
+            data: {
+                floors: [
+                    { name: "ground", display_name: "Ground Floor" },
+                    { name: "first", display_name: "First Floor" },
+                ],
+            },
+        });
+
+        render(<HomeHeaderLink />, { wrapper: MemoryRouter });
+
+        const subLinks = screen.getAllByRole("menuitem");
+        expect(subLinks).toHaveLength(2);
+
+        expect(subLinks[0]).toBeInTheDocument();
+        expect(subLinks[0]).toHaveTextContent("Ground Floor");
+
+        expect(subLinks[1]).toBeInTheDocument();
+        expect(subLinks[1]).toHaveTextContent("First Floor");
+    });
+});

--- a/services/ui/src/components/Header/HomeHeaderLink.tsx
+++ b/services/ui/src/components/Header/HomeHeaderLink.tsx
@@ -11,13 +11,14 @@ const HomeHeaderLink = () => {
 
     return (
         <HeaderLink route={Route.Home} icon="home" text={t("navigation.home")}>
-            {floorplan.floors.map((floor) => (
-                <HeaderLink.SubLink
-                    key={floor.name}
-                    route={RouteBuilder.build(Route.Root, Route.Home, floor.name)}
-                    text={floor.display_name ?? floor.name}
-                />
-            ))}
+            {floorplan.floors.length > 1 &&
+                floorplan.floors.map((floor) => (
+                    <HeaderLink.SubLink
+                        key={floor.name}
+                        route={RouteBuilder.build(Route.Root, Route.Home, floor.name)}
+                        text={floor.display_name ?? floor.name}
+                    />
+                ))}
         </HeaderLink>
     );
 };

--- a/services/ui/src/components/Header/HomeHeaderLink.tsx
+++ b/services/ui/src/components/Header/HomeHeaderLink.tsx
@@ -1,0 +1,24 @@
+import { useTranslation } from "react-i18next";
+import useQueryFloorplan from "../../queries/useQueryFloorPlan";
+import Route from "../../routing/Route";
+import RouteBuilder from "../../routing/RouteBuilder";
+import HeaderLink from "../HeaderLink";
+
+const HomeHeaderLink = () => {
+    const { t } = useTranslation();
+
+    const { data: floorplan } = useQueryFloorplan();
+
+    return (
+        <HeaderLink route={Route.Home} icon="home" text={t("navigation.home")}>
+            {floorplan.floors.map((floor) => (
+                <HeaderLink.SubLink
+                    key={floor.name}
+                    route={RouteBuilder.build(Route.Root, Route.Home, floor.name)}
+                    text={floor.display_name ?? floor.name}
+                />
+            ))}
+        </HeaderLink>
+    );
+};
+export default HomeHeaderLink;

--- a/services/ui/src/components/HeaderLink/CommonHeaderLink.ts
+++ b/services/ui/src/components/HeaderLink/CommonHeaderLink.ts
@@ -1,0 +1,10 @@
+import Route from "../../routing/Route";
+import { IconType } from "../Icon";
+
+export type CommonHeaderLinkProps = {
+    route: Route;
+
+    icon?: IconType;
+
+    text: string;
+};

--- a/services/ui/src/components/HeaderLink/CommonHeaderLink.ts
+++ b/services/ui/src/components/HeaderLink/CommonHeaderLink.ts
@@ -2,7 +2,7 @@ import Route from "../../routing/Route";
 import { IconType } from "../Icon";
 
 export type CommonHeaderLinkProps = {
-    route: Route;
+    route: Route | string;
 
     icon?: IconType;
 

--- a/services/ui/src/components/HeaderLink/HeaderLink.test.tsx
+++ b/services/ui/src/components/HeaderLink/HeaderLink.test.tsx
@@ -1,9 +1,19 @@
 import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
+import { vi } from "vitest";
 import Route from "../../routing/Route";
 import HeaderLink from "./HeaderLink";
+import HeaderSubLink from "./HeaderSubLink";
+
+// Mock the click outside hook
+vi.mock("../../hooks/useOnClickOutside", () => ({
+    default: vi.fn(() => ({ current: null })),
+}));
 
 describe("HeaderLink", () => {
+    const user = userEvent.setup();
+
     test("renders", () => {
         render(<HeaderLink route={Route.Home} icon="home" text="Home" />, {
             wrapper: MemoryRouter,
@@ -31,5 +41,147 @@ describe("HeaderLink", () => {
         const icon = within(link).getByRole("img", { hidden: true });
         expect(icon).toBeInTheDocument();
         expect(icon).toHaveAttribute("data-icon", "gear");
+    });
+
+    test("renders without submenu", () => {
+        render(<HeaderLink route={Route.Home} icon="home" text="Home" />, {
+            wrapper: MemoryRouter,
+        });
+
+        const link = screen.getByRole("link");
+        expect(link).toBeInTheDocument();
+        expect(link).not.toHaveAttribute("aria-haspopup");
+        expect(link).not.toHaveAttribute("aria-expanded");
+        expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+
+    describe("with submenu", () => {
+        beforeEach(() => {
+            // Mock touch device detection
+            Object.defineProperty(window, "matchMedia", {
+                writable: true,
+                value: vi.fn().mockImplementation((query) => ({
+                    matches: query === "(hover: none)",
+                    media: query,
+                    onchange: null,
+                    addEventListener: vi.fn(),
+                    removeEventListener: vi.fn(),
+                    dispatchEvent: vi.fn(),
+                })),
+            });
+        });
+
+        test("renders with submenu accessibility attributes", () => {
+            render(
+                <HeaderLink route={Route.Home} icon="home" text="Home">
+                    <HeaderSubLink route={Route.Device} icon="device" text="Devices" />
+                </HeaderLink>,
+                { wrapper: MemoryRouter },
+            );
+
+            const link = screen.getByRole("link");
+            expect(link).toBeInTheDocument();
+            expect(link).toHaveAttribute("aria-haspopup", "menu");
+            expect(link).toHaveAttribute("aria-expanded", "false");
+        });
+
+        test("opens submenu on keyboard activation", async () => {
+            render(
+                <HeaderLink route={Route.Home} icon="home" text="Home">
+                    <HeaderSubLink route={Route.Device} icon="device" text="Devices" />
+                </HeaderLink>,
+                { wrapper: MemoryRouter },
+            );
+
+            const trigger = screen.getByRole("link");
+            expect(trigger).toBeInTheDocument();
+            trigger.focus();
+
+            await user.keyboard("{Enter}");
+            expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+            const menu = screen.getByRole("menu");
+            expect(menu).toBeInTheDocument();
+
+            const sublink = screen.getByRole("menuitem");
+            expect(sublink).toBeInTheDocument();
+            expect(sublink).toHaveTextContent("Devices");
+        });
+
+        test("supports arrow key navigation in submenu", async () => {
+            render(
+                <HeaderLink route={Route.Home} icon="home" text="Home">
+                    <HeaderSubLink route={Route.Device} icon="device" text="Devices" />
+                    <HeaderSubLink route={Route.Settings} icon="settings" text="Settings" />
+                </HeaderLink>,
+                { wrapper: MemoryRouter },
+            );
+
+            const trigger = screen.getByRole("link");
+            expect(trigger).toBeInTheDocument();
+            trigger.focus();
+            await user.keyboard("{ArrowDown}");
+
+            const menuItems = screen.getAllByRole("menuitem");
+            expect(menuItems[0]).toBeInTheDocument();
+            expect(menuItems[0]).toHaveFocus();
+
+            await user.keyboard("{ArrowDown}");
+            expect(menuItems[1]).toHaveFocus();
+
+            await user.keyboard("{ArrowUp}");
+            expect(menuItems[0]).toHaveFocus();
+        });
+
+        test("closes submenu with escape key", async () => {
+            render(
+                <HeaderLink route={Route.Home} icon="home" text="Home">
+                    <HeaderSubLink route={Route.Device} icon="device" text="Devices" />
+                </HeaderLink>,
+                { wrapper: MemoryRouter },
+            );
+
+            const trigger = screen.getByRole("link");
+            expect(trigger).toBeInTheDocument();
+            trigger.focus();
+            await user.keyboard("{Enter}");
+
+            const menu = screen.getByRole("menu");
+            expect(menu).toBeInTheDocument();
+            expect(menu).not.toHaveClass("hidden");
+
+            const sublink = screen.getByRole("menuitem");
+            expect(sublink).toBeInTheDocument();
+            await user.keyboard("{Escape}");
+
+            expect(menu).toHaveClass("hidden");
+            expect(trigger).toHaveFocus();
+        });
+
+        test("supports home/end keys", async () => {
+            render(
+                <HeaderLink route={Route.Home} icon="home" text="Home">
+                    <HeaderSubLink route={Route.Device} icon="device" text="Devices" />
+                    <HeaderSubLink route={Route.History} icon="history" text="History" />
+                    <HeaderSubLink route={Route.Settings} icon="settings" text="Settings" />
+                </HeaderLink>,
+                { wrapper: MemoryRouter },
+            );
+
+            const trigger = screen.getByRole("link");
+            expect(trigger).toBeInTheDocument();
+            trigger.focus();
+            await user.keyboard("{Enter}");
+
+            const menuItems = screen.getAllByRole("menuitem");
+            expect(menuItems[0]).toBeInTheDocument();
+            expect(menuItems[2]).toBeInTheDocument();
+
+            await user.keyboard("{End}");
+            expect(menuItems[2]).toHaveFocus();
+
+            await user.keyboard("{Home}");
+            expect(menuItems[0]).toHaveFocus();
+        });
     });
 });

--- a/services/ui/src/components/HeaderLink/HeaderLink.tsx
+++ b/services/ui/src/components/HeaderLink/HeaderLink.tsx
@@ -19,7 +19,7 @@ const HeaderLink = ({ route, icon, text, small = false, children }: HeaderLinkPr
     const linkId = useId();
 
     return (
-        <div className={classNames("h-20 group", { grow: !small })}>
+        <div className={classNames("relative h-20 group", { grow: !small })}>
             <HeaderLinkBody
                 id={linkId}
                 route={route}
@@ -35,7 +35,7 @@ const HeaderLink = ({ route, icon, text, small = false, children }: HeaderLinkPr
             {children != null && (
                 <div
                     id={subMenuId}
-                    className={classNames("relative flex-col z-50", {
+                    className={classNames("absolute top-full left-0 min-w-full flex-col z-50", {
                         flex: showSubMenu,
                         "hidden group-hover:flex": !showSubMenu,
                     })}

--- a/services/ui/src/components/HeaderLink/HeaderLink.tsx
+++ b/services/ui/src/components/HeaderLink/HeaderLink.tsx
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 import { PropsWithChildren, useCallback, useState } from "react";
+import useOnClickOutside from "../../hooks/useOnClickOutside";
 import { CommonHeaderLinkProps } from "./CommonHeaderLink";
 import HeaderLinkBody from "./HeaderLinkBody";
 
@@ -13,25 +14,36 @@ type HeaderLinkProps = CommonHeaderLinkProps &
 const HeaderLink = ({ route, icon, text, small = false, children }: HeaderLinkProps) => {
     const [showSubMenu, setShowSubMenu] = useState(false);
 
-    const handleHover = useCallback(() => {
-        if (!children) {
-            // no action if it doesn't have a submenu
-            return;
-        }
+    const toggleSubMenu = useCallback((newState: boolean) => {
+        const isTouchDevice = window.matchMedia("(hover: none)").matches;
 
-        setShowSubMenu(true);
-    }, [children]);
+        if (isTouchDevice) {
+            setShowSubMenu(newState);
+        }
+    }, []);
+
+    const handleClick = useCallback(() => toggleSubMenu(true), [toggleSubMenu]);
+
+    const ref = useOnClickOutside<HTMLAnchorElement>(() => toggleSubMenu(false));
 
     return (
-        <div className={classNames("h-20", { grow: !small })}>
+        <div className={classNames("h-20 group", { grow: !small })}>
             <HeaderLinkBody
                 route={route}
                 icon={icon}
                 text={small ? undefined : text}
-                onMouseEnter={handleHover}
+                onClick={handleClick}
+                ref={ref}
             />
 
-            {showSubMenu && <div className="relative flex flex-col z-50">{children}</div>}
+            <div
+                className={classNames("relative flex-col z-50", {
+                    flex: showSubMenu,
+                    "hidden group-hover:flex": !showSubMenu,
+                })}
+            >
+                {children}
+            </div>
         </div>
     );
 };

--- a/services/ui/src/components/HeaderLink/HeaderLink.tsx
+++ b/services/ui/src/components/HeaderLink/HeaderLink.tsx
@@ -1,20 +1,14 @@
 import classNames from "classnames";
-import { NavLink } from "react-router-dom";
-import Route from "../../routing/Route";
-import RouteBuilder from "../../routing/RouteBuilder";
+import { PropsWithChildren } from "react";
 import { buttonStyles } from "../Button";
-import Icon, { IconType } from "../Icon";
+import { CommonHeaderLinkProps } from "./CommonHeaderLink";
+import HeaderLinkBody from "./HeaderLinkBody";
 
-type HeaderLinkProps = {
-    route: Route;
-
-    icon: IconType;
-
-    text: string;
-
-    /** Whether to always show as a small link. */
-    small?: boolean;
-};
+type HeaderLinkProps = CommonHeaderLinkProps &
+    PropsWithChildren<{
+        /** Whether to always show as a small link. */
+        small?: boolean;
+    }>;
 
 const headerLinkClasses = classNames(
     "relative h-full flex flex-row justify-center items-center gap-sm grow text-2xl",
@@ -26,11 +20,12 @@ const headerLinkClasses = classNames(
 /** Component for one of the main header navigation links. */
 const HeaderLink = ({ route, icon, text, small = false }: HeaderLinkProps) => (
     <div className={classNames("h-20", { grow: !small })}>
-        <NavLink to={RouteBuilder.build(route)} className={headerLinkClasses} aria-label={text}>
-            <Icon icon={icon} className="text-3xl md:text-2xl" />
-
-            {!small && <span className="hidden md:block">{text}</span>}
-        </NavLink>
+        <HeaderLinkBody
+            route={route}
+            icon={icon}
+            text={small ? text : undefined}
+            className={headerLinkClasses}
+        />
     </div>
 );
 export default HeaderLink;

--- a/services/ui/src/components/HeaderLink/HeaderLink.tsx
+++ b/services/ui/src/components/HeaderLink/HeaderLink.tsx
@@ -1,6 +1,5 @@
 import classNames from "classnames";
-import { PropsWithChildren } from "react";
-import { buttonStyles } from "../Button";
+import { PropsWithChildren, useCallback, useState } from "react";
 import { CommonHeaderLinkProps } from "./CommonHeaderLink";
 import HeaderLinkBody from "./HeaderLinkBody";
 
@@ -10,22 +9,30 @@ type HeaderLinkProps = CommonHeaderLinkProps &
         small?: boolean;
     }>;
 
-const headerLinkClasses = classNames(
-    "relative h-full flex flex-row justify-center items-center gap-sm grow text-2xl",
-    buttonStyles("default"),
-    // when the link is the current route
-    "aria-current-page:bg-bg-selected",
-);
-
 /** Component for one of the main header navigation links. */
-const HeaderLink = ({ route, icon, text, small = false }: HeaderLinkProps) => (
-    <div className={classNames("h-20", { grow: !small })}>
-        <HeaderLinkBody
-            route={route}
-            icon={icon}
-            text={small ? text : undefined}
-            className={headerLinkClasses}
-        />
-    </div>
-);
+const HeaderLink = ({ route, icon, text, small = false, children }: HeaderLinkProps) => {
+    const [showSubMenu, setShowSubMenu] = useState(false);
+
+    const handleHover = useCallback(() => {
+        if (!children) {
+            // no action if it doesn't have a submenu
+            return;
+        }
+
+        setShowSubMenu(true);
+    }, [children]);
+
+    return (
+        <div className={classNames("h-20", { grow: !small })}>
+            <HeaderLinkBody
+                route={route}
+                icon={icon}
+                text={small ? undefined : text}
+                onMouseEnter={handleHover}
+            />
+
+            {showSubMenu && <div className="relative flex flex-col z-50">{children}</div>}
+        </div>
+    );
+};
 export default HeaderLink;

--- a/services/ui/src/components/HeaderLink/HeaderLink.tsx
+++ b/services/ui/src/components/HeaderLink/HeaderLink.tsx
@@ -27,6 +27,7 @@ const HeaderLink = ({ route, icon, text, small = false, children }: HeaderLinkPr
                 text={small ? undefined : text}
                 onClick={handleClick}
                 onKeyDown={handleKeyDown}
+                aria-label={text}
                 aria-haspopup={children ? "menu" : undefined}
                 aria-expanded={children ? showSubMenu : undefined}
                 ref={ref}

--- a/services/ui/src/components/HeaderLink/HeaderLinkBody.tsx
+++ b/services/ui/src/components/HeaderLink/HeaderLinkBody.tsx
@@ -22,13 +22,7 @@ type HeaderLinkBodyProps = Omit<
     };
 
 const HeaderLinkBody = ({ route, icon, text, ref, ...props }: HeaderLinkBodyProps) => (
-    <NavLink
-        {...props}
-        to={RouteBuilder.build(route)}
-        className={headerLinkBodyClasses}
-        aria-label={text}
-        ref={ref}
-    >
+    <NavLink {...props} to={RouteBuilder.build(route)} className={headerLinkBodyClasses} ref={ref}>
         {icon && <Icon icon={icon} className="text-3xl md:text-2xl" />}
 
         {text && <span className={classNames("md:block", { hidden: icon != null })}>{text}</span>}

--- a/services/ui/src/components/HeaderLink/HeaderLinkBody.tsx
+++ b/services/ui/src/components/HeaderLink/HeaderLinkBody.tsx
@@ -1,16 +1,33 @@
+import classNames from "classnames";
+import { ComponentProps } from "react";
 import { NavLink } from "react-router-dom";
 import RouteBuilder from "../../routing/RouteBuilder";
+import { buttonStyles } from "../Button";
 import Icon from "../Icon";
 import { CommonHeaderLinkProps } from "./CommonHeaderLink";
 
-type HeaderLinkBodyProps = Omit<CommonHeaderLinkProps, "text"> & {
-    text?: CommonHeaderLinkProps["text"];
+const headerLinkBodyClasses = classNames(
+    "relative h-full flex flex-row justify-center items-center gap-sm grow text-2xl",
+    buttonStyles("default"),
+    // when the link is the current route
+    "aria-current-page:bg-bg-selected",
+);
 
-    className?: HTMLDivElement["className"];
-};
+type HeaderLinkBodyProps = Omit<
+    ComponentProps<typeof NavLink>,
+    "to" | "aria-label" | "children" | "className"
+> &
+    Omit<CommonHeaderLinkProps, "text"> & {
+        text?: CommonHeaderLinkProps["text"];
+    };
 
-const HeaderLinkBody = ({ route, icon, text, className }: HeaderLinkBodyProps) => (
-    <NavLink to={RouteBuilder.build(route)} aria-label={text} className={className}>
+const HeaderLinkBody = ({ route, icon, text, ...props }: HeaderLinkBodyProps) => (
+    <NavLink
+        {...props}
+        to={RouteBuilder.build(route)}
+        className={headerLinkBodyClasses}
+        aria-label={text}
+    >
         {icon && <Icon icon={icon} className="text-3xl md:text-2xl" />}
 
         {text && <span className="hidden md:block">{text}</span>}

--- a/services/ui/src/components/HeaderLink/HeaderLinkBody.tsx
+++ b/services/ui/src/components/HeaderLink/HeaderLinkBody.tsx
@@ -21,12 +21,13 @@ type HeaderLinkBodyProps = Omit<
         text?: CommonHeaderLinkProps["text"];
     };
 
-const HeaderLinkBody = ({ route, icon, text, ...props }: HeaderLinkBodyProps) => (
+const HeaderLinkBody = ({ route, icon, text, ref, ...props }: HeaderLinkBodyProps) => (
     <NavLink
         {...props}
         to={RouteBuilder.build(route)}
         className={headerLinkBodyClasses}
         aria-label={text}
+        ref={ref}
     >
         {icon && <Icon icon={icon} className="text-3xl md:text-2xl" />}
 

--- a/services/ui/src/components/HeaderLink/HeaderLinkBody.tsx
+++ b/services/ui/src/components/HeaderLink/HeaderLinkBody.tsx
@@ -31,7 +31,7 @@ const HeaderLinkBody = ({ route, icon, text, ref, ...props }: HeaderLinkBodyProp
     >
         {icon && <Icon icon={icon} className="text-3xl md:text-2xl" />}
 
-        {text && <span className="hidden md:block">{text}</span>}
+        {text && <span className={classNames("md:block", { hidden: icon != null })}>{text}</span>}
     </NavLink>
 );
 export default HeaderLinkBody;

--- a/services/ui/src/components/HeaderLink/HeaderLinkBody.tsx
+++ b/services/ui/src/components/HeaderLink/HeaderLinkBody.tsx
@@ -1,0 +1,19 @@
+import { NavLink } from "react-router-dom";
+import RouteBuilder from "../../routing/RouteBuilder";
+import Icon from "../Icon";
+import { CommonHeaderLinkProps } from "./CommonHeaderLink";
+
+type HeaderLinkBodyProps = Omit<CommonHeaderLinkProps, "text"> & {
+    text?: CommonHeaderLinkProps["text"];
+
+    className?: HTMLDivElement["className"];
+};
+
+const HeaderLinkBody = ({ route, icon, text, className }: HeaderLinkBodyProps) => (
+    <NavLink to={RouteBuilder.build(route)} aria-label={text} className={className}>
+        {icon && <Icon icon={icon} className="text-3xl md:text-2xl" />}
+
+        {text && <span className="hidden md:block">{text}</span>}
+    </NavLink>
+);
+export default HeaderLinkBody;

--- a/services/ui/src/components/HeaderLink/HeaderSubLink.test.tsx
+++ b/services/ui/src/components/HeaderLink/HeaderSubLink.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { vi } from "vitest";
+import Route from "../../routing/Route";
+import HeaderSubLink from "./HeaderSubLink";
+import HeaderSubMenuContext, { HeaderSubMenuContextType } from "./HeaderSubMenuContext";
+
+describe("HeaderSubLink", () => {
+    const mockContext: HeaderSubMenuContextType = {
+        subMenuId: "test-submenu",
+        activeSubMenuIndex: 0,
+        registerSubMenuLink: vi.fn(() => 0),
+        closeSubMenu: vi.fn(),
+        focusNext: vi.fn(),
+        focusPrevious: vi.fn(),
+        focusFirst: vi.fn(),
+        focusLast: vi.fn(),
+    };
+
+    test("renders with correct accessibility attributes", () => {
+        render(
+            <HeaderSubMenuContext.Provider value={mockContext}>
+                <HeaderSubLink route={Route.Device} icon="device" text="Devices" />
+            </HeaderSubMenuContext.Provider>,
+            { wrapper: MemoryRouter },
+        );
+
+        const menuItem = screen.getByRole("menuitem");
+        expect(menuItem).toBeInTheDocument();
+        expect(menuItem).toHaveTextContent("Devices");
+        expect(menuItem).toHaveAttribute("aria-controls", "test-submenu");
+        expect(menuItem).toHaveAttribute("tabIndex", "-1"); // Initially inactive
+    });
+
+    test("updates tabIndex when activeSubMenuIndex changes", () => {
+        const { rerender } = render(
+            <HeaderSubMenuContext.Provider value={mockContext}>
+                <HeaderSubLink route={Route.Device} icon="device" text="Devices" />
+            </HeaderSubMenuContext.Provider>,
+            { wrapper: MemoryRouter },
+        );
+
+        const menuItem = screen.getByRole("menuitem");
+        expect(menuItem).toBeInTheDocument();
+        expect(menuItem).toHaveAttribute("tabIndex", "-1"); // Initially
+
+        expect(mockContext.registerSubMenuLink).toHaveBeenCalled();
+
+        const updatedContext = { ...mockContext, activeSubMenuIndex: 0 };
+        rerender(
+            <HeaderSubMenuContext.Provider value={updatedContext}>
+                <HeaderSubLink route={Route.Device} icon="device" text="Devices" />
+            </HeaderSubMenuContext.Provider>,
+        );
+
+        expect(menuItem).toHaveAttribute("tabIndex", "0"); // After context update
+    });
+
+    test("renders inactive item with correct tabIndex", () => {
+        const inactiveContext = { ...mockContext, activeSubMenuIndex: 1 };
+
+        render(
+            <HeaderSubMenuContext.Provider value={inactiveContext}>
+                <HeaderSubLink route={Route.Device} icon="device" text="Devices" />
+            </HeaderSubMenuContext.Provider>,
+            { wrapper: MemoryRouter },
+        );
+
+        const menuItem = screen.getByRole("menuitem");
+        expect(menuItem).toBeInTheDocument();
+        expect(menuItem).toHaveAttribute("tabIndex", "-1"); // Inactive item
+    });
+});

--- a/services/ui/src/components/HeaderLink/HeaderSubLink.tsx
+++ b/services/ui/src/components/HeaderLink/HeaderSubLink.tsx
@@ -1,0 +1,7 @@
+import { CommonHeaderLinkProps } from "./CommonHeaderLink";
+import HeaderLinkBody from "./HeaderLinkBody";
+
+const HeaderSubLink = ({ route, icon, text }: CommonHeaderLinkProps) => {
+    return <HeaderLinkBody route={route} icon={icon} text={text} />;
+};
+export default HeaderSubLink;

--- a/services/ui/src/components/HeaderLink/HeaderSubLink.tsx
+++ b/services/ui/src/components/HeaderLink/HeaderSubLink.tsx
@@ -1,7 +1,69 @@
+import { ComponentProps, KeyboardEvent, useCallback, useContext, useEffect, useRef } from "react";
 import { CommonHeaderLinkProps } from "./CommonHeaderLink";
 import HeaderLinkBody from "./HeaderLinkBody";
+import HeaderSubMenuContext from "./HeaderSubMenuContext";
 
-const HeaderSubLink = ({ route, icon, text }: CommonHeaderLinkProps) => {
-    return <HeaderLinkBody route={route} icon={icon} text={text} />;
+type HeaderSubLinkProps = CommonHeaderLinkProps & ComponentProps<typeof HeaderLinkBody>;
+
+const HeaderSubLink = ({ route, icon, text, ...props }: HeaderSubLinkProps) => {
+    const index = useRef<number | null>(null);
+
+    const ref = useRef<HTMLAnchorElement>(null);
+
+    const {
+        subMenuId,
+        activeSubMenuIndex,
+        registerSubMenuLink,
+        closeSubMenu,
+        focusNext,
+        focusPrevious,
+        focusFirst,
+        focusLast,
+    } = useContext(HeaderSubMenuContext);
+
+    const handleKeyDown = useCallback(
+        (event: KeyboardEvent) => {
+            switch (event.key) {
+                case "ArrowDown":
+                    focusNext();
+                    break;
+
+                case "ArrowUp":
+                    focusPrevious();
+                    break;
+
+                case "Home":
+                    focusFirst();
+                    break;
+
+                case "End":
+                    focusLast();
+                    break;
+
+                case "Escape":
+                    closeSubMenu();
+                    break;
+            }
+        },
+        [closeSubMenu, focusFirst, focusLast, focusNext, focusPrevious],
+    );
+
+    useEffect(() => {
+        index.current = registerSubMenuLink(ref);
+    }, [registerSubMenuLink]);
+
+    return (
+        <HeaderLinkBody
+            {...props}
+            route={route}
+            icon={icon}
+            text={text}
+            role="menuitem"
+            tabIndex={index.current === activeSubMenuIndex ? 0 : -1}
+            onKeyDown={handleKeyDown}
+            aria-controls={subMenuId}
+            ref={ref}
+        />
+    );
 };
 export default HeaderSubLink;

--- a/services/ui/src/components/HeaderLink/HeaderSubMenuContext.tsx
+++ b/services/ui/src/components/HeaderLink/HeaderSubMenuContext.tsx
@@ -1,0 +1,28 @@
+import { createContext, RefObject } from "react";
+
+export type HeaderSubMenuContextType = {
+    subMenuId: string;
+    activeSubMenuIndex: number | null;
+
+    registerSubMenuLink: (ref: RefObject<HTMLAnchorElement | null>) => number;
+    closeSubMenu(): void;
+
+    focusNext(): void;
+    focusPrevious(): void;
+    focusFirst(): void;
+    focusLast(): void;
+};
+
+const HeaderSubMenuContext = createContext<HeaderSubMenuContextType>({
+    subMenuId: "",
+    activeSubMenuIndex: null,
+
+    registerSubMenuLink: () => -1,
+    closeSubMenu: () => {},
+
+    focusNext: () => {},
+    focusPrevious: () => {},
+    focusFirst: () => {},
+    focusLast: () => {},
+});
+export default HeaderSubMenuContext;

--- a/services/ui/src/components/HeaderLink/index.ts
+++ b/services/ui/src/components/HeaderLink/index.ts
@@ -1,1 +1,11 @@
-export { default } from "./HeaderLink";
+import HeaderLinkComponent from "./HeaderLink";
+import HeaderSubLink from "./HeaderSubLink";
+
+type HeaderLinkCompoundComponent = typeof HeaderLinkComponent & {
+    SubLink: typeof HeaderSubLink;
+};
+
+const HeaderLink = HeaderLinkComponent as HeaderLinkCompoundComponent;
+HeaderLink.SubLink = HeaderSubLink;
+
+export default HeaderLink;

--- a/services/ui/src/components/HeaderLink/useSubMenu.ts
+++ b/services/ui/src/components/HeaderLink/useSubMenu.ts
@@ -1,0 +1,116 @@
+import { KeyboardEvent, RefObject, useCallback, useId, useMemo, useState } from "react";
+import useOnClickOutside from "../../hooks/useOnClickOutside";
+import { HeaderSubMenuContextType } from "./HeaderSubMenuContext";
+
+export default function useSubMenu(hasChildren: boolean) {
+    const [showSubMenu, setShowSubMenu] = useState(false);
+    const [subMenuRefs, setSubMenuRefs] = useState<RefObject<HTMLAnchorElement | null>[]>([]);
+    const [activeSubMenuIndex, setActiveSubMenuIndex] = useState<number | null>(null);
+
+    const subMenuId = useId();
+
+    const ref = useOnClickOutside<HTMLAnchorElement>(() => setShowSubMenu(false));
+
+    const registerSubMenuLink = useCallback((ref: RefObject<HTMLAnchorElement | null>) => {
+        let newIndex: number = -1;
+
+        setSubMenuRefs((prev) => {
+            newIndex = prev.length;
+
+            return [...prev, ref];
+        });
+
+        return newIndex;
+    }, []);
+
+    const focus = useCallback(
+        (index: number) => {
+            setActiveSubMenuIndex(index);
+            subMenuRefs[index]?.current?.focus();
+        },
+        [subMenuRefs],
+    );
+
+    const focusNext = useCallback(
+        () => focus((activeSubMenuIndex ?? -1) + 1),
+        [activeSubMenuIndex, focus],
+    );
+
+    const focusPrevious = useCallback(
+        () => focus(((activeSubMenuIndex ?? 0) - 1 + subMenuRefs.length) % subMenuRefs.length),
+        [activeSubMenuIndex, focus, subMenuRefs.length],
+    );
+
+    const focusFirst = useCallback(() => focus(0), [focus]);
+    const focusLast = useCallback(() => focus(subMenuRefs.length - 1), [focus, subMenuRefs.length]);
+
+    const openSubMenu = useCallback(() => {
+        setShowSubMenu(true);
+
+        setTimeout(() => focusFirst(), 0);
+    }, [focusFirst]);
+
+    const closeSubMenu = useCallback(() => {
+        setShowSubMenu(false);
+        setActiveSubMenuIndex(null);
+        ref.current?.focus();
+    }, [ref]);
+
+    const context: HeaderSubMenuContextType = useMemo(
+        () => ({
+            subMenuId,
+            activeSubMenuIndex,
+
+            registerSubMenuLink,
+            closeSubMenu,
+            focusNext,
+            focusPrevious,
+            focusFirst,
+            focusLast,
+        }),
+        [
+            activeSubMenuIndex,
+            closeSubMenu,
+            focusNext,
+            focusPrevious,
+            focusFirst,
+            focusLast,
+            registerSubMenuLink,
+            subMenuId,
+        ],
+    );
+
+    const handleClick = useCallback(() => {
+        const isTouchDevice = window.matchMedia("(hover: none)").matches;
+
+        if (isTouchDevice) {
+            openSubMenu();
+        }
+    }, [openSubMenu]);
+
+    const handleKeyDown = useCallback(
+        (event: KeyboardEvent) => {
+            if (!hasChildren) {
+                return;
+            }
+
+            switch (event.key) {
+                case "Enter":
+                case " ":
+                case "ArrowDown":
+                    openSubMenu();
+                    break;
+            }
+        },
+        [hasChildren, openSubMenu],
+    );
+
+    return {
+        subMenuId,
+        context,
+        showSubMenu,
+        handleClick,
+        handleKeyDown,
+        ref,
+    };
+}

--- a/services/ui/src/components/HeaderLink/useSubMenu.ts
+++ b/services/ui/src/components/HeaderLink/useSubMenu.ts
@@ -47,12 +47,13 @@ export default function useSubMenu(hasChildren: boolean) {
     const openSubMenu = useCallback(() => {
         setShowSubMenu(true);
 
-        setTimeout(() => focusFirst(), 0);
+        setTimeout(focusFirst, 0);
     }, [focusFirst]);
 
     const closeSubMenu = useCallback(() => {
         setShowSubMenu(false);
         setActiveSubMenuIndex(null);
+
         ref.current?.focus();
     }, [ref]);
 

--- a/services/ui/src/components/HeaderLink/useSubMenu.ts
+++ b/services/ui/src/components/HeaderLink/useSubMenu.ts
@@ -25,6 +25,10 @@ export default function useSubMenu(hasChildren: boolean) {
 
     const focus = useCallback(
         (index: number) => {
+            if (subMenuRefs.length === 0) {
+                return;
+            }
+
             setActiveSubMenuIndex(index);
             subMenuRefs[index]?.current?.focus();
         },
@@ -32,14 +36,17 @@ export default function useSubMenu(hasChildren: boolean) {
     );
 
     const focusNext = useCallback(
-        () => focus((activeSubMenuIndex ?? -1) + 1),
-        [activeSubMenuIndex, focus],
-    );
-
-    const focusPrevious = useCallback(
-        () => focus(((activeSubMenuIndex ?? 0) - 1 + subMenuRefs.length) % subMenuRefs.length),
+        () => focus(((activeSubMenuIndex ?? -1) + 1) % subMenuRefs.length),
         [activeSubMenuIndex, focus, subMenuRefs.length],
     );
+
+    const focusPrevious = useCallback(() => {
+        if (subMenuRefs.length === 0) {
+            return;
+        }
+
+        focus(((activeSubMenuIndex ?? 0) - 1 + subMenuRefs.length) % subMenuRefs.length);
+    }, [activeSubMenuIndex, focus, subMenuRefs.length]);
 
     const focusFirst = useCallback(() => focus(0), [focus]);
     const focusLast = useCallback(() => focus(subMenuRefs.length - 1), [focus, subMenuRefs.length]);

--- a/services/ui/src/hooks/useOnClickOutside.test.tsx
+++ b/services/ui/src/hooks/useOnClickOutside.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import useOnClickOutside from "./useOnClickOutside";
+
+const TestComponent = ({ onClickOutside }: { onClickOutside: () => void }) => {
+    const ref = useOnClickOutside<HTMLDivElement>(onClickOutside);
+
+    return (
+        <div>
+            <div ref={ref} data-testid="target">
+                <button data-testid="inside-button">Inside</button>
+            </div>
+            <button data-testid="outside-button">Outside</button>
+        </div>
+    );
+};
+
+describe("useOnClickOutside", () => {
+    const user = userEvent.setup();
+    let mockHandler: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => (mockHandler = vi.fn()));
+
+    test("calls handler when clicking outside the element", async () => {
+        render(<TestComponent onClickOutside={mockHandler} />);
+
+        const outsideButton = screen.getByTestId("outside-button");
+        expect(outsideButton).toBeInTheDocument();
+
+        await user.click(outsideButton);
+
+        expect(mockHandler).toHaveBeenCalledTimes(1);
+    });
+
+    test("does not call handler when clicking inside the element", async () => {
+        render(<TestComponent onClickOutside={mockHandler} />);
+
+        const insideButton = screen.getByTestId("inside-button");
+        expect(insideButton).toBeInTheDocument();
+
+        await user.click(insideButton);
+
+        expect(mockHandler).not.toHaveBeenCalled();
+    });
+
+    test("does not call handler when clicking on the target element itself", async () => {
+        render(<TestComponent onClickOutside={mockHandler} />);
+
+        const target = screen.getByTestId("target");
+        expect(target).toBeInTheDocument();
+
+        await user.click(target);
+
+        expect(mockHandler).not.toHaveBeenCalled();
+    });
+
+    test("calls handler when clicking on document body", async () => {
+        render(<TestComponent onClickOutside={mockHandler} />);
+
+        await user.click(document.body);
+
+        expect(mockHandler).toHaveBeenCalledTimes(1);
+    });
+});

--- a/services/ui/src/hooks/useOnClickOutside/index.ts
+++ b/services/ui/src/hooks/useOnClickOutside/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./useOnClickOutside";

--- a/services/ui/src/hooks/useOnClickOutside/useOnClickOutside.ts
+++ b/services/ui/src/hooks/useOnClickOutside/useOnClickOutside.ts
@@ -1,0 +1,22 @@
+import { useEffect, useRef } from "react";
+
+/** Hook to perform an action when the user clicks outside the component. */
+export default function useOnClickOutside<TElement extends HTMLElement>(handle: () => void) {
+    const ref = useRef<TElement | null>(null);
+
+    useEffect(() => {
+        function handleClickOutside(event: MouseEvent) {
+            if (ref.current && !ref.current.contains(event.target as Node)) {
+                handle();
+            }
+        }
+
+        document.addEventListener("mousedown", handleClickOutside);
+
+        return () => {
+            document.removeEventListener("mousedown", handleClickOutside);
+        };
+    }, [handle]);
+
+    return ref;
+}

--- a/services/ui/src/pages/HomePage/HomePage.test.tsx
+++ b/services/ui/src/pages/HomePage/HomePage.test.tsx
@@ -72,15 +72,6 @@ describe("HomePage", () => {
             wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter>,
         });
 
-        const links = screen.getAllByRole("link");
-        expect(links).toHaveLength(2);
-
-        expect(links[0]).toHaveTextContent("Ground");
-        expect(links[0]).toHaveProperty("href", "http://localhost:3000/home/Ground");
-
-        expect(links[1]).toHaveTextContent("First Floor");
-        expect(links[1]).toHaveProperty("href", "http://localhost:3000/home/FirstFloor");
-
         expect(screen.getByTestId("floorplan")).toBeInTheDocument();
     });
 });

--- a/services/ui/src/pages/HomePage/HomePage.test.tsx
+++ b/services/ui/src/pages/HomePage/HomePage.test.tsx
@@ -76,10 +76,10 @@ describe("HomePage", () => {
         expect(links).toHaveLength(2);
 
         expect(links[0]).toHaveTextContent("Ground");
-        expect(links[0]).toHaveProperty("href", "http://localhost:3000/Ground");
+        expect(links[0]).toHaveProperty("href", "http://localhost:3000/home/Ground");
 
         expect(links[1]).toHaveTextContent("First Floor");
-        expect(links[1]).toHaveProperty("href", "http://localhost:3000/FirstFloor");
+        expect(links[1]).toHaveProperty("href", "http://localhost:3000/home/FirstFloor");
 
         expect(screen.getByTestId("floorplan")).toBeInTheDocument();
     });

--- a/services/ui/src/pages/HomePage/HomePage.tsx
+++ b/services/ui/src/pages/HomePage/HomePage.tsx
@@ -1,6 +1,7 @@
 import { NavLink } from "react-router-dom";
 import Message from "../../components/Message";
 import useQueryFloorplan from "../../queries/useQueryFloorPlan";
+import Route from "../../routing/Route";
 import RouteBuilder from "../../routing/RouteBuilder";
 import Floorplan from "./Floorplan";
 import useFloor from "./useFloor";
@@ -23,7 +24,10 @@ const HomePage = () => {
             {floorplan.floors.length > 1 && (
                 <div className="flex flex-row gap">
                     {floorplan.floors.map((floor) => (
-                        <NavLink key={floor.name} to={RouteBuilder.build(floor.name)}>
+                        <NavLink
+                            key={floor.name}
+                            to={RouteBuilder.build(Route.Root, Route.Home, floor.name)}
+                        >
                             {floor.display_name ?? floor.name}
                         </NavLink>
                     ))}

--- a/services/ui/src/pages/HomePage/HomePage.tsx
+++ b/services/ui/src/pages/HomePage/HomePage.tsx
@@ -1,8 +1,5 @@
-import { NavLink } from "react-router-dom";
 import Message from "../../components/Message";
 import useQueryFloorplan from "../../queries/useQueryFloorPlan";
-import Route from "../../routing/Route";
-import RouteBuilder from "../../routing/RouteBuilder";
 import Floorplan from "./Floorplan";
 import useFloor from "./useFloor";
 
@@ -19,23 +16,6 @@ const HomePage = () => {
         return <Message type="unknown" translation="pages.home" value={currentFloor} />;
     }
 
-    return (
-        <div className="flex flex-col gap flex-1">
-            {floorplan.floors.length > 1 && (
-                <div className="flex flex-row gap">
-                    {floorplan.floors.map((floor) => (
-                        <NavLink
-                            key={floor.name}
-                            to={RouteBuilder.build(Route.Root, Route.Home, floor.name)}
-                        >
-                            {floor.display_name ?? floor.name}
-                        </NavLink>
-                    ))}
-                </div>
-            )}
-
-            <Floorplan floorplan={floorplan} />
-        </div>
-    );
+    return <Floorplan floorplan={floorplan} />;
 };
 export default HomePage;


### PR DESCRIPTION
Fixes #651.
The multi-story floorplan option had broken links and were not styled well, this fixes that by:
- Moving the story selection into a drop-down under the `Home` main menu item.
- Removing the old story selection buttons.
- Ensure the links use the route builder to generate the correct links.