### PR TITLE
#541 fix(ui): Fix drop-down menus appearing behind sticky table headers

### DIFF
--- a/services/ui/src/App.tsx
+++ b/services/ui/src/App.tsx
@@ -1,6 +1,6 @@
 import { QueryClientProvider } from "@tanstack/react-query";
 import { PropsWithChildren } from "react";
-import DialogHost from "./components/Dialog/DialogHost";
+import { PortalHost } from "./components/PortalHost";
 import UserSettingsContextProvider from "./hooks/useUserSettings/UserSettingsContextProvider";
 import { PowerPiAPIContextProvider } from "./queries/PowerPiApiContext";
 import { queryClient } from "./queries/client";
@@ -13,7 +13,7 @@ const App = ({ children }: AppProps) => (
         <PowerPiAPIContextProvider>
             <NotificationContextProvider>
                 <UserSettingsContextProvider>
-                    <DialogHost>{children}</DialogHost>
+                    <PortalHost>{children}</PortalHost>
                 </UserSettingsContextProvider>
             </NotificationContextProvider>
         </PowerPiAPIContextProvider>

--- a/services/ui/src/components/DevicePowerToggle/DevicePowerToggle.tsx
+++ b/services/ui/src/components/DevicePowerToggle/DevicePowerToggle.tsx
@@ -96,7 +96,7 @@ const DevicePowerToggle = ({ device, ...props }: DevicePowerToggleProps) => {
                 {...props}
                 className={classNames(
                     "h-6 w-12 flex flex-row items-center rounded-full select-none cursor-pointer",
-                    "focus-within:ring-offset focus-within:ring-offset-outline-offset focus-within:ring focus-within:ring-outline focus:z-10",
+                    "focus-within:ring-offset focus-within:ring-offset-outline-offset focus-within:ring focus-within:ring-outline focus:z-focus",
                     "relative",
                     {
                         ["bg-on hover:bg-on-hover active:bg-on-active"]:

--- a/services/ui/src/components/Dialog/Dialog.test.tsx
+++ b/services/ui/src/components/Dialog/Dialog.test.tsx
@@ -1,12 +1,15 @@
 import { render, screen, within } from "@testing-library/react";
+import { PortalHost } from "../PortalHost";
 import Dialog from "./Dialog";
 
 describe("Dialog", () => {
     test("renders", () => {
         render(
-            <Dialog heading="My Dialog" icon={<div>My Icon</div>} open ref={{ current: null }}>
-                My Content
-            </Dialog>,
+            <PortalHost>
+                <Dialog heading="My Dialog" icon={<div>My Icon</div>} open ref={{ current: null }}>
+                    My Content
+                </Dialog>
+            </PortalHost>,
         );
 
         const dialog = screen.getByRole("dialog");

--- a/services/ui/src/components/Dialog/Dialog.tsx
+++ b/services/ui/src/components/Dialog/Dialog.tsx
@@ -2,6 +2,7 @@ import classNames from "classnames";
 import { DialogHTMLAttributes, ReactNode, RefObject } from "react";
 import { useTranslation } from "react-i18next";
 import Button from "../Button";
+import { PortalHost } from "../PortalHost";
 
 type DialogProps = {
     icon?: ReactNode;
@@ -30,21 +31,23 @@ const Dialog = ({ icon, heading, children, ref, ...props }: DialogProps) => {
             ref={ref}
         >
             <form method="dialog">
-                <header
-                    className={classNames(
-                        "p flex flex-row gap-4 justify-between items-center",
-                        "bg-bg-primary",
-                        "border-b-2 border-b-outline",
-                    )}
-                >
-                    {icon}
+                <PortalHost>
+                    <header
+                        className={classNames(
+                            "p flex flex-row gap-4 justify-between items-center",
+                            "bg-bg-primary",
+                            "border-b-2 border-b-outline",
+                        )}
+                    >
+                        {icon}
 
-                    <h1 className="font-semibold">{heading}</h1>
+                        <h1 className="font-semibold">{heading}</h1>
 
-                    <Button buttonType="icon" icon="close" aria-label={t("common.close")} />
-                </header>
+                        <Button buttonType="icon" icon="close" aria-label={t("common.close")} />
+                    </header>
 
-                <div className="p">{children}</div>
+                    <div className="p">{children}</div>
+                </PortalHost>
             </form>
         </dialog>
     );

--- a/services/ui/src/components/Dialog/useDialog.test.ts
+++ b/services/ui/src/components/Dialog/useDialog.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook, screen, within } from "@testing-library/react";
 import { vi } from "vitest";
-import DialogHost from "./DialogHost";
+import { PortalHost } from "../PortalHost";
 import useDialog from "./useDialog";
 
 const mocks = vi.hoisted(() => ({
@@ -17,7 +17,7 @@ describe("useDialog", () => {
     });
 
     test("opens dialog", () => {
-        const { result } = renderHook(useDialog, { wrapper: DialogHost });
+        const { result } = renderHook(useDialog, { wrapper: PortalHost });
 
         const dialog = screen.getByRole("dialog", { hidden: true });
         expect(dialog).toBeInTheDocument();
@@ -32,7 +32,7 @@ describe("useDialog", () => {
     });
 
     test("closes dialog", () => {
-        const { result } = renderHook(useDialog, { wrapper: DialogHost });
+        const { result } = renderHook(useDialog, { wrapper: PortalHost });
 
         const dialog = screen.getByRole("dialog", { hidden: true });
         expect(dialog).toBeInTheDocument();

--- a/services/ui/src/components/PortalHost/PortalHost.test.tsx
+++ b/services/ui/src/components/PortalHost/PortalHost.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import { createPortal } from "react-dom";
+import PortalHost from "./PortalHost";
+import usePortalHost from "./usePortalHost";
+
+const TestChild = () => {
+    const { dropdownHost, tooltipHost, getElementByHostId } = usePortalHost();
+
+    return (
+        <div>
+            <span data-testid="child">Test Content</span>
+            {createPortal(
+                <div data-testid="dropdown-content">Dropdown Content</div>,
+                getElementByHostId(dropdownHost),
+            )}
+            {createPortal(
+                <div data-testid="tooltip-content">Tooltip Content</div>,
+                getElementByHostId(tooltipHost),
+            )}
+        </div>
+    );
+};
+
+describe("PortalHost", () => {
+    test("renders children", () => {
+        render(
+            <PortalHost>
+                <div data-testid="test-child">Test Child</div>
+            </PortalHost>,
+        );
+
+        expect(screen.getByTestId("test-child")).toBeInTheDocument();
+    });
+
+    test("creates dropdown and tooltip host containers for portaled content", () => {
+        render(
+            <PortalHost>
+                <TestChild />
+            </PortalHost>,
+        );
+
+        expect(screen.getByTestId("child")).toBeInTheDocument();
+        expect(screen.getByTestId("dropdown-content")).toBeInTheDocument();
+        expect(screen.getByTestId("tooltip-content")).toBeInTheDocument();
+    });
+
+    test("supports nested PortalHost components", () => {
+        render(
+            <PortalHost>
+                <PortalHost>
+                    <TestChild />
+                </PortalHost>
+            </PortalHost>,
+        );
+
+        expect(screen.getByTestId("child")).toBeInTheDocument();
+        expect(screen.getByTestId("dropdown-content")).toBeInTheDocument();
+        expect(screen.getByTestId("tooltip-content")).toBeInTheDocument();
+    });
+});

--- a/services/ui/src/components/PortalHost/PortalHost.tsx
+++ b/services/ui/src/components/PortalHost/PortalHost.tsx
@@ -1,0 +1,43 @@
+import { Fragment, PropsWithChildren, useContext, useId, useMemo } from "react";
+import { DialogHost } from "../Dialog";
+import PortalHostContext from "./PortalHostContext";
+import usePortalHost from "./usePortalHost";
+
+type PortalHostProps = PropsWithChildren<unknown>;
+
+const PortalHost = ({ children }: PortalHostProps) => {
+    const { layer } = useContext(PortalHostContext);
+
+    const dropdownHost = useId();
+    const tooltipHost = useId();
+
+    const context = useMemo(
+        () => ({ layer: layer + 1, dropdownHost, tooltipHost }),
+        [dropdownHost, layer, tooltipHost],
+    );
+
+    return (
+        <PortalHostContext.Provider value={context}>
+            <PortalHostInner layer={layer}>{children}</PortalHostInner>
+        </PortalHostContext.Provider>
+    );
+};
+export default PortalHost;
+
+type PortalHostInnerProps = PropsWithChildren<{
+    layer: number;
+}>;
+
+const PortalHostInner = ({ layer, children }: PortalHostInnerProps) => {
+    const { dropdownHost, tooltipHost } = usePortalHost();
+
+    const Wrapper = layer === 0 ? DialogHost : Fragment;
+
+    return (
+        <Wrapper>
+            {children}
+            <div id={dropdownHost} className="fixed z-portal-overlay" />
+            <div id={tooltipHost} className="fixed z-portal-overlay" />
+        </Wrapper>
+    );
+};

--- a/services/ui/src/components/PortalHost/PortalHost.tsx
+++ b/services/ui/src/components/PortalHost/PortalHost.tsx
@@ -12,24 +12,20 @@ const PortalHost = ({ children }: PortalHostProps) => {
     const tooltipHost = useId();
 
     const context = useMemo(
-        () => ({ layer: layer + 1, dropdownHost, tooltipHost }),
+        () => ({ layer: layer == null ? 0 : layer + 1, dropdownHost, tooltipHost }),
         [dropdownHost, layer, tooltipHost],
     );
 
     return (
         <PortalHostContext.Provider value={context}>
-            <PortalHostInner layer={layer}>{children}</PortalHostInner>
+            <PortalHostInner>{children}</PortalHostInner>
         </PortalHostContext.Provider>
     );
 };
 export default PortalHost;
 
-type PortalHostInnerProps = PropsWithChildren<{
-    layer: number;
-}>;
-
-const PortalHostInner = ({ layer, children }: PortalHostInnerProps) => {
-    const { dropdownHost, tooltipHost } = usePortalHost();
+const PortalHostInner = ({ children }: PortalHostProps) => {
+    const { layer, dropdownHost, tooltipHost } = usePortalHost();
 
     const Wrapper = layer === 0 ? DialogHost : Fragment;
 

--- a/services/ui/src/components/PortalHost/PortalHostContext.ts
+++ b/services/ui/src/components/PortalHost/PortalHostContext.ts
@@ -1,13 +1,13 @@
 import { createContext } from "react";
 
 export type PortalHostContextType = {
-    layer: number;
+    layer: number | undefined;
     dropdownHost: string;
     tooltipHost: string;
 };
 
 const PortalHostContext = createContext<PortalHostContextType>({
-    layer: 0,
+    layer: undefined,
     dropdownHost: "dropdown-host",
     tooltipHost: "tooltip-host",
 });

--- a/services/ui/src/components/PortalHost/PortalHostContext.ts
+++ b/services/ui/src/components/PortalHost/PortalHostContext.ts
@@ -1,0 +1,14 @@
+import { createContext } from "react";
+
+export type PortalHostContextType = {
+    layer: number;
+    dropdownHost: string;
+    tooltipHost: string;
+};
+
+const PortalHostContext = createContext<PortalHostContextType>({
+    layer: 0,
+    dropdownHost: "dropdown-host",
+    tooltipHost: "tooltip-host",
+});
+export default PortalHostContext;

--- a/services/ui/src/components/PortalHost/index.ts
+++ b/services/ui/src/components/PortalHost/index.ts
@@ -1,0 +1,2 @@
+export { default as PortalHost } from "./PortalHost";
+export { default as usePortalHost } from "./usePortalHost";

--- a/services/ui/src/components/PortalHost/usePortalHost.ts
+++ b/services/ui/src/components/PortalHost/usePortalHost.ts
@@ -1,0 +1,6 @@
+import { useContext } from "react";
+import PortalHostContext from "./PortalHostContext";
+
+export default function usePortalHost() {
+    return useContext(PortalHostContext);
+}

--- a/services/ui/src/components/PortalHost/usePortalHost.ts
+++ b/services/ui/src/components/PortalHost/usePortalHost.ts
@@ -1,6 +1,16 @@
-import { useContext } from "react";
+import { useCallback, useContext } from "react";
 import PortalHostContext from "./PortalHostContext";
 
 export default function usePortalHost() {
-    return useContext(PortalHostContext);
+    const getElementByHostId = useCallback(
+        (hostId: string) => document.getElementById(hostId) ?? document.body,
+        [],
+    );
+
+    const context = useContext(PortalHostContext);
+
+    return {
+        ...context,
+        getElementByHostId,
+    };
 }

--- a/services/ui/src/components/Select/Select.tsx
+++ b/services/ui/src/components/Select/Select.tsx
@@ -34,7 +34,7 @@ const Select = <TValueType,>({
     onChange,
     ...props
 }: SelectProps<TValueType>) => {
-    const { dropdownHost } = usePortalHost();
+    const { dropdownHost, getElementByHostId } = usePortalHost();
 
     const currentValue = useMemo(
         () => options.find((option) => option.value === value),
@@ -90,7 +90,7 @@ const Select = <TValueType,>({
                     menu: () => "mt-2 rounded border border-outline",
                     menuList: () => "scrollbar-thin",
                 }}
-                menuPortalTarget={document.getElementById(dropdownHost) ?? document.body}
+                menuPortalTarget={getElementByHostId(dropdownHost)}
                 aria-label={label}
                 onChange={handleChange}
                 onMenuOpen={handleMenuOpen}

--- a/services/ui/src/components/Select/Select.tsx
+++ b/services/ui/src/components/Select/Select.tsx
@@ -3,6 +3,7 @@ import { HTMLAttributes, useCallback, useMemo, useState } from "react";
 import ReactSelect, { SingleValue } from "react-select";
 import _ from "underscore";
 import { inputStyles } from "../Input";
+import { usePortalHost } from "../PortalHost";
 import SelectDropDownIndicator from "./SelectDropDownIndicator";
 import SelectLoadingIndicator from "./SelectLoadingIndicator";
 import SelectOption from "./SelectOption";
@@ -33,6 +34,8 @@ const Select = <TValueType,>({
     onChange,
     ...props
 }: SelectProps<TValueType>) => {
+    const { dropdownHost } = usePortalHost();
+
     const currentValue = useMemo(
         () => options.find((option) => option.value === value),
         [options, value],
@@ -87,6 +90,7 @@ const Select = <TValueType,>({
                     menu: () => "mt-2 rounded border border-outline",
                     menuList: () => "scrollbar-thin",
                 }}
+                menuPortalTarget={document.getElementById(dropdownHost) ?? document.body}
                 aria-label={label}
                 onChange={handleChange}
                 onMenuOpen={handleMenuOpen}

--- a/services/ui/src/components/Select/SelectOption.tsx
+++ b/services/ui/src/components/Select/SelectOption.tsx
@@ -27,7 +27,7 @@ const SelectOption = <TValueType,>({
                 {
                     "bg-bg-primary": !isSelected && !isFocused,
                     "bg-bg-selected": isSelected && !isFocused,
-                    "bg-bg-hover ring-2 ring-outline z-10": isFocused,
+                    "bg-bg-hover ring-2 ring-outline z-focus": isFocused,
                 },
             )}
         >

--- a/services/ui/src/components/TableRow/TableRow.tsx
+++ b/services/ui/src/components/TableRow/TableRow.tsx
@@ -19,7 +19,7 @@ const TableRow = ({ children, ...props }: TableRow) => (
     <tr
         {...omit(props, "header", "index")}
         className={classNames("h-8", {
-            "sticky top-0 bg-bg z-10": props.header,
+            "sticky top-0 bg-bg z-table-header": props.header,
             "bg-transparent": !props.header && props.index % 2 === 1,
             "bg-bg-zebra": !props.header && props.index % 2 === 0,
         })}

--- a/services/ui/src/components/Tooltip/Tooltip.tsx
+++ b/services/ui/src/components/Tooltip/Tooltip.tsx
@@ -12,7 +12,7 @@ type TooltipProps = PropsWithChildren<
  * Use alongside the @see useTooltip hook.
  */
 const Tooltip = ({ className, children, ...props }: TooltipProps) => {
-    const { tooltipHost } = usePortalHost();
+    const { tooltipHost, getElementByHostId } = usePortalHost();
 
     return (
         <>
@@ -27,7 +27,7 @@ const Tooltip = ({ className, children, ...props }: TooltipProps) => {
                 >
                     {children}
                 </ReactTooltip>,
-                document.getElementById(tooltipHost) ?? document.body,
+                getElementByHostId(tooltipHost),
             )}
         </>
     );

--- a/services/ui/src/components/Tooltip/Tooltip.tsx
+++ b/services/ui/src/components/Tooltip/Tooltip.tsx
@@ -2,6 +2,7 @@ import classNames from "classnames";
 import { ComponentProps, PropsWithChildren } from "react";
 import { createPortal } from "react-dom";
 import { Tooltip as ReactTooltip } from "react-tooltip";
+import { usePortalHost } from "../PortalHost";
 
 type TooltipProps = PropsWithChildren<
     Pick<ComponentProps<typeof ReactTooltip>, "id" | "place" | "className">
@@ -10,22 +11,25 @@ type TooltipProps = PropsWithChildren<
 /** A tooltip to show when hovering over and element.
  * Use alongside the @see useTooltip hook.
  */
-const Tooltip = ({ className, children, ...props }: TooltipProps) => (
-    <>
-        {createPortal(
-            <ReactTooltip
-                {...props}
-                className={classNames(
-                    className,
-                    "!p !rounded !text-sm z-50",
-                    "!bg-bg-primary !text-text",
-                )}
-            >
-                {children}
-            </ReactTooltip>,
-            document.body,
-        )}
-    </>
-);
+const Tooltip = ({ className, children, ...props }: TooltipProps) => {
+    const { tooltipHost } = usePortalHost();
 
+    return (
+        <>
+            {createPortal(
+                <ReactTooltip
+                    {...props}
+                    className={classNames(
+                        className,
+                        "!p !rounded !text-sm",
+                        "!bg-bg-primary !text-text",
+                    )}
+                >
+                    {children}
+                </ReactTooltip>,
+                document.getElementById(tooltipHost) ?? document.body,
+            )}
+        </>
+    );
+};
 export default Tooltip;

--- a/services/ui/src/pages/SettingsPage/Language/LanguageSettings.test.tsx
+++ b/services/ui/src/pages/SettingsPage/Language/LanguageSettings.test.tsx
@@ -30,7 +30,7 @@ describe("LanguageSettings", () => {
 
         await userEvent.type(combobox, "english");
 
-        const options = within(group).getAllByRole("option");
+        const options = screen.getAllByRole("option");
         expect(options).toHaveLength(2);
 
         expect(options[0]).toHaveAccessibleName("English (UK)");

--- a/services/ui/tailwind.config.js
+++ b/services/ui/tailwind.config.js
@@ -87,6 +87,12 @@ export default {
             transitionProperty: {
                 grid: "grid-template-rows",
             },
+
+            zIndex: {
+                "focus": "50", 
+                "table-header": "10",
+                "portal-overlay": "50",
+            },
         },
     },
 };


### PR DESCRIPTION
Fix drop-down menus appearing behind sticky table headers using `PortalHost` and z-index to enforce the rendering order.