### PR TITLE
#693 fix(pipeline): Fix the parsing of yarn why result

### DIFF
--- a/.github/scripts/auto_version.sh
+++ b/.github/scripts/auto_version.sh
@@ -149,8 +149,8 @@ then
         workspaces=$(echo "$why_output" \
             | grep '"list"' \
             | jq -r '.data.items[]' \
-            | grep 'depends on it' \
-            | grep -oP '_project_#@powerpi#\K[^"]+')
+            | grep -oP '_project_#@powerpi#\K[^#]+' \
+            | sort -u) || true
 
         for workspace in $workspaces
         do


### PR DESCRIPTION
Fix the parsing of `yarn why` result