### PR TITLE
#693 fix(pipeline): Fix yarn lock regex for yarn why

### DIFF
--- a/.github/scripts/auto_version.sh
+++ b/.github/scripts/auto_version.sh
@@ -138,7 +138,7 @@ if [ -n "$yarn_lock_changed" ]
 then
     # Extract changed package names from yarn.lock diff
     packages=$(git diff origin/main...HEAD -- yarn.lock \
-        | grep -oP '^\+"\K@?[^@"]+' \
+        | grep -oP '^\+"?\K@?[^@"]+(?=@)' \
         | sort -u)
 
     for package in $packages


### PR DESCRIPTION
`yarn.lock` regex for finding the changed packages was too restrictive.