### PR TITLE
#693 fix(pipeline): Handle version only bumps as well

### DIFF
--- a/.github/scripts/auto_version.sh
+++ b/.github/scripts/auto_version.sh
@@ -138,7 +138,8 @@ if [ -n "$yarn_lock_changed" ]
 then
     # Extract changed package names from yarn.lock diff
     packages=$(git diff origin/main...HEAD -- yarn.lock \
-        | grep -oP '^\+"?\K@?[^@"]+(?=@)' \
+        | grep '^\+  resolved.*registry.yarnpkg.com' \
+        | grep -oP 'registry.yarnpkg.com/\K.+(?=/-/)' \
         | sort -u)
 
     for package in $packages


### PR DESCRIPTION
When a dependabot PR only changes a version it wasn't detected by the auto versioning script.