### PR TITLE
#183 feat(network): Add presence detection sensor

### DIFF
--- a/controllers/network/Dockerfile
+++ b/controllers/network/Dockerfile
@@ -29,7 +29,7 @@ FROM build-base-image-gcc AS build-image
 WORKDIR /opt/powerpi/controllers/network
 COPY --from=build-common-image /opt/powerpi/common ./../../common
 COPY controllers/network/poetry.lock controllers/network/pyproject.toml ./
-RUN poetry install --compile --only main --no-root --no-directory --no-interaction --no-ansi
+RUN poetry install --compile --only main,runtime --no-root --no-directory --no-interaction --no-ansi
 
 # install the common library
 COPY --from=build-common-image /opt/powerpi/common/python/dist/*.whl .

--- a/controllers/network/Dockerfile
+++ b/controllers/network/Dockerfile
@@ -2,7 +2,9 @@
 FROM python:3.11.14-slim-bookworm AS base-image
 RUN pip install --upgrade pip==25.3 \
     && apt-get update \
-    && apt-get install -y --no-install-recommends libpcap0.8 \
+    && apt-get install -y --no-install-recommends libpcap0.8 libcap2-bin \
+    && setcap cap_net_raw,cap_net_admin=eip /usr/local/bin/python3.11 \
+    && apt-get remove -y libcap2-bin \
     && apt-get clean -y
 
 # create a base image for building

--- a/controllers/network/Dockerfile
+++ b/controllers/network/Dockerfile
@@ -1,11 +1,19 @@
 # create a common base image
 FROM python:3.11.14-slim-bookworm AS base-image
-RUN pip install --upgrade pip==25.3
+RUN pip install --upgrade pip==25.3 \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends libpcap0.8 \
+    && apt-get clean -y
 
 # create a base image for building
 FROM base-image AS build-base-image
 RUN pip3 install --prefer-binary poetry==2.2.1
 RUN poetry config virtualenvs.in-project true
+
+FROM build-base-image AS build-base-image-gcc
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gcc libpcap0.8-dev python3.11-dev \
+    && apt-get clean -y
 
 # build the common library
 FROM build-base-image AS build-common-image
@@ -15,7 +23,7 @@ COPY common/python/powerpi_common ./powerpi_common
 RUN poetry build
 
 # install the controller's dependencies
-FROM build-base-image AS build-image
+FROM build-base-image-gcc AS build-image
 WORKDIR /opt/powerpi/controllers/network
 COPY --from=build-common-image /opt/powerpi/common ./../../common
 COPY controllers/network/poetry.lock controllers/network/pyproject.toml ./

--- a/controllers/network/network_controller/__main__.py
+++ b/controllers/network/network_controller/__main__.py
@@ -2,12 +2,14 @@ import sys
 
 from network_controller.container import ApplicationContainer
 from network_controller.device.container import add_devices
+from network_controller.sensor.container import add_sensors
 
 if __name__ == '__main__':
     # initialise DI
     container = ApplicationContainer()
     container.wire(modules=[sys.modules[__name__]])
     add_devices(container)
+    add_sensors(container)
 
     controller = container.common().controller()
     controller.start()

--- a/controllers/network/network_controller/__main__.py
+++ b/controllers/network/network_controller/__main__.py
@@ -11,5 +11,5 @@ if __name__ == '__main__':
     add_devices(container)
     add_sensors(container)
 
-    controller = container.common().controller()
+    controller = container.controller()
     controller.start()

--- a/controllers/network/network_controller/config.py
+++ b/controllers/network/network_controller/config.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv, getuid
 
 from powerpi_common.config import Config
 from powerpi_common.config.config import as_int
@@ -6,6 +6,10 @@ from powerpi_common.config.config import as_int
 
 class NetworkConfig(Config):
     @property
+    def is_root(self):
+        return getuid() == 0
+
+    @property
     def arp_cache_expiry(self):
-        value = as_int(os.getenv("ARP_CACHE_EXPIRY"))
+        value = as_int(getenv("ARP_CACHE_EXPIRY"))
         return value if value is not None else 60

--- a/controllers/network/network_controller/config.py
+++ b/controllers/network/network_controller/config.py
@@ -1,0 +1,11 @@
+import os
+
+from powerpi_common.config import Config
+from powerpi_common.config.config import as_int
+
+
+class NetworkConfig(Config):
+    @property
+    def arp_cache_expiry(self):
+        value = as_int(os.getenv("ARP_CACHE_EXPIRY"))
+        return value if value is not None else 60

--- a/controllers/network/network_controller/config.py
+++ b/controllers/network/network_controller/config.py
@@ -1,13 +1,10 @@
-from os import getenv, getuid
+from os import getenv
 
 from powerpi_common.config import Config
 from powerpi_common.config.config import as_int
 
 
 class NetworkConfig(Config):
-    @property
-    def is_root(self):
-        return getuid() == 0
 
     @property
     def arp_cache_expiry(self):

--- a/controllers/network/network_controller/container.py
+++ b/controllers/network/network_controller/container.py
@@ -2,6 +2,7 @@ from dependency_injector import containers, providers
 from powerpi_common.container import Container as CommonContainer
 
 from network_controller.__version__ import __app_name__, __version__
+from network_controller.config import NetworkConfig
 from network_controller.controller import Controller
 from network_controller.services import ServicesContainer
 
@@ -14,16 +15,22 @@ class ApplicationContainer(containers.DeclarativeContainer):
         __self__
     )
 
+    config = providers.Singleton(
+        NetworkConfig
+    )
+
     common = providers.Container(
         CommonContainer,
         app_name=__app_name__,
-        version=__version__
+        version=__version__,
+        config=config
     )
 
     services = providers.Container(
         ServicesContainer,
         common=common,
-        device=common.device
+        device=common.device,
+        config=config
     )
 
     controller = providers.Singleton(

--- a/controllers/network/network_controller/container.py
+++ b/controllers/network/network_controller/container.py
@@ -22,7 +22,8 @@ class ApplicationContainer(containers.DeclarativeContainer):
 
     services = providers.Container(
         ServicesContainer,
-        common=common
+        common=common,
+        device=common.device
     )
 
     controller = providers.Singleton(

--- a/controllers/network/network_controller/container.py
+++ b/controllers/network/network_controller/container.py
@@ -2,6 +2,8 @@ from dependency_injector import containers, providers
 from powerpi_common.container import Container as CommonContainer
 
 from network_controller.__version__ import __app_name__, __version__
+from network_controller.controller import Controller
+from network_controller.services import ServicesContainer
 
 
 class ApplicationContainer(containers.DeclarativeContainer):
@@ -16,4 +18,20 @@ class ApplicationContainer(containers.DeclarativeContainer):
         CommonContainer,
         app_name=__app_name__,
         version=__version__
+    )
+
+    services = providers.Container(
+        ServicesContainer,
+        common=common
+    )
+
+    controller = providers.Singleton(
+        Controller,
+        logger=common.logger,
+        device_manager=common.device.device_manager,
+        mqtt_client=common.mqtt_client,
+        device_status_checker=common.device.device_status_checker,
+        scheduler=common.scheduler,
+        health=common.health,
+        arp_factory=services.container.arp_factory
     )

--- a/controllers/network/network_controller/container.py
+++ b/controllers/network/network_controller/container.py
@@ -41,5 +41,5 @@ class ApplicationContainer(containers.DeclarativeContainer):
         device_status_checker=common.device.device_status_checker,
         scheduler=common.scheduler,
         health=common.health,
-        arp_factory=services.container.arp_factory
+        arp_provider_factory=services.container.arp_provider_factory
     )

--- a/controllers/network/network_controller/controller.py
+++ b/controllers/network/network_controller/controller.py
@@ -6,11 +6,11 @@ from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
 
 from network_controller.__version__ import __app_name__, __version__
-from network_controller.services.arp import ARPFactory, ARPReader
+from network_controller.services.arp import ARPProviderFactory, ARPProvider
 
 
 class Controller(CommonController):
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
     def __init__(
         self,
         logger: Logger,
@@ -19,7 +19,7 @@ class Controller(CommonController):
         device_status_checker: DeviceStatusChecker,
         scheduler: AsyncIOScheduler,
         health: HealthService,
-        arp_factory: ARPFactory
+        arp_provider_factory: ARPProviderFactory
     ):
         CommonController.__init__(
             self, logger, device_manager,
@@ -28,18 +28,18 @@ class Controller(CommonController):
             __app_name__, __version__
         )
 
-        self.__arp_factory = arp_factory
-        self.__arp_service: ARPReader | None
+        self.__arp_provider_factory = arp_provider_factory
+        self.__arp_provider: ARPProvider | None
 
     async def _app_start(self):
         await CommonController._app_start(self)
 
-        self.__arp_service = self.__arp_factory.get_arp_service()
-        if self.__arp_service is not None:
-            await self.__arp_service.start()
+        self.__arp_provider = self.__arp_provider_factory.get_arp_service()
+        if self.__arp_provider is not None:
+            await self.__arp_provider.start()
 
     async def _app_stop(self):
-        if self.__arp_service is not None:
-            await self.__arp_service.stop()
+        if self.__arp_provider is not None:
+            await self.__arp_provider.stop()
 
         await CommonController._app_stop(self)

--- a/controllers/network/network_controller/controller.py
+++ b/controllers/network/network_controller/controller.py
@@ -1,0 +1,42 @@
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from powerpi_common.config import Config
+from powerpi_common.controller import Controller as CommonController
+from powerpi_common.device import DeviceManager, DeviceStatusChecker
+from powerpi_common.health import HealthService
+from powerpi_common.logger import Logger
+from powerpi_common.mqtt import MQTTClient
+
+from network_controller.__version__ import __app_name__, __version__
+from network_controller.services.arp import ARPFactory
+
+
+class Controller(CommonController):
+    # pylint: disable=too-many-arguments
+    def __init__(
+        self,
+        logger: Logger,
+        device_manager: DeviceManager,
+        mqtt_client: MQTTClient,
+        device_status_checker: DeviceStatusChecker,
+        scheduler: AsyncIOScheduler,
+        health: HealthService,
+        arp_factory: ARPFactory
+    ):
+        CommonController.__init__(
+            self, logger, device_manager,
+            mqtt_client, device_status_checker,
+            scheduler, health,
+            __app_name__, __version__
+        )
+
+        self.__arp_service = arp_factory.get_arp_service()
+
+    async def _app_start(self):
+        await CommonController._app_start(self)
+
+        await self.__arp_service.start()
+
+    async def _app_stop(self):
+        await self.__arp_service.stop()
+
+        await CommonController._app_stop(self)

--- a/controllers/network/network_controller/controller.py
+++ b/controllers/network/network_controller/controller.py
@@ -1,5 +1,4 @@
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
-from powerpi_common.config import Config
 from powerpi_common.controller import Controller as CommonController
 from powerpi_common.device import DeviceManager, DeviceStatusChecker
 from powerpi_common.health import HealthService
@@ -7,7 +6,7 @@ from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
 
 from network_controller.__version__ import __app_name__, __version__
-from network_controller.services.arp import ARPFactory
+from network_controller.services.arp import ARPFactory, ARPReader
 
 
 class Controller(CommonController):
@@ -29,14 +28,18 @@ class Controller(CommonController):
             __app_name__, __version__
         )
 
-        self.__arp_service = arp_factory.get_arp_service()
+        self.__arp_factory = arp_factory
+        self.__arp_service: ARPReader | None
 
     async def _app_start(self):
         await CommonController._app_start(self)
 
-        await self.__arp_service.start()
+        self.__arp_service = self.__arp_factory.get_arp_service()
+        if self.__arp_service is not None:
+            await self.__arp_service.start()
 
     async def _app_stop(self):
-        await self.__arp_service.stop()
+        if self.__arp_service is not None:
+            await self.__arp_service.stop()
 
         await CommonController._app_stop(self)

--- a/controllers/network/network_controller/device/computer.py
+++ b/controllers/network/network_controller/device/computer.py
@@ -1,6 +1,5 @@
 from asyncio import sleep
 
-from icmplib import async_ping
 from powerpi_common.device import Device, DeviceStatus
 from powerpi_common.device.mixin import PollableMixin
 from powerpi_common.logger import Logger
@@ -8,6 +7,7 @@ from powerpi_common.mqtt import MQTTClient
 from wakeonlan import send_magic_packet
 
 from network_controller.config import NetworkConfig
+from network_controller.util import ping
 
 
 class ComputerDevice(Device, PollableMixin):
@@ -31,8 +31,6 @@ class ComputerDevice(Device, PollableMixin):
         # pylint: disable=too-many-arguments,too-many-positional-arguments
         Device.__init__(self, config, logger, mqtt_client, **kwargs)
         PollableMixin.__init__(self, config, **kwargs)
-
-        self.__config = config
 
         self.__mac_address = mac
         self.__network_address = ip if ip is not None else hostname
@@ -70,12 +68,6 @@ class ComputerDevice(Device, PollableMixin):
         return False
 
     async def __is_alive(self, count=1):
-        result = await async_ping(
-            self.__network_address,
-            count=count,
-            interval=0.2,
-            timeout=2,
-            privileged=self.__config.is_root
-        )
+        result = await ping(self.__network_address, count)
 
         return result.is_alive

--- a/controllers/network/network_controller/device/computer.py
+++ b/controllers/network/network_controller/device/computer.py
@@ -1,12 +1,13 @@
 from asyncio import sleep
 
 from icmplib import async_ping
-from powerpi_common.config import Config
 from powerpi_common.device import Device, DeviceStatus
 from powerpi_common.device.mixin import PollableMixin
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
 from wakeonlan import send_magic_packet
+
+from network_controller.config import NetworkConfig
 
 
 class ComputerDevice(Device, PollableMixin):
@@ -18,7 +19,7 @@ class ComputerDevice(Device, PollableMixin):
 
     def __init__(
         self,
-        config: Config,
+        config: NetworkConfig,
         logger: Logger,
         mqtt_client: MQTTClient,
         mac: str,
@@ -30,6 +31,8 @@ class ComputerDevice(Device, PollableMixin):
         # pylint: disable=too-many-arguments,too-many-positional-arguments
         Device.__init__(self, config, logger, mqtt_client, **kwargs)
         PollableMixin.__init__(self, config, **kwargs)
+
+        self.__config = config
 
         self.__mac_address = mac
         self.__network_address = ip if ip is not None else hostname
@@ -72,7 +75,7 @@ class ComputerDevice(Device, PollableMixin):
             count=count,
             interval=0.2,
             timeout=2,
-            privileged=False
+            privileged=self.__config.is_root
         )
 
         return result.is_alive

--- a/controllers/network/network_controller/sensor/container.py
+++ b/controllers/network/network_controller/sensor/container.py
@@ -16,6 +16,6 @@ def add_sensors(container):
             config=container.common.config,
             logger=container.common.logger,
             mqtt_client=container.common.mqtt_client,
-            arp_factory=services_container.arp_factory
+            arp_provider_factory=services_container.arp_provider_factory
         )
     )

--- a/controllers/network/network_controller/sensor/container.py
+++ b/controllers/network/network_controller/sensor/container.py
@@ -5,6 +5,7 @@ from .presence import PresenceSensor
 
 def add_sensors(container):
     common_container = container.common()
+    services_container = container.services()
     device_container = common_container.device()
 
     setattr(
@@ -14,6 +15,7 @@ def add_sensors(container):
             PresenceSensor,
             config=container.common.config,
             logger=container.common.logger,
-            mqtt_client=container.common.mqtt_client
+            mqtt_client=container.common.mqtt_client,
+            arp_factory=services_container.arp_factory
         )
     )

--- a/controllers/network/network_controller/sensor/container.py
+++ b/controllers/network/network_controller/sensor/container.py
@@ -1,0 +1,19 @@
+from dependency_injector import providers
+
+from .presence import PresenceSensor
+
+
+def add_sensors(container):
+    common_container = container.common()
+    device_container = common_container.device()
+
+    setattr(
+        device_container,
+        'network_presence_sensor',
+        providers.Factory(
+            PresenceSensor,
+            config=container.common.config,
+            logger=container.common.logger,
+            mqtt_client=container.common.mqtt_client
+        )
+    )

--- a/controllers/network/network_controller/sensor/presence.py
+++ b/controllers/network/network_controller/sensor/presence.py
@@ -98,8 +98,9 @@ class PresenceSensor(Sensor, PollableMixin):
 
             return
 
-        # start the timer
-        self.__grace_period.timer = now
+        # start the timer, but only if it's not already started
+        if self.__grace_period.timer == 0:
+            self.__grace_period.timer = now
 
         # try to ping
         is_alive = await self.__is_alive()

--- a/controllers/network/network_controller/sensor/presence.py
+++ b/controllers/network/network_controller/sensor/presence.py
@@ -6,12 +6,7 @@ from powerpi_common.mqtt import MQTTClient
 from powerpi_common.sensor import Sensor
 from powerpi_common.device.mixin import PollableMixin
 
-
-@dataclass
-class HostAddress:
-    mac: str | None = None
-    ip: str | None = None
-    hostname: str | None = None
+from network_controller.services.arp import ARPFactory, HostAddress
 
 
 class PresenceSensor(Sensor, PollableMixin):
@@ -25,6 +20,7 @@ class PresenceSensor(Sensor, PollableMixin):
         config: Config,
         logger: Logger,
         mqtt_client: MQTTClient,
+        arp_factory: ARPFactory,
         mac: str | None = None,
         ip: str | None = None,
         hostname: str | None = None,
@@ -34,6 +30,7 @@ class PresenceSensor(Sensor, PollableMixin):
         PollableMixin.__init__(self, config, **kwargs)
 
         self._logger = logger
+        self.__reader = arp_factory.get_arp_service()
 
         self.__host_address = HostAddress(mac, ip, hostname)
 
@@ -42,11 +39,11 @@ class PresenceSensor(Sensor, PollableMixin):
 
     @property
     def mac_address(self):
-        return self.__get_real_or_cached('mac')
+        return self.__get_real_or_cached('mac_address')
 
     @property
     def ip_address(self):
-        return self.__get_real_or_cached('ip')
+        return self.__get_real_or_cached('ip_address')
 
     @property
     def hostname(self):

--- a/controllers/network/network_controller/sensor/presence.py
+++ b/controllers/network/network_controller/sensor/presence.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 from enum import StrEnum, unique
 from time import time
 
-from icmplib import async_ping
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
 from powerpi_common.sensor import Sensor
@@ -10,6 +9,7 @@ from powerpi_common.device.mixin import PollableMixin
 
 from network_controller.config import NetworkConfig
 from network_controller.services.arp import ARPFactory, ARPReader, HostAddress
+from network_controller.util import ping
 
 
 @unique
@@ -47,7 +47,6 @@ class PresenceSensor(Sensor, PollableMixin):
         Sensor.__init__(self, mqtt_client, **kwargs)
         PollableMixin.__init__(self, config, **kwargs)
 
-        self.__config = config
         self._logger = logger
         self.__factory = arp_factory
         self.__reader: ARPReader | None = None
@@ -147,12 +146,6 @@ class PresenceSensor(Sensor, PollableMixin):
     async def __is_alive(self):
         network_address = self.ip_address if self.ip_address else self.hostname
 
-        result = await async_ping(
-            network_address,
-            count=1,
-            interval=0.2,
-            timeout=2,
-            privileged=self.__config.is_root
-        )
+        result = await ping(network_address, 1)
 
         return result.is_alive

--- a/controllers/network/network_controller/sensor/presence.py
+++ b/controllers/network/network_controller/sensor/presence.py
@@ -3,12 +3,12 @@ from enum import StrEnum, unique
 from time import time
 
 from icmplib import async_ping
-from powerpi_common.config import Config
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
 from powerpi_common.sensor import Sensor
 from powerpi_common.device.mixin import PollableMixin
 
+from network_controller.config import NetworkConfig
 from network_controller.services.arp import ARPFactory, ARPReader, HostAddress
 
 
@@ -33,7 +33,7 @@ class PresenceSensor(Sensor, PollableMixin):
 
     def __init__(
         self,
-        config: Config,
+        config: NetworkConfig,
         logger: Logger,
         mqtt_client: MQTTClient,
         arp_factory: ARPFactory,
@@ -47,6 +47,7 @@ class PresenceSensor(Sensor, PollableMixin):
         Sensor.__init__(self, mqtt_client, **kwargs)
         PollableMixin.__init__(self, config, **kwargs)
 
+        self.__config = config
         self._logger = logger
         self.__factory = arp_factory
         self.__reader: ARPReader | None = None
@@ -151,7 +152,7 @@ class PresenceSensor(Sensor, PollableMixin):
             count=1,
             interval=0.2,
             timeout=2,
-            privileged=False
+            privileged=self.__config.is_root
         )
 
         return result.is_alive

--- a/controllers/network/network_controller/sensor/presence.py
+++ b/controllers/network/network_controller/sensor/presence.py
@@ -1,8 +1,17 @@
+from dataclasses import dataclass
+
 from powerpi_common.config import Config
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
 from powerpi_common.sensor import Sensor
 from powerpi_common.device.mixin import PollableMixin
+
+
+@dataclass
+class HostAddress:
+    mac: str | None = None
+    ip: str | None = None
+    hostname: str | None = None
 
 
 class PresenceSensor(Sensor, PollableMixin):
@@ -16,12 +25,39 @@ class PresenceSensor(Sensor, PollableMixin):
         config: Config,
         logger: Logger,
         mqtt_client: MQTTClient,
+        mac: str | None = None,
+        ip: str | None = None,
+        hostname: str | None = None,
         **kwargs
     ):
         Sensor.__init__(self, mqtt_client, **kwargs)
-        PollableMixin(self, config, **kwargs)
+        PollableMixin.__init__(self, config, **kwargs)
 
         self._logger = logger
 
+        self.__host_address = HostAddress(mac, ip, hostname)
+
+        # we cache the values we get from the service, and use them as fallbacks
+        self.__cache = HostAddress()
+
+    @property
+    def mac_address(self):
+        return self.__get_real_or_cached('mac')
+
+    @property
+    def ip_address(self):
+        return self.__get_real_or_cached('ip')
+
+    @property
+    def hostname(self):
+        return self.__get_real_or_cached('hostname')
+
     async def poll(self):
         pass
+
+    def __get_real_or_cached(self, prop: str):
+        value = getattr(self.__host_address, prop)
+        if value is not None:
+            return value
+
+        return getattr(self.__cache, prop)

--- a/controllers/network/network_controller/sensor/presence.py
+++ b/controllers/network/network_controller/sensor/presence.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from enum import StrEnum, unique
+from time import time
 
+from icmplib import async_ping
 from powerpi_common.config import Config
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
@@ -15,6 +17,12 @@ class PresenceStatus(StrEnum):
     PRESENT = 'present'
     ABSENT = 'absent'
     UNKNOWN = 'unknown'
+
+
+@dataclass
+class GracePeriod:
+    delay: int
+    timer: int = 0
 
 
 class PresenceSensor(Sensor, PollableMixin):
@@ -32,8 +40,10 @@ class PresenceSensor(Sensor, PollableMixin):
         mac: str | None = None,
         ip: str | None = None,
         hostname: str | None = None,
+        absent_delay: int = 3 * 60,
         **kwargs
     ):
+        # pylint: disable=too-many-arguments,too-many-positional-arguments
         Sensor.__init__(self, mqtt_client, **kwargs)
         PollableMixin.__init__(self, config, **kwargs)
 
@@ -45,6 +55,8 @@ class PresenceSensor(Sensor, PollableMixin):
 
         # we cache the values we get from the service, and use them as fallbacks
         self.__cache = HostAddress()
+
+        self.__grace_period = GracePeriod(absent_delay)
 
         self.__state = PresenceStatus.UNKNOWN
 
@@ -63,12 +75,41 @@ class PresenceSensor(Sensor, PollableMixin):
     async def poll(self):
         entry = self.__arp_service.find(self)
         if entry is None:
-            self.__set_new_state(PresenceStatus.ABSENT)
+            # apply the grace period before marking the device as absent
+            await self.__check_grace_period()
         else:
-            self.__cache = entry
-            self.__set_new_state(PresenceStatus.PRESENT)
+            self.log_debug('Device present in ARP cache')
 
-    def _broadcast(self, state: PresenceStatus):
+            # update the cache of MAC, IP and hostname
+            self.__cache = entry
+
+            self.__set_present()
+
+    async def __check_grace_period(self):
+        # first has the period already expired?
+        now = int(time())
+        expiry = now - self.__grace_period.delay
+
+        if self.__grace_period.timer != 0 and self.__grace_period.timer < expiry:
+            # it has expired
+            self.log_debug('Device absent after grace period')
+
+            self.__set_new_state(PresenceStatus.ABSENT)
+
+            return
+
+        # start the timer
+        self.__grace_period.timer = now
+
+        # try to ping
+        is_alive = await self.__is_alive()
+        if is_alive:
+            # it is actually present
+            self.log_debug('Device present after ping')
+
+            self.__set_present()
+
+    def __broadcast(self, state: PresenceStatus):
         topic = f'presence/{self.entity}/status'
 
         message = {'state': state}
@@ -79,7 +120,14 @@ class PresenceSensor(Sensor, PollableMixin):
         if self.__state != state:
             self.__state = state
 
-            self._broadcast(state)
+            self.__broadcast(state)
+
+    def __set_present(self):
+        # reset the grace period timer as the device is present
+        # if it disappears again we want to allow the grace period again
+        self.__grace_period.timer = 0
+
+        self.__set_new_state(PresenceStatus.PRESENT)
 
     @property
     def __arp_service(self):
@@ -94,3 +142,16 @@ class PresenceSensor(Sensor, PollableMixin):
             return value
 
         return getattr(self.__cache, prop)
+
+    async def __is_alive(self):
+        network_address = self.ip_address if self.ip_address else self.hostname
+
+        result = await async_ping(
+            network_address,
+            count=1,
+            interval=0.2,
+            timeout=2,
+            privileged=False
+        )
+
+        return result.is_alive

--- a/controllers/network/network_controller/sensor/presence.py
+++ b/controllers/network/network_controller/sensor/presence.py
@@ -1,0 +1,27 @@
+from powerpi_common.config import Config
+from powerpi_common.logger import Logger
+from powerpi_common.mqtt import MQTTClient
+from powerpi_common.sensor import Sensor
+from powerpi_common.device.mixin import PollableMixin
+
+
+class PresenceSensor(Sensor, PollableMixin):
+    '''
+    Add supports for detecting a device on the network for user presence detection,
+    using ARP tables and ICMP ping.
+    '''
+
+    def __init__(
+        self,
+        config: Config,
+        logger: Logger,
+        mqtt_client: MQTTClient,
+        **kwargs
+    ):
+        Sensor.__init__(self, mqtt_client, **kwargs)
+        PollableMixin(self, config, **kwargs)
+
+        self._logger = logger
+
+    async def poll(self):
+        pass

--- a/controllers/network/network_controller/sensor/presence.py
+++ b/controllers/network/network_controller/sensor/presence.py
@@ -8,7 +8,7 @@ from powerpi_common.sensor import Sensor
 from powerpi_common.device.mixin import PollableMixin
 
 from network_controller.config import NetworkConfig
-from network_controller.services.arp import ARPFactory, ARPReader, HostAddress
+from network_controller.services.arp import ARPProviderFactory, ARPProvider, HostAddress
 from network_controller.util import ping
 
 
@@ -36,7 +36,7 @@ class PresenceSensor(Sensor, PollableMixin):
         config: NetworkConfig,
         logger: Logger,
         mqtt_client: MQTTClient,
-        arp_factory: ARPFactory,
+        arp_provider_factory: ARPProviderFactory,
         mac: str | None = None,
         ip: str | None = None,
         hostname: str | None = None,
@@ -48,8 +48,8 @@ class PresenceSensor(Sensor, PollableMixin):
         PollableMixin.__init__(self, config, **kwargs)
 
         self._logger = logger
-        self.__factory = arp_factory
-        self.__reader: ARPReader | None = None
+        self.__factory = arp_provider_factory
+        self.__provider: ARPProvider | None = None
 
         self.__host_address = HostAddress(mac, ip, hostname)
 
@@ -73,7 +73,7 @@ class PresenceSensor(Sensor, PollableMixin):
         return self.__get_real_or_cached('hostname')
 
     async def poll(self):
-        entry = self.__arp_service.find(self)
+        entry = self.__arp_provider.find(self)
         if entry is None:
             # apply the grace period before marking the device as absent
             await self.__check_grace_period()
@@ -131,11 +131,11 @@ class PresenceSensor(Sensor, PollableMixin):
         self.__set_new_state(PresenceStatus.PRESENT)
 
     @property
-    def __arp_service(self):
-        if self.__reader is None:
-            self.__reader = self.__factory.get_arp_service()
+    def __arp_provider(self):
+        if self.__provider is None:
+            self.__provider = self.__factory.get_arp_service()
 
-        return self.__reader
+        return self.__provider
 
     def __get_real_or_cached(self, prop: str):
         value = getattr(self.__host_address, prop)

--- a/controllers/network/network_controller/sensor/presence.py
+++ b/controllers/network/network_controller/sensor/presence.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from enum import StrEnum, unique
 
 from powerpi_common.config import Config
 from powerpi_common.logger import Logger
@@ -7,6 +8,13 @@ from powerpi_common.sensor import Sensor
 from powerpi_common.device.mixin import PollableMixin
 
 from network_controller.services.arp import ARPFactory, ARPReader, HostAddress
+
+
+@unique
+class PresenceStatus(StrEnum):
+    PRESENT = 'present'
+    ABSENT = 'absent'
+    UNKNOWN = 'unknown'
 
 
 class PresenceSensor(Sensor, PollableMixin):
@@ -38,6 +46,8 @@ class PresenceSensor(Sensor, PollableMixin):
         # we cache the values we get from the service, and use them as fallbacks
         self.__cache = HostAddress()
 
+        self.__state = PresenceStatus.UNKNOWN
+
     @property
     def mac_address(self):
         return self.__get_real_or_cached('mac_address')
@@ -51,14 +61,32 @@ class PresenceSensor(Sensor, PollableMixin):
         return self.__get_real_or_cached('hostname')
 
     async def poll(self):
-        pass
+        entry = self.__arp_service.find(self)
+        if entry is None:
+            self.__set_new_state(PresenceStatus.ABSENT)
+        else:
+            self.__cache = entry
+            self.__set_new_state(PresenceStatus.PRESENT)
+
+    def _broadcast(self, state: PresenceStatus):
+        topic = f'presence/{self.entity}/status'
+
+        message = {'state': state}
+
+        self._producer(topic, message)
+
+    def __set_new_state(self, state: PresenceStatus):
+        if self.__state != state:
+            self.__state = state
+
+            self._broadcast(state)
 
     @property
     def __arp_service(self):
         if self.__reader is None:
             self.__reader = self.__factory.get_arp_service()
 
-        return self.__arp
+        return self.__reader
 
     def __get_real_or_cached(self, prop: str):
         value = getattr(self.__host_address, prop)

--- a/controllers/network/network_controller/sensor/presence.py
+++ b/controllers/network/network_controller/sensor/presence.py
@@ -6,7 +6,7 @@ from powerpi_common.mqtt import MQTTClient
 from powerpi_common.sensor import Sensor
 from powerpi_common.device.mixin import PollableMixin
 
-from network_controller.services.arp import ARPFactory, HostAddress
+from network_controller.services.arp import ARPFactory, ARPReader, HostAddress
 
 
 class PresenceSensor(Sensor, PollableMixin):
@@ -30,7 +30,8 @@ class PresenceSensor(Sensor, PollableMixin):
         PollableMixin.__init__(self, config, **kwargs)
 
         self._logger = logger
-        self.__reader = arp_factory.get_arp_service()
+        self.__factory = arp_factory
+        self.__reader: ARPReader | None = None
 
         self.__host_address = HostAddress(mac, ip, hostname)
 
@@ -51,6 +52,13 @@ class PresenceSensor(Sensor, PollableMixin):
 
     async def poll(self):
         pass
+
+    @property
+    def __arp_service(self):
+        if self.__reader is None:
+            self.__reader = self.__factory.get_arp_service()
+
+        return self.__arp
 
     def __get_real_or_cached(self, prop: str):
         value = getattr(self.__host_address, prop)

--- a/controllers/network/network_controller/sensor/presence.py
+++ b/controllers/network/network_controller/sensor/presence.py
@@ -83,7 +83,7 @@ class PresenceSensor(Sensor, PollableMixin):
             # update the cache of MAC, IP and hostname
             self.__cache = entry
 
-            self.__set_present()
+            self.__set_new_state(PresenceStatus.PRESENT)
 
     async def __check_grace_period(self):
         # first has the period already expired?
@@ -108,7 +108,7 @@ class PresenceSensor(Sensor, PollableMixin):
             # it is actually present
             self.log_debug('Device present after ping')
 
-            self.__set_present()
+            self.__set_new_state(PresenceStatus.PRESENT)
 
     def __broadcast(self, state: PresenceStatus):
         topic = f'presence/{self.entity}/status'
@@ -118,17 +118,14 @@ class PresenceSensor(Sensor, PollableMixin):
         self._producer(topic, message)
 
     def __set_new_state(self, state: PresenceStatus):
+        # reset the grace period timer as the device state is confirmed
+        # if it disappears again we want to allow the grace period again
+        self.__grace_period.timer = 0
+
         if self.__state != state:
             self.__state = state
 
             self.__broadcast(state)
-
-    def __set_present(self):
-        # reset the grace period timer as the device is present
-        # if it disappears again we want to allow the grace period again
-        self.__grace_period.timer = 0
-
-        self.__set_new_state(PresenceStatus.PRESENT)
 
     @property
     def __arp_provider(self):

--- a/controllers/network/network_controller/services/__init__.py
+++ b/controllers/network/network_controller/services/__init__.py
@@ -1,0 +1,1 @@
+from .container import ServicesContainer

--- a/controllers/network/network_controller/services/arp/__init__.py
+++ b/controllers/network/network_controller/services/arp/__init__.py
@@ -1,3 +1,3 @@
-from .arp import ARPReader, HostAddress
-from .factory import ARPFactory
-from .local_arp_listener import LocalARPListener
+from .provider import ARPProvider, HostAddress
+from .factory import ARPProviderFactory
+from .packet import PacketARPProvider

--- a/controllers/network/network_controller/services/arp/__init__.py
+++ b/controllers/network/network_controller/services/arp/__init__.py
@@ -1,3 +1,3 @@
-from .arp import HostAddress
+from .arp import ARPReader, HostAddress
 from .factory import ARPFactory
 from .local_arp_listener import LocalARPListener

--- a/controllers/network/network_controller/services/arp/__init__.py
+++ b/controllers/network/network_controller/services/arp/__init__.py
@@ -1,0 +1,3 @@
+from .arp import HostAddress
+from .factory import ARPFactory
+from .local_arp_listener import LocalARPListener

--- a/controllers/network/network_controller/services/arp/arp.py
+++ b/controllers/network/network_controller/services/arp/arp.py
@@ -1,0 +1,49 @@
+from abc import abstractmethod
+from dataclasses import dataclass
+
+from powerpi_common.logger import LogMixin
+
+
+@dataclass
+class HostAddress:
+    mac_address: str | None = None
+    ip_address: str | None = None
+    hostname: str | None = None
+
+
+class ARPReader(LogMixin):
+    '''
+    Abstract class defining the operations an ARP table reading service will provide.
+    '''
+
+    @property
+    @abstractmethod
+    def table(self) -> list[HostAddress]:
+        '''
+        Return the ARP table.
+        '''
+        raise NotImplementedError
+
+    async def start(self):
+        '''
+        If the listener needs to do anything to start processing implement this method.
+        '''
+
+    async def stop(self):
+        '''
+        If the listener needs to do anything to stop processing implement this method.
+        '''
+
+    def find(self, address: HostAddress) -> HostAddress | None:
+        props = ['mac_address', 'ip_address', 'hostname']
+
+        for prop in props:
+            address_value = getattr(address, prop)
+            if address_value is None:
+                continue
+
+            for entry in self.table:
+                if address_value == getattr(entry, prop):
+                    return entry
+
+        return None

--- a/controllers/network/network_controller/services/arp/factory.py
+++ b/controllers/network/network_controller/services/arp/factory.py
@@ -1,7 +1,10 @@
+from powerpi_common.logger import Logger, LogMixin
+from powerpi_common.device import DeviceManager
+
 from .arp import ARPReader
 
 
-class ARPFactory:
+class ARPFactory(LogMixin):
     '''
     Factory to return the ARPReader that is available.
     Currently only supports a local ARP listener, which won't with VLANs.
@@ -9,13 +12,29 @@ class ARPFactory:
 
     def __init__(
         self,
+        logger: Logger,
+        device_manager: DeviceManager,
         service_provider
     ):
+        self._logger = logger
+        self.__device_manager = device_manager
         self.__service_provider = service_provider
 
-    def get_arp_service(self) -> ARPReader:
+    def get_arp_service(self) -> ARPReader | None:
+        # first, do we have any presence services?
+        from network_controller.sensor.presence import PresenceSensor
+        presence = [
+            sensor for sensor in self.__device_manager.sensors.values()
+            if isinstance(sensor, PresenceSensor)
+        ]
+
+        if len(presence) == 0:
+            self.log_info(
+                'No ARP Reader when no presence sensors are detected'
+            )
+            return None
+
         # for now there is only one service
-        # we should return None if there are no presence sensors
         service: ARPReader = self.__service_provider.local_arp_listener()
 
         return service

--- a/controllers/network/network_controller/services/arp/factory.py
+++ b/controllers/network/network_controller/services/arp/factory.py
@@ -1,13 +1,13 @@
 from powerpi_common.logger import Logger, LogMixin
 from powerpi_common.device import DeviceManager
 
-from .arp import ARPReader
+from .provider import ARPProvider
 
 
-class ARPFactory(LogMixin):
+class ARPProviderFactory(LogMixin):
     '''
-    Factory to return the ARPReader that is available.
-    Currently only supports a local ARP listener, which won't with VLANs.
+    Factory to return the ARPProvider that is available.
+    Currently only supports a packet listener, which won't work with VLANs.
     '''
 
     def __init__(
@@ -20,7 +20,7 @@ class ARPFactory(LogMixin):
         self.__device_manager = device_manager
         self.__service_provider = service_provider
 
-    def get_arp_service(self) -> ARPReader | None:
+    def get_arp_service(self) -> ARPProvider | None:
         # first, do we have any presence services?
         from network_controller.sensor.presence import PresenceSensor
         presence = [
@@ -35,6 +35,6 @@ class ARPFactory(LogMixin):
             return None
 
         # for now there is only one service
-        service: ARPReader = self.__service_provider.local_arp_listener()
+        service: ARPProvider = self.__service_provider.packet_arp_provider()
 
         return service

--- a/controllers/network/network_controller/services/arp/factory.py
+++ b/controllers/network/network_controller/services/arp/factory.py
@@ -1,0 +1,21 @@
+from .arp import ARPReader
+
+
+class ARPFactory:
+    '''
+    Factory to return the ARPReader that is available.
+    Currently only supports a local ARP listener, which won't with VLANs.
+    '''
+
+    def __init__(
+        self,
+        service_provider
+    ):
+        self.__service_provider = service_provider
+
+    def get_arp_service(self) -> ARPReader:
+        # for now there is only one service
+        # we should return None if there are no presence sensors
+        service: ARPReader = self.__service_provider.local_arp_listener()
+
+        return service

--- a/controllers/network/network_controller/services/arp/local_arp_listener.py
+++ b/controllers/network/network_controller/services/arp/local_arp_listener.py
@@ -1,15 +1,16 @@
 from asyncio import ensure_future, sleep, Future
 from dataclasses import dataclass
-from dpkt import ethernet
-from netifaces import interfaces, ifaddresses, AF_INET
-from pcap import pcap
 from socket import inet_ntoa
 from time import time
 from threading import RLock
 
+from dpkt import ethernet
+from netifaces import interfaces, ifaddresses, AF_INET
+from pcap import pcap
 from powerpi_common.logger import Logger
 
-from .arp import ARPReader, HostAddress
+from network_controller.config import NetworkConfig
+from network_controller.services.arp import ARPReader, HostAddress
 
 
 @dataclass
@@ -25,8 +26,10 @@ class LocalARPListener(ARPReader):
 
     def __init__(
         self,
+        config: NetworkConfig,
         logger: Logger
     ):
+        self.__config = config
         self._logger = logger
 
         self.__running = False
@@ -50,7 +53,10 @@ class LocalARPListener(ARPReader):
             return self.__table
 
     async def __sniff(self):
-        self.log_info('Sniffing ARP traffic')
+        self.log_info(
+            'Sniffing ARP traffic, cache expiry after %ds',
+            self.__config.arp_cache_expiry
+        )
 
         try:
             interface = self.__get_interface()
@@ -67,8 +73,8 @@ class LocalARPListener(ARPReader):
 
                 sniffer.dispatch(-1, self.__handle_packet)
 
-                # every 120s we prune anything too old
-                if counter >= 120:
+                # prune anything that hasn't been seen in a while
+                if counter >= self.__config.arp_cache_expiry:
                     counter = 0
 
                     self.__prune()
@@ -111,7 +117,7 @@ class LocalARPListener(ARPReader):
 
     def __prune(self):
         now = int(time())
-        expiry = now - 120
+        expiry = now - self.__config.arp_cache_expiry
 
         with self.__lock:
             count = len(self.__table)

--- a/controllers/network/network_controller/services/arp/local_arp_listener.py
+++ b/controllers/network/network_controller/services/arp/local_arp_listener.py
@@ -79,7 +79,7 @@ class LocalARPListener(ARPReader):
 
     def __get_interface(self):
         for iface in interfaces():
-            if iface.startswith(('lo', 'docker', 'br-', 'veth', 'virbr', 'tun', 'tap')):
+            if iface.startswith(('lo', 'docker', 'br-', 'veth', 'virbr', 'vxlan', 'tun', 'tap')):
                 continue
 
             if AF_INET in ifaddresses(iface):

--- a/controllers/network/network_controller/services/arp/local_arp_listener.py
+++ b/controllers/network/network_controller/services/arp/local_arp_listener.py
@@ -123,7 +123,7 @@ class LocalARPListener(ARPReader):
 
             host_address.hostname = result[0]
         except herror:
-            pass
+            host_address.hostname = None
 
     def __prune(self):
         now = int(time())

--- a/controllers/network/network_controller/services/arp/local_arp_listener.py
+++ b/controllers/network/network_controller/services/arp/local_arp_listener.py
@@ -1,13 +1,20 @@
 from asyncio import ensure_future, sleep, Future
+from dataclasses import dataclass
 from dpkt import ethernet
-from netifaces import gateways, interfaces, ifaddresses, AF_INET
+from netifaces import interfaces, ifaddresses, AF_INET
 from pcap import pcap
 from socket import inet_ntoa
+from time import time
 from threading import RLock
 
 from powerpi_common.logger import Logger
 
 from .arp import ARPReader, HostAddress
+
+
+@dataclass
+class ARPEntry(HostAddress):
+    timestamp: int = 0
 
 
 class LocalARPListener(ARPReader):
@@ -25,7 +32,7 @@ class LocalARPListener(ARPReader):
         self.__running = False
         self.__future: Future | None
 
-        self.__table: list[HostAddress] = []
+        self.__table: list[ARPEntry] = []
         self.__lock = RLock()
 
     async def start(self):
@@ -53,14 +60,24 @@ class LocalARPListener(ARPReader):
             sniffer.setfilter('arp')
             sniffer.setnonblock()
 
+            counter = 0
+
             while self.__running:
+                counter += 1
+
                 sniffer.dispatch(-1, self.__handle_packet)
+
+                # every 120s we prune anything too old
+                if counter >= 120:
+                    counter = 0
+
+                    self.__prune()
 
                 await sleep(1)
         except Exception as ex:
             self.log_error(ex)
 
-    def __handle_packet(self, _, raw):
+    def __handle_packet(self, timestamp: int, raw):
         eth = ethernet.Ethernet(raw)
         arp = eth.data
         src_ip = inet_ntoa(arp.spa)
@@ -72,7 +89,12 @@ class LocalARPListener(ARPReader):
         with self.__lock:
             entry = self.find(host_address)
             if entry is None:
-                self.__table.append(host_address)
+                self.__table.append(ARPEntry(
+                    host_address.mac_address,
+                    host_address.ip_address,
+                    host_address.hostname,
+                    timestamp
+                ))
             else:
                 entry.mac_address = src_mac
                 entry.ip_address = src_ip
@@ -86,3 +108,22 @@ class LocalARPListener(ARPReader):
                 return iface
 
         raise RuntimeError('No suitable network interface found')
+
+    def __prune(self):
+        now = int(time())
+        expiry = now - 120
+
+        with self.__lock:
+            count = len(self.__table)
+
+            self.__table = [
+                entry for entry in self.__table
+                if entry.timestamp > expiry
+            ]
+
+            new_count = len(self.__table)
+            if new_count != count:
+                self.log_debug(
+                    'Removed %d expired ARP records',
+                    count - new_count
+                )

--- a/controllers/network/network_controller/services/arp/local_arp_listener.py
+++ b/controllers/network/network_controller/services/arp/local_arp_listener.py
@@ -1,6 +1,6 @@
 from asyncio import ensure_future, sleep, Future
 from dataclasses import dataclass
-from socket import inet_ntoa
+from socket import inet_ntoa, gethostbyaddr, herror
 from time import time
 from threading import RLock
 
@@ -90,6 +90,7 @@ class LocalARPListener(ARPReader):
         src_mac = ':'.join('%02x' % bit for bit in arp.sha)
 
         host_address = HostAddress(src_mac, src_ip)
+        self.__set_hostname(host_address)
         self.log_debug('Received ARP packet %s', host_address)
 
         with self.__lock:
@@ -104,6 +105,7 @@ class LocalARPListener(ARPReader):
             else:
                 entry.mac_address = src_mac
                 entry.ip_address = src_ip
+                entry.hostname = host_address.hostname
 
     def __get_interface(self):
         for iface in interfaces():
@@ -114,6 +116,14 @@ class LocalARPListener(ARPReader):
                 return iface
 
         raise RuntimeError('No suitable network interface found')
+
+    def __set_hostname(self, host_address: HostAddress):
+        try:
+            result = gethostbyaddr(host_address.ip_address)
+
+            host_address.hostname = result[0]
+        except herror:
+            pass
 
     def __prune(self):
         now = int(time())

--- a/controllers/network/network_controller/services/arp/local_arp_listener.py
+++ b/controllers/network/network_controller/services/arp/local_arp_listener.py
@@ -1,0 +1,88 @@
+from asyncio import ensure_future, sleep, Future
+from dpkt import ethernet
+from netifaces import gateways, interfaces, ifaddresses, AF_INET
+from pcap import pcap
+from socket import inet_ntoa
+from threading import RLock
+
+from powerpi_common.logger import Logger
+
+from .arp import ARPReader, HostAddress
+
+
+class LocalARPListener(ARPReader):
+    '''
+    Local ARP listener which listens for ARP events on the local network.
+    Will only work if the devices are on the same VLAN as the cluster nodes running the service.
+    '''
+
+    def __init__(
+        self,
+        logger: Logger
+    ):
+        self._logger = logger
+
+        self.__running = False
+        self.__future: Future | None
+
+        self.__table: list[HostAddress] = []
+        self.__lock = RLock()
+
+    async def start(self):
+        self.__running = True
+
+        self.__future = ensure_future(self.__sniff())
+
+    async def stop(self):
+        self.__running = False
+        await self.__future
+
+    @property
+    def table(self):
+        with self.__lock:
+            return self.__table
+
+    async def __sniff(self):
+        self.log_info('Sniffing ARP traffic')
+
+        try:
+            interface = self.__get_interface()
+            self.log_info('Using interface %s', interface)
+
+            sniffer = pcap(interface, timeout_ms=1000)
+            sniffer.setfilter('arp')
+            sniffer.setnonblock()
+
+            while self.__running:
+                sniffer.dispatch(-1, self.__handle_packet)
+
+                await sleep(1)
+        except Exception as ex:
+            self.log_error(ex)
+
+    def __handle_packet(self, _, raw):
+        eth = ethernet.Ethernet(raw)
+        arp = eth.data
+        src_ip = inet_ntoa(arp.spa)
+        src_mac = ':'.join('%02x' % bit for bit in arp.sha)
+
+        host_address = HostAddress(src_mac, src_ip)
+        self.log_debug('Received ARP packet %s', host_address)
+
+        with self.__lock:
+            entry = self.find(host_address)
+            if entry is None:
+                self.__table.append(host_address)
+            else:
+                entry.mac_address = src_mac
+                entry.ip_address = src_ip
+
+    def __get_interface(self):
+        for iface in interfaces():
+            if iface.startswith(('lo', 'docker', 'br-', 'veth', 'virbr', 'tun', 'tap')):
+                continue
+
+            if AF_INET in ifaddresses(iface):
+                return iface
+
+        raise RuntimeError('No suitable network interface found')

--- a/controllers/network/network_controller/services/arp/packet.py
+++ b/controllers/network/network_controller/services/arp/packet.py
@@ -10,7 +10,7 @@ from pcap import pcap
 from powerpi_common.logger import Logger
 
 from network_controller.config import NetworkConfig
-from network_controller.services.arp import ARPReader, HostAddress
+from network_controller.services.arp import ARPProvider, HostAddress
 
 
 @dataclass
@@ -18,9 +18,9 @@ class ARPEntry(HostAddress):
     timestamp: int = 0
 
 
-class LocalARPListener(ARPReader):
+class PacketARPProvider(ARPProvider):
     '''
-    Local ARP listener which listens for ARP events on the local network.
+    Packet ARP provider which listens for ARP events on the local network.
     Will only work if the devices are on the same VLAN as the cluster nodes running the service.
     '''
 

--- a/controllers/network/network_controller/services/arp/provider.py
+++ b/controllers/network/network_controller/services/arp/provider.py
@@ -11,9 +11,9 @@ class HostAddress:
     hostname: str | None = None
 
 
-class ARPReader(LogMixin):
+class ARPProvider(LogMixin):
     '''
-    Abstract class defining the operations an ARP table reading service will provide.
+    Abstract class defining the operations an ARP table providing service will need.
     '''
 
     @property

--- a/controllers/network/network_controller/services/container.py
+++ b/controllers/network/network_controller/services/container.py
@@ -11,9 +11,12 @@ class ServicesContainer(containers.DeclarativeContainer):
     )
 
     common = providers.DependenciesContainer()
+    device = providers.DependenciesContainer()
 
     arp_factory = providers.Singleton(
         ARPFactory,
+        logger=common.logger,
+        device_manager=device.device_manager,
         service_provider=service_provider
     )
 

--- a/controllers/network/network_controller/services/container.py
+++ b/controllers/network/network_controller/services/container.py
@@ -1,0 +1,23 @@
+from dependency_injector import containers, providers
+
+from .arp import ARPFactory, LocalARPListener
+
+
+class ServicesContainer(containers.DeclarativeContainer):
+    __self__ = providers.Self()
+
+    service_provider = providers.Singleton(
+        __self__
+    )
+
+    common = providers.DependenciesContainer()
+
+    arp_factory = providers.Singleton(
+        ARPFactory,
+        service_provider=service_provider
+    )
+
+    local_arp_listener = providers.Singleton(
+        LocalARPListener,
+        logger=common.logger
+    )

--- a/controllers/network/network_controller/services/container.py
+++ b/controllers/network/network_controller/services/container.py
@@ -1,6 +1,6 @@
 from dependency_injector import containers, providers
 
-from .arp import ARPFactory, LocalARPListener
+from .arp import ARPProviderFactory, PacketARPProvider
 
 
 class ServicesContainer(containers.DeclarativeContainer):
@@ -14,15 +14,15 @@ class ServicesContainer(containers.DeclarativeContainer):
     device = providers.DependenciesContainer()
     config = providers.Dependency()
 
-    arp_factory = providers.Singleton(
-        ARPFactory,
+    arp_provider_factory = providers.Singleton(
+        ARPProviderFactory,
         logger=common.logger,
         device_manager=device.device_manager,
         service_provider=service_provider
     )
 
-    local_arp_listener = providers.Singleton(
-        LocalARPListener,
+    packet_arp_provider = providers.Singleton(
+        PacketARPProvider,
         config=config,
         logger=common.logger
     )

--- a/controllers/network/network_controller/services/container.py
+++ b/controllers/network/network_controller/services/container.py
@@ -12,6 +12,7 @@ class ServicesContainer(containers.DeclarativeContainer):
 
     common = providers.DependenciesContainer()
     device = providers.DependenciesContainer()
+    config = providers.Dependency()
 
     arp_factory = providers.Singleton(
         ARPFactory,
@@ -22,5 +23,6 @@ class ServicesContainer(containers.DeclarativeContainer):
 
     local_arp_listener = providers.Singleton(
         LocalARPListener,
+        config=config,
         logger=common.logger
     )

--- a/controllers/network/network_controller/util/__init__.py
+++ b/controllers/network/network_controller/util/__init__.py
@@ -1,0 +1,1 @@
+from .ping import ping

--- a/controllers/network/network_controller/util/ping.py
+++ b/controllers/network/network_controller/util/ping.py
@@ -1,0 +1,15 @@
+from os import getuid
+
+from icmplib import async_ping
+
+
+async def ping(network_address: str, count=1):
+    is_root = getuid() == 0
+
+    return await async_ping(
+        network_address,
+        count=count,
+        interval=0.2,
+        timeout=2,
+        privileged=is_root
+    )

--- a/controllers/network/poetry.lock
+++ b/controllers/network/poetry.lock
@@ -217,6 +217,18 @@ pydantic2 = ["pydantic-settings"]
 yaml = ["pyyaml"]
 
 [[package]]
+name = "dpkt"
+version = "1.9.8"
+description = "fast, simple packet creation / parsing, with definitions for the basic TCP/IP protocols"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "dpkt-1.9.8-py3-none-any.whl", hash = "sha256:4da4d111d7bf67575b571f5c678c71bddd2d8a01a3d57d489faf0a92c748fbfd"},
+    {file = "dpkt-1.9.8.tar.gz", hash = "sha256:43f8686e455da5052835fd1eda2689d51de3670aac9799b1b00cfd203927ee45"},
+]
+
+[[package]]
 name = "gmqtt"
 version = "0.7.0"
 description = "Client for MQTT protocol"
@@ -254,6 +266,37 @@ files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
 ]
+
+[[package]]
+name = "netifaces2"
+version = "0.0.22"
+description = "Portable network interface information"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "netifaces2-0.0.22-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b7bd4e11cb72d3c182b0b532a5c39d3945a35258cdade2ebaac55ab8ff3ba0e6"},
+    {file = "netifaces2-0.0.22-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:81bf88e39ced999d66fff6db5c0dd70c532af18558b3e37da7cda70b6a52f842"},
+    {file = "netifaces2-0.0.22-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e9a880fd3fe76bc5fb040ccafee40f752300ef6349fd7c4c6e66151763b224f8"},
+    {file = "netifaces2-0.0.22-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb4ac86acfe2f23522c2b5d1bed097e810dbbe4a5bd829528e5db52a83290e52"},
+    {file = "netifaces2-0.0.22-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:4b7073aabee570466373e312b7f92a81e669f2462051eaefafb8a3d9ba078a35"},
+    {file = "netifaces2-0.0.22-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f6fa1ca50ede5d148a9c378ab08e093418666b58353a2fe31b02d772f568231"},
+    {file = "netifaces2-0.0.22-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e1393ddecc35fcbb5ca89c90783ef44c1cae3f93b60bbdcb2e2ebd20783b9e06"},
+    {file = "netifaces2-0.0.22-cp37-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:150804d34f1a97d07ec7032573561267e1753c30670df5e32021a2cf4e3f76b5"},
+    {file = "netifaces2-0.0.22-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:47d15b7235804e4b506298d757856c97e9d969be9cf91642581bf314f98cdefa"},
+    {file = "netifaces2-0.0.22-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c0f59974328a3481eb0b3264a1cb479f2058cc8f09a3a0097a24d306fd59ec5e"},
+    {file = "netifaces2-0.0.22-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:69689cf211d17968e020582ddf3b023b0b956c003571e088a86ad21e27b678d9"},
+    {file = "netifaces2-0.0.22-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:043ddcd4b09f9b8e86c2bd54214a90904c2fec8869d0cfd295c671c2f4cb27b3"},
+    {file = "netifaces2-0.0.22-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:e24c4089c743ad61c59e988d2c2de9ba2c91f1dccaecd57cf1d03c4414946a8f"},
+    {file = "netifaces2-0.0.22-cp37-abi3-musllinux_1_1_armv7l.whl", hash = "sha256:03151c24171e6da9079e5abcd303f3e0d8ac275a8fe4e178f82fdf1590f989e4"},
+    {file = "netifaces2-0.0.22-cp37-abi3-musllinux_1_1_i686.whl", hash = "sha256:db607a05fa9e7b4791649b83bdc260dcc2f1082e502e6c9e22eb3853a5ff1485"},
+    {file = "netifaces2-0.0.22-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:a203a34be5976a747777add600d3d9942bd87b8252bbb7d250273ec4f23744f4"},
+    {file = "netifaces2-0.0.22-cp37-abi3-win_amd64.whl", hash = "sha256:c31ef56334aa73d0cb81d49e7a9bc3cdd8822e566594038b76c27eaf0334ea6d"},
+    {file = "netifaces2-0.0.22.tar.gz", hash = "sha256:c872a54e1a0e2bf078593b4460013996de804e40cab1b0ebc377b0e74b52a244"},
+]
+
+[package.extras]
+dev = ["black (>=23.1.0)", "mypy (>=0.991)", "pytest (>=7.1.1)", "ruff (>=0.0.240)"]
 
 [[package]]
 name = "packaging"
@@ -322,6 +365,17 @@ pytest-mock = ">=3.14.0,<3.15.0"
 [package.source]
 type = "directory"
 url = "../../common/pytest"
+
+[[package]]
+name = "pypcap"
+version = "1.3.0"
+description = "pypcap -- Python interface to pcap a packet capture library"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "pypcap-1.3.0.tar.gz", hash = "sha256:669976786b2b4c43869c0ecf6228cbbb70336d1d8eb8d4fe2a3a81df395f45b5"},
+]
 
 [[package]]
 name = "pytest"
@@ -458,4 +512,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "928158e604c4b9ba82d9251bc4c7c586260e4edbca0f699c2f999b3a2fb73255"
+content-hash = "6226fdd6520b23565254cdfa748213a38ac9f250ed2cc25550c7593a5644d918"

--- a/controllers/network/poetry.lock
+++ b/controllers/network/poetry.lock
@@ -372,7 +372,7 @@ version = "1.3.0"
 description = "pypcap -- Python interface to pcap a packet capture library"
 optional = false
 python-versions = "*"
-groups = ["main"]
+groups = ["runtime"]
 files = [
     {file = "pypcap-1.3.0.tar.gz", hash = "sha256:669976786b2b4c43869c0ecf6228cbbb70336d1d8eb8d4fe2a3a81df395f45b5"},
 ]
@@ -512,4 +512,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "6226fdd6520b23565254cdfa748213a38ac9f250ed2cc25550c7593a5644d918"
+content-hash = "eef679ce9c4d92080a61012df74688a392af596e93dfcda1b3d46d7415658f37"

--- a/controllers/network/pyproject.toml
+++ b/controllers/network/pyproject.toml
@@ -14,12 +14,14 @@ dependencies = [
     "dpkt (~=1.9.8)",
     "icmplib (~=3.0.4)",
     "netifaces2 (~=0.0.22)",
-    "pypcap (~=1.3.0)",
     "wakeonlan (~=3.1.0)"
 ]
 
 [tool.poetry.group.powerpi.dependencies]
 powerpi-common = {path = "../../common/python", develop = true}
+
+[tool.poetry.group.runtime.dependencies]
+pypcap = "~=1.3.0"
 
 [tool.poetry.group.test.dependencies]
 powerpi-common-test = {path = "../../common/pytest", develop = true}

--- a/controllers/network/pyproject.toml
+++ b/controllers/network/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "network_controller"
-version = "0.2.6-rc.5"
+version = "0.3.0-rc.1"
 description = "PowerPi Network Controller"
 license = "GPL-3.0-only"
 authors = [

--- a/controllers/network/pyproject.toml
+++ b/controllers/network/pyproject.toml
@@ -11,7 +11,10 @@ readme = "README.md"
 
 requires-python = ">=3.11,<4.0"
 dependencies = [
+    "dpkt (~=1.9.8)",
     "icmplib (~=3.0.4)",
+    "netifaces2 (~=0.0.22)",
+    "pypcap (~=1.3.0)",
     "wakeonlan (~=3.1.0)"
 ]
 

--- a/controllers/network/tests/conftest.py
+++ b/controllers/network/tests/conftest.py
@@ -1,6 +1,11 @@
 # pylint: disable=unused-import
 
 import pytest
-from powerpi_common_test.fixture import (powerpi_config, powerpi_logger,
-                                         powerpi_mqtt_client,
-                                         powerpi_mqtt_producer)
+from powerpi_common_test.fixture import (
+    powerpi_config,
+    powerpi_device_manager,
+    powerpi_logger,
+    powerpi_mqtt_client,
+    powerpi_mqtt_producer,
+    powerpi_service_provider,
+)

--- a/controllers/network/tests/conftest.py
+++ b/controllers/network/tests/conftest.py
@@ -1,5 +1,11 @@
 # pylint: disable=unused-import
 
+import sys
+from unittest.mock import MagicMock
+
+# pcap requires libpcap and a C compiler; mock it out since tests never use the real module
+sys.modules['pcap'] = MagicMock()
+
 import pytest
 from powerpi_common_test.fixture import (
     powerpi_config,

--- a/controllers/network/tests/device/test_computer.py
+++ b/controllers/network/tests/device/test_computer.py
@@ -23,7 +23,7 @@ class TestComputer(DeviceTestBase, PollableMixinTestBase):
         type(host).is_alive = PropertyMock(return_value=True)
 
         mocker.patch(
-            'network_controller.device.computer.async_ping',
+            'network_controller.device.computer.ping',
             return_value=host
         )
 
@@ -47,7 +47,7 @@ class TestComputer(DeviceTestBase, PollableMixinTestBase):
         type(host).is_alive = PropertyMock(return_value=is_alive)
 
         mocker.patch(
-            'network_controller.device.computer.async_ping',
+            'network_controller.device.computer.ping',
             return_value=host
         )
 
@@ -74,7 +74,7 @@ class TestComputer(DeviceTestBase, PollableMixinTestBase):
         type(host).is_alive = PropertyMock(side_effect=is_alive)
 
         mocker.patch(
-            'network_controller.device.computer.async_ping',
+            'network_controller.device.computer.ping',
             return_value=host
         )
 
@@ -114,7 +114,7 @@ class TestComputer(DeviceTestBase, PollableMixinTestBase):
         type(host).is_alive = PropertyMock(return_value=True)
 
         mocker.patch(
-            'network_controller.device.computer.async_ping',
+            'network_controller.device.computer.ping',
             return_value=host
         )
 

--- a/controllers/network/tests/sensor/test_presence.py
+++ b/controllers/network/tests/sensor/test_presence.py
@@ -184,6 +184,52 @@ class TestPresenceSensor(SensorTestBase, PollableMixinTestBase):
             {'state': PresenceStatus.PRESENT},
         )
 
+    @pytest.mark.asyncio
+    async def test_poll_absent_recovers_via_ping(
+        self,
+        subject: PresenceSensor,
+        arp_reader: MagicMock,
+        mocker: MockerFixture,
+        powerpi_mqtt_producer: MagicMock,
+    ):
+        arp_reader.find.return_value = None
+
+        host = mocker.Mock()
+        type(host).is_alive = PropertyMock(return_value=False)
+        mocker.patch(
+            'network_controller.sensor.presence.ping',
+            return_value=host,
+        )
+        # absent_delay=10, each poll gap (5s) is less than the delay
+        # 1000: timer starts, ping dead
+        # 1005: within grace period, ping dead
+        # 1011: grace period expired, marked absent
+        # 1016: timer should have reset, new grace period starts, ping alive
+        mocker.patch(
+            'network_controller.sensor.presence.time',
+            side_effect=[1000, 1005, 1011, 1016],
+        )
+
+        await subject.poll()
+        await subject.poll()
+        await subject.poll()
+
+        powerpi_mqtt_producer.assert_called_once_with(
+            'presence/test_presence/status',
+            {'state': PresenceStatus.ABSENT},
+        )
+
+        # device now responds to ping
+        type(host).is_alive = PropertyMock(return_value=True)
+
+        await subject.poll()
+
+        assert powerpi_mqtt_producer.call_count == 2
+        powerpi_mqtt_producer.assert_called_with(
+            'presence/test_presence/status',
+            {'state': PresenceStatus.PRESENT},
+        )
+
     @pytest.fixture
     def arp_reader(self, mocker: MockerFixture):
         reader = mocker.MagicMock()

--- a/controllers/network/tests/sensor/test_presence.py
+++ b/controllers/network/tests/sensor/test_presence.py
@@ -110,12 +110,23 @@ class TestPresenceSensor(SensorTestBase, PollableMixinTestBase):
             'network_controller.sensor.presence.ping',
             return_value=host,
         )
+        # absent_delay=10, each poll gap (5s) is less than the delay
+        # 1000: timer starts
+        # 1005: within grace period, timer must not reset
+        # 1011: 11s since timer started, grace period expired
+        # 1016: still absent, no duplicate broadcast
         mocker.patch(
             'network_controller.sensor.presence.time',
-            side_effect=[1000, 1011, 1022],
+            side_effect=[1000, 1005, 1011, 1016],
         )
 
+        # polls within the grace period should not trigger absent
         await subject.poll()
+        await subject.poll()
+
+        powerpi_mqtt_producer.assert_not_called()
+
+        # poll after the grace period has expired
         await subject.poll()
 
         powerpi_mqtt_producer.assert_called_once_with(
@@ -144,11 +155,16 @@ class TestPresenceSensor(SensorTestBase, PollableMixinTestBase):
             'network_controller.sensor.presence.ping',
             return_value=host,
         )
+        # absent_delay=10, each poll gap (5s) is less than the delay
+        # 1000: timer starts
+        # 1005: within grace period, timer must not reset
+        # 1011: 11s since timer started, grace period expired
         mocker.patch(
             'network_controller.sensor.presence.time',
-            side_effect=[1000, 1011],
+            side_effect=[1000, 1005, 1011],
         )
 
+        await subject.poll()
         await subject.poll()
         await subject.poll()
 

--- a/controllers/network/tests/sensor/test_presence.py
+++ b/controllers/network/tests/sensor/test_presence.py
@@ -80,7 +80,7 @@ class TestPresenceSensor(SensorTestBase, PollableMixinTestBase):
         host = mocker.Mock()
         type(host).is_alive = PropertyMock(return_value=is_alive)
         mocker.patch(
-            'network_controller.sensor.presence.async_ping',
+            'network_controller.sensor.presence.ping',
             return_value=host,
         )
 
@@ -107,7 +107,7 @@ class TestPresenceSensor(SensorTestBase, PollableMixinTestBase):
         host = mocker.Mock()
         type(host).is_alive = PropertyMock(return_value=False)
         mocker.patch(
-            'network_controller.sensor.presence.async_ping',
+            'network_controller.sensor.presence.ping',
             return_value=host,
         )
         mocker.patch(
@@ -141,7 +141,7 @@ class TestPresenceSensor(SensorTestBase, PollableMixinTestBase):
         host = mocker.Mock()
         type(host).is_alive = PropertyMock(return_value=False)
         mocker.patch(
-            'network_controller.sensor.presence.async_ping',
+            'network_controller.sensor.presence.ping',
             return_value=host,
         )
         mocker.patch(

--- a/controllers/network/tests/sensor/test_presence.py
+++ b/controllers/network/tests/sensor/test_presence.py
@@ -1,0 +1,216 @@
+from unittest.mock import MagicMock, PropertyMock
+
+import pytest
+from powerpi_common_test.device.mixin import PollableMixinTestBase
+from powerpi_common_test.sensor import SensorTestBase
+from pytest_mock import MockerFixture
+
+from network_controller.sensor.presence import PresenceSensor, PresenceStatus
+from network_controller.services.arp import HostAddress
+
+
+class TestPresenceSensor(SensorTestBase, PollableMixinTestBase):
+
+    @pytest.mark.parametrize('prop,expected', [
+        ('mac_address', '00:11:22:33:44:55'),
+        ('ip_address', '192.168.1.100'),
+        ('hostname', 'mydevice.local'),
+    ])
+    def test_properties(self, subject: PresenceSensor, prop: str, expected: str):
+        assert getattr(subject, prop) == expected
+
+    @pytest.mark.asyncio
+    async def test_ip_address_from_cache(
+        self,
+        subject_no_ip: PresenceSensor,
+        arp_reader: MagicMock,
+    ):
+        assert subject_no_ip.ip_address is None
+
+        arp_reader.find.return_value = HostAddress(
+            mac_address='00:11:22:33:44:55',
+            ip_address='192.168.1.100',
+            hostname='mydevice.local',
+        )
+
+        await subject_no_ip.poll()
+
+        assert subject_no_ip.ip_address == '192.168.1.100'
+
+    @pytest.mark.asyncio
+    async def test_poll_found_in_arp(
+        self,
+        subject: PresenceSensor,
+        arp_reader: MagicMock,
+        powerpi_mqtt_producer: MagicMock,
+    ):
+        arp_reader.find.return_value = HostAddress(
+            mac_address='00:11:22:33:44:55',
+            ip_address='192.168.1.100',
+        )
+
+        await subject.poll()
+
+        powerpi_mqtt_producer.assert_called_once_with(
+            'presence/test_presence/status',
+            {'state': PresenceStatus.PRESENT},
+        )
+
+        # if we call it again it won't publish again
+        await subject.poll()
+
+        powerpi_mqtt_producer.assert_called_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('is_alive,expected_state', [
+        (True, PresenceStatus.PRESENT),
+        (False, None),
+    ])
+    async def test_poll_not_in_arp_ping(
+        self,
+        subject: PresenceSensor,
+        arp_reader: MagicMock,
+        mocker: MockerFixture,
+        powerpi_mqtt_producer: MagicMock,
+        is_alive: bool,
+        expected_state: PresenceStatus | None,
+    ):
+        arp_reader.find.return_value = None
+
+        host = mocker.Mock()
+        type(host).is_alive = PropertyMock(return_value=is_alive)
+        mocker.patch(
+            'network_controller.sensor.presence.async_ping',
+            return_value=host,
+        )
+
+        await subject.poll()
+
+        if expected_state is not None:
+            powerpi_mqtt_producer.assert_called_once_with(
+                'presence/test_presence/status',
+                {'state': expected_state},
+            )
+        else:
+            powerpi_mqtt_producer.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_poll_not_in_arp_ping_dead_grace_expired(
+        self,
+        subject: PresenceSensor,
+        arp_reader: MagicMock,
+        mocker: MockerFixture,
+        powerpi_mqtt_producer: MagicMock,
+    ):
+        arp_reader.find.return_value = None
+
+        host = mocker.Mock()
+        type(host).is_alive = PropertyMock(return_value=False)
+        mocker.patch(
+            'network_controller.sensor.presence.async_ping',
+            return_value=host,
+        )
+        mocker.patch(
+            'network_controller.sensor.presence.time',
+            side_effect=[1000, 1011, 1022],
+        )
+
+        await subject.poll()
+        await subject.poll()
+
+        powerpi_mqtt_producer.assert_called_once_with(
+            'presence/test_presence/status',
+            {'state': PresenceStatus.ABSENT},
+        )
+
+        # if we call it again it won't publish again
+        await subject.poll()
+
+        powerpi_mqtt_producer.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_poll_absent_then_present(
+        self,
+        subject: PresenceSensor,
+        arp_reader: MagicMock,
+        mocker: MockerFixture,
+        powerpi_mqtt_producer: MagicMock,
+    ):
+        arp_reader.find.return_value = None
+
+        host = mocker.Mock()
+        type(host).is_alive = PropertyMock(return_value=False)
+        mocker.patch(
+            'network_controller.sensor.presence.async_ping',
+            return_value=host,
+        )
+        mocker.patch(
+            'network_controller.sensor.presence.time',
+            side_effect=[1000, 1011],
+        )
+
+        await subject.poll()
+        await subject.poll()
+
+        arp_reader.find.return_value = HostAddress(
+            mac_address='00:11:22:33:44:55',
+        )
+
+        await subject.poll()
+
+        assert powerpi_mqtt_producer.call_count == 2
+        powerpi_mqtt_producer.assert_any_call(
+            'presence/test_presence/status',
+            {'state': PresenceStatus.ABSENT},
+        )
+        powerpi_mqtt_producer.assert_any_call(
+            'presence/test_presence/status',
+            {'state': PresenceStatus.PRESENT},
+        )
+
+    @pytest.fixture
+    def arp_reader(self, mocker: MockerFixture):
+        reader = mocker.MagicMock()
+        reader.find.return_value = HostAddress()
+        return reader
+
+    @pytest.fixture
+    def arp_factory(self, mocker: MockerFixture, arp_reader: MagicMock):
+        factory = mocker.MagicMock()
+        factory.get_arp_service.return_value = arp_reader
+        return factory
+
+    @pytest.fixture
+    def subject(
+        self,
+        powerpi_config,
+        powerpi_logger,
+        powerpi_mqtt_client,
+        arp_factory,
+    ):
+        return PresenceSensor(
+            powerpi_config, powerpi_logger, powerpi_mqtt_client, arp_factory,
+            mac='00:11:22:33:44:55',
+            ip='192.168.1.100',
+            hostname='mydevice.local',
+            absent_delay=10,
+            name='test_presence',
+            poll_frequency=120,
+        )
+
+    @pytest.fixture
+    def subject_no_ip(
+        self,
+        powerpi_config,
+        powerpi_logger,
+        powerpi_mqtt_client,
+        arp_factory,
+    ):
+        return PresenceSensor(
+            powerpi_config, powerpi_logger, powerpi_mqtt_client, arp_factory,
+            mac='00:11:22:33:44:55',
+            hostname='mydevice.local',
+            absent_delay=10,
+            name='test_presence',
+            poll_frequency=120,
+        )

--- a/controllers/network/tests/services/arp/test_arp.py
+++ b/controllers/network/tests/services/arp/test_arp.py
@@ -1,0 +1,110 @@
+import pytest
+
+from network_controller.services.arp import ARPReader, HostAddress
+
+
+class ConcreteARPReader(ARPReader):
+    def __init__(self, table, logger):
+        self._logger = logger
+        self._table = table
+
+    @property
+    def table(self):
+        return self._table
+
+
+class TestARPReader:
+
+    @pytest.mark.parametrize('table,search,expected', [
+        pytest.param(
+            [HostAddress(
+                mac_address='aa:bb',
+                ip_address='1.2.3.4',
+                hostname='host1'
+            )],
+            HostAddress(mac_address='aa:bb'),
+            HostAddress(
+                mac_address='aa:bb',
+                ip_address='1.2.3.4',
+                hostname='host1'
+            ),
+            id='match_by_mac',
+        ),
+        pytest.param(
+            [HostAddress(
+                mac_address='aa:bb',
+                ip_address='1.2.3.4',
+                hostname='host1'
+            )],
+            HostAddress(ip_address='1.2.3.4'),
+            HostAddress(
+                mac_address='aa:bb',
+                ip_address='1.2.3.4',
+                hostname='host1'
+            ),
+            id='match_by_ip',
+        ),
+        pytest.param(
+            [HostAddress(
+                mac_address='aa:bb',
+                ip_address='1.2.3.4',
+                hostname='host1'
+            )],
+            HostAddress(hostname='host1'),
+            HostAddress(
+                mac_address='aa:bb',
+                ip_address='1.2.3.4',
+                hostname='host1'
+            ),
+            id='match_by_hostname',
+        ),
+        pytest.param(
+            [
+                HostAddress(mac_address='aa:bb', ip_address='5.6.7.8'),
+                HostAddress(mac_address='cc:dd', ip_address='1.2.3.4'),
+            ],
+            HostAddress(mac_address='aa:bb', ip_address='1.2.3.4'),
+            HostAddress(mac_address='aa:bb', ip_address='5.6.7.8'),
+            id='mac_match_takes_priority',
+        ),
+        pytest.param(
+            [HostAddress(mac_address='aa:bb')],
+            HostAddress(mac_address='cc:dd'),
+            None,
+            id='no_match',
+        ),
+        pytest.param(
+            [],
+            HostAddress(mac_address='aa:bb'),
+            None,
+            id='empty_table',
+        ),
+        pytest.param(
+            [HostAddress(mac_address='aa:bb')],
+            HostAddress(),
+            None,
+            id='all_fields_none',
+        ),
+    ])
+    def test_find(
+        self,
+        subject,
+        table: list[HostAddress],
+        search: HostAddress,
+        expected: HostAddress | None,
+    ):
+        reader = subject(table)
+
+        result = reader.find(search)
+
+        if expected is None:
+            assert result is None
+        else:
+            assert result == expected
+
+    @pytest.fixture
+    def subject(self, powerpi_logger):
+        def build(table: list[HostAddress]) -> ARPReader:
+            return ConcreteARPReader(table, powerpi_logger)
+
+        return build

--- a/controllers/network/tests/services/arp/test_factory.py
+++ b/controllers/network/tests/services/arp/test_factory.py
@@ -4,14 +4,14 @@ import pytest
 from pytest_mock import MockerFixture
 
 from network_controller.sensor.presence import PresenceSensor
-from network_controller.services.arp import ARPFactory
+from network_controller.services.arp import ARPProviderFactory
 
 
-class TestARPFactory:
+class TestARPProviderFactory:
 
     def test_no_sensors(
         self,
-        subject: ARPFactory,
+        subject: ARPProviderFactory,
         powerpi_device_manager: MagicMock,
     ):
         powerpi_device_manager.sensors = {}
@@ -22,7 +22,7 @@ class TestARPFactory:
 
     def test_no_presence_sensors(
         self,
-        subject: ARPFactory,
+        subject: ARPProviderFactory,
         powerpi_device_manager: MagicMock,
         mocker: MockerFixture,
     ):
@@ -36,7 +36,7 @@ class TestARPFactory:
 
     def test_has_presence_sensor(
         self,
-        subject: ARPFactory,
+        subject: ARPProviderFactory,
         powerpi_device_manager: MagicMock,
         powerpi_service_provider: MagicMock,
         mocker: MockerFixture,
@@ -47,7 +47,7 @@ class TestARPFactory:
 
         result = subject.get_arp_service()
 
-        assert result is powerpi_service_provider.local_arp_listener()
+        assert result is powerpi_service_provider.packet_arp_provider()
 
     @pytest.fixture
     def subject(
@@ -55,8 +55,8 @@ class TestARPFactory:
         powerpi_logger,
         powerpi_device_manager,
         powerpi_service_provider,
-    ) -> ARPFactory:
-        return ARPFactory(
+    ) -> ARPProviderFactory:
+        return ARPProviderFactory(
             powerpi_logger,
             powerpi_device_manager,
             powerpi_service_provider,

--- a/controllers/network/tests/services/arp/test_factory.py
+++ b/controllers/network/tests/services/arp/test_factory.py
@@ -1,0 +1,63 @@
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from network_controller.sensor.presence import PresenceSensor
+from network_controller.services.arp import ARPFactory
+
+
+class TestARPFactory:
+
+    def test_no_sensors(
+        self,
+        subject: ARPFactory,
+        powerpi_device_manager: MagicMock,
+    ):
+        powerpi_device_manager.sensors = {}
+
+        result = subject.get_arp_service()
+
+        assert result is None
+
+    def test_no_presence_sensors(
+        self,
+        subject: ARPFactory,
+        powerpi_device_manager: MagicMock,
+        mocker: MockerFixture,
+    ):
+        powerpi_device_manager.sensors = {
+            'other': mocker.MagicMock(),
+        }
+
+        result = subject.get_arp_service()
+
+        assert result is None
+
+    def test_has_presence_sensor(
+        self,
+        subject: ARPFactory,
+        powerpi_device_manager: MagicMock,
+        powerpi_service_provider: MagicMock,
+        mocker: MockerFixture,
+    ):
+        powerpi_device_manager.sensors = {
+            'presence': mocker.MagicMock(spec=PresenceSensor),
+        }
+
+        result = subject.get_arp_service()
+
+        assert result is powerpi_service_provider.local_arp_listener()
+
+    @pytest.fixture
+    def subject(
+        self,
+        powerpi_logger,
+        powerpi_device_manager,
+        powerpi_service_provider,
+    ) -> ARPFactory:
+        return ARPFactory(
+            powerpi_logger,
+            powerpi_device_manager,
+            powerpi_service_provider,
+        )

--- a/controllers/network/tests/services/arp/test_local_arp_listener.py
+++ b/controllers/network/tests/services/arp/test_local_arp_listener.py
@@ -1,0 +1,160 @@
+from asyncio import Event
+from collections.abc import Callable
+from socket import herror, inet_aton
+from unittest.mock import MagicMock, PropertyMock
+
+import pytest
+from netifaces import AF_INET
+from pytest_mock import MockerFixture
+
+from network_controller.services.arp.local_arp_listener import LocalARPListener
+
+MODULE = 'network_controller.services.arp.local_arp_listener'
+
+SubjectFactory = Callable[..., tuple[LocalARPListener, Event]]
+
+
+class _LoopDone(Exception):
+    pass
+
+
+class TestLocalARPListener:
+
+    def test_table_initially_empty(self, subject: LocalARPListener):
+        assert subject.table == []
+
+    @pytest.mark.asyncio
+    async def test_packet_received(self, create_subject: SubjectFactory):
+        subject, loop_done = create_subject()
+
+        await subject.start()
+        await loop_done.wait()
+        await subject.stop()
+
+        assert len(subject.table) == 1
+
+        entry = subject.table[0]
+        assert entry.mac_address == 'aa:bb:cc:dd:ee:ff'
+        assert entry.ip_address == '192.168.1.100'
+        assert entry.hostname == 'myhost.local'
+
+    @pytest.mark.asyncio
+    async def test_hostname_resolution_fails(self, create_subject: SubjectFactory):
+        subject, loop_done = create_subject(hostname=None)
+
+        await subject.start()
+        await loop_done.wait()
+        await subject.stop()
+
+        assert len(subject.table) == 1
+        assert subject.table[0].hostname is None
+
+    @pytest.mark.asyncio
+    async def test_prune_removes_old_entries(
+        self,
+        create_subject: SubjectFactory,
+        mocker: MockerFixture,
+    ):
+        mocker.patch(f'{MODULE}.time', return_value=2000)
+
+        subject, loop_done = create_subject(arp_cache_expiry=1)
+
+        await subject.start()
+        await loop_done.wait()
+        await subject.stop()
+
+        assert subject.table == []
+
+    @pytest.mark.asyncio
+    async def test_no_suitable_interface(
+        self,
+        subject: LocalARPListener,
+        mocker: MockerFixture,
+    ):
+        mocker.patch(f'{MODULE}.interfaces', return_value=['lo', 'docker0'])
+
+        await subject.start()
+        await subject.stop()
+
+        assert subject.table == []
+
+    @pytest.fixture
+    def subject(
+        self,
+        powerpi_config,
+        powerpi_logger,
+    ) -> LocalARPListener:
+        type(powerpi_config).arp_cache_expiry = PropertyMock(return_value=60)
+        return LocalARPListener(powerpi_config, powerpi_logger)
+
+    @pytest.fixture(autouse=True)
+    def mock_infrastructure(self, mocker: MockerFixture):
+        mocker.patch(f'{MODULE}.interfaces', return_value=['eth0'])
+        mocker.patch(
+            f'{MODULE}.ifaddresses',
+            return_value={AF_INET: [{'addr': '192.168.1.1'}]},
+        )
+
+        iteration_complete = Event()
+
+        def end_loop(_):
+            iteration_complete.set()
+            raise _LoopDone()
+        mocker.patch(f'{MODULE}.sleep', side_effect=end_loop)
+
+        sniffer = mocker.MagicMock()
+        mocker.patch(f'{MODULE}.pcap', return_value=sniffer)
+
+        return sniffer, iteration_complete
+
+    @pytest.fixture
+    def create_subject(
+        self,
+        powerpi_config,
+        powerpi_logger,
+        mock_infrastructure,
+        mocker: MockerFixture,
+    ):
+        def build(
+            arp_cache_expiry: int = 60,
+            hostname: str | None = 'myhost.local',
+        ) -> tuple[LocalARPListener, Event]:
+            sniffer, iteration_complete = mock_infrastructure
+
+            type(powerpi_config).arp_cache_expiry = PropertyMock(
+                return_value=arp_cache_expiry,
+            )
+
+            self.__setup_dispatch(sniffer, mocker, hostname=hostname)
+
+            subject = LocalARPListener(powerpi_config, powerpi_logger)
+            return subject, iteration_complete
+
+        return build
+
+    def __setup_dispatch(
+        self,
+        sniffer: MagicMock,
+        mocker: MockerFixture,
+        hostname: str | None = 'myhost.local',
+    ):
+        mock_arp = mocker.MagicMock()
+        mock_arp.spa = inet_aton('192.168.1.100')
+        mock_arp.sha = bytes([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff])
+
+        mock_eth = mocker.MagicMock()
+        mock_eth.data = mock_arp
+
+        mocker.patch(f'{MODULE}.ethernet.Ethernet', return_value=mock_eth)
+
+        if hostname is not None:
+            mocker.patch(
+                f'{MODULE}.gethostbyaddr',
+                return_value=(hostname, [], []),
+            )
+        else:
+            mocker.patch(f'{MODULE}.gethostbyaddr', side_effect=herror())
+
+        def dispatch_handler(__, callback):
+            callback(1000, b'raw')
+        sniffer.dispatch.side_effect = dispatch_handler

--- a/controllers/network/tests/services/arp/test_packet.py
+++ b/controllers/network/tests/services/arp/test_packet.py
@@ -7,20 +7,20 @@ import pytest
 from netifaces import AF_INET
 from pytest_mock import MockerFixture
 
-from network_controller.services.arp.local_arp_listener import LocalARPListener
+from network_controller.services.arp.packet import PacketARPProvider
 
-MODULE = 'network_controller.services.arp.local_arp_listener'
+MODULE = 'network_controller.services.arp.packet'
 
-SubjectFactory = Callable[..., tuple[LocalARPListener, Event]]
+SubjectFactory = Callable[..., tuple[PacketARPProvider, Event]]
 
 
 class _LoopDone(Exception):
     pass
 
 
-class TestLocalARPListener:
+class TestPacketARPProvider:
 
-    def test_table_initially_empty(self, subject: LocalARPListener):
+    def test_table_initially_empty(self, subject: PacketARPProvider):
         assert subject.table == []
 
     @pytest.mark.asyncio
@@ -68,7 +68,7 @@ class TestLocalARPListener:
     @pytest.mark.asyncio
     async def test_no_suitable_interface(
         self,
-        subject: LocalARPListener,
+        subject: PacketARPProvider,
         mocker: MockerFixture,
     ):
         mocker.patch(f'{MODULE}.interfaces', return_value=['lo', 'docker0'])
@@ -83,9 +83,9 @@ class TestLocalARPListener:
         self,
         powerpi_config,
         powerpi_logger,
-    ) -> LocalARPListener:
+    ) -> PacketARPProvider:
         type(powerpi_config).arp_cache_expiry = PropertyMock(return_value=60)
-        return LocalARPListener(powerpi_config, powerpi_logger)
+        return PacketARPProvider(powerpi_config, powerpi_logger)
 
     @pytest.fixture(autouse=True)
     def mock_infrastructure(self, mocker: MockerFixture):
@@ -118,7 +118,7 @@ class TestLocalARPListener:
         def build(
             arp_cache_expiry: int = 60,
             hostname: str | None = 'myhost.local',
-        ) -> tuple[LocalARPListener, Event]:
+        ) -> tuple[PacketARPProvider, Event]:
             sniffer, iteration_complete = mock_infrastructure
 
             type(powerpi_config).arp_cache_expiry = PropertyMock(
@@ -127,7 +127,7 @@ class TestLocalARPListener:
 
             self.__setup_dispatch(sniffer, mocker, hostname=hostname)
 
-            subject = LocalARPListener(powerpi_config, powerpi_logger)
+            subject = PacketARPProvider(powerpi_config, powerpi_logger)
             return subject, iteration_complete
 
         return build

--- a/controllers/network/tests/services/arp/test_provider.py
+++ b/controllers/network/tests/services/arp/test_provider.py
@@ -1,9 +1,9 @@
 import pytest
 
-from network_controller.services.arp import ARPReader, HostAddress
+from network_controller.services.arp import ARPProvider, HostAddress
 
 
-class ConcreteARPReader(ARPReader):
+class ConcreteARPProvider(ARPProvider):
     def __init__(self, table, logger):
         self._logger = logger
         self._table = table
@@ -13,7 +13,7 @@ class ConcreteARPReader(ARPReader):
         return self._table
 
 
-class TestARPReader:
+class TestARPProvider:
 
     @pytest.mark.parametrize('table,search,expected', [
         pytest.param(
@@ -104,7 +104,7 @@ class TestARPReader:
 
     @pytest.fixture
     def subject(self, powerpi_logger):
-        def build(table: list[HostAddress]) -> ARPReader:
-            return ConcreteARPReader(table, powerpi_logger)
+        def build(table: list[HostAddress]) -> ARPProvider:
+            return ConcreteARPProvider(table, powerpi_logger)
 
         return build

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -48,7 +48,7 @@ dependencies:
     version: 0.1.17
     condition: global.lifx
   - name: network-controller
-    version: 0.1.16
+    version: 0.1.17
     condition: global.network
   - name: snapcast-controller
     version: 0.0.14

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
     version: 0.0.7
     condition: global.event
   - name: mosquitto
-    version: 0.3.3
+    version: 0.3.4
   - name: persistence
     version: 0.1.22
     condition: global.persistence

--- a/kubernetes/charts/mosquitto/Chart.yaml
+++ b/kubernetes/charts/mosquitto/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: mosquitto
 description: A Helm chart for deploying the mosquitto message queue for PowerPi
 type: application
-version: 0.3.3
+version: 0.3.4
 appVersion: 2.0.22

--- a/kubernetes/charts/mosquitto/acl.conf
+++ b/kubernetes/charts/mosquitto/acl.conf
@@ -12,6 +12,12 @@ topic read powerpi/config/devices/change
 topic readwrite powerpi/device/#
 topic readwrite powerpi/event/#
 
+user network_controller
+topic read powerpi/config/devices/change
+topic readwrite powerpi/device/#
+topic readwrite powerpi/event/#
+topic readwrite powerpi/presence/#
+
 user device
 topic read powerpi/device/+/change
 topic readwrite powerpi/device/+/status

--- a/kubernetes/charts/mosquitto/acl.conf
+++ b/kubernetes/charts/mosquitto/acl.conf
@@ -32,7 +32,9 @@ topic readwrite powerpi/device/+/change
 topic readwrite powerpi/device/+/scene
 
 user persistence
-topic read powerpi/#
+topic read powerpi/config/#
+topic read powerpi/device/#
+topic read powerpi/event/#
 
 user scheduler
 topic read powerpi/config/#

--- a/kubernetes/charts/mosquitto/templates/secret.yaml
+++ b/kubernetes/charts/mosquitto/templates/secret.yaml
@@ -9,6 +9,9 @@
   (print "api:" .Params.ApiSecret)
   (print "controller:" .Params.ControllerSecret)
 ) -}}
+{{- if eq .Values.global.network true -}}
+{{- $passwords = append $passwords (print "network-controller:" .Params.NetworkControllerSecret) -}}
+{{- end -}}
 {{- if eq .Values.global.config true -}}
 {{- $passwords = append $passwords (print "config:" .Params.ConfigSecret) -}}
 {{- end -}}
@@ -42,6 +45,7 @@
 {{- $schedulerSecret := "" -}}
 {{- $sensorSecret := "" -}}
 {{- $voiceSecret := "" -}}
+{{- $networkControllerSecret := "" -}}
 
 {{- $apiSecret := include "powerpi.generate-mosquitto-secret" (merge (dict "Params" (dict
   "Name" "mosquitto-api-secret"
@@ -56,6 +60,12 @@
 {{- $controllerSecret := include "powerpi.generate-mosquitto-secret" (merge (dict "Params" (dict
   "Name" "mosquitto-controller-secret"
 )) . ) -}}
+
+{{- if eq .Values.global.network true -}}
+{{- $networkControllerSecret = include "powerpi.generate-mosquitto-secret" (merge (dict "Params" (dict
+  "Name" "mosquitto-network-controller-secret"
+)) . ) -}}
+{{- end -}}
 
 {{- if eq .Values.global.useSensors true -}}
 {{- $deviceSecret = include "powerpi.generate-mosquitto-secret" (merge (dict "Params" (dict
@@ -98,6 +108,7 @@
   "ApiSecret" ($apiSecret | b64dec)
   "ConfigSecret" ($configSecret | b64dec)
   "ControllerSecret" ($controllerSecret | b64dec)
+  "NetworkControllerSecret" ($networkControllerSecret | b64dec)
   "DeviceSecret" ($deviceSecret | b64dec)
   "PersistenceSecret" ($persistenceSecret | b64dec)
   "EventSecret" ($eventSecret | b64dec)
@@ -150,6 +161,19 @@ data:
   username: {{ "controller" | b64enc | quote }}
   password: {{ $controllerSecret | quote }}
 ---
+
+{{- if eq .Values.global.network true -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mosquitto-network-controller-secret
+  {{- include "powerpi.labels" . }}
+type: Opaque
+data:
+  username: {{ "network-controller" | b64enc | quote }}
+  password: {{ $networkControllerSecret | quote }}
+---
+{{- end -}}
 
 {{- if eq .Values.global.useSensors true -}}
 apiVersion: v1

--- a/kubernetes/charts/network-controller/Chart.yaml
+++ b/kubernetes/charts/network-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: network-controller
 description: A Helm chart for the PowerPi Network device controller
 type: application
-version: 0.1.16
-appVersion: 0.2.6-rc.5
+version: 0.1.17
+appVersion: 0.3.0-rc.1

--- a/kubernetes/charts/network-controller/templates/deployment.yaml
+++ b/kubernetes/charts/network-controller/templates/deployment.yaml
@@ -4,6 +4,7 @@
     $data := dict
     "HostNetwork" (true | quote)
     "Capabilities" (list "NET_RAW" "NET_ADMIN")
+    "MqttSecret" "mosquitto-network-controller-secret"
     "Env" (list
         (dict
             "Name" "MQTT_ADDRESS"

--- a/kubernetes/charts/network-controller/templates/deployment.yaml
+++ b/kubernetes/charts/network-controller/templates/deployment.yaml
@@ -3,6 +3,7 @@
 {{-
     $data := dict
     "HostNetwork" (true | quote)
+    "Capabilities" (list "NET_RAW" "NET_ADMIN")
     "Env" (list
         (dict
             "Name" "MQTT_ADDRESS"

--- a/kubernetes/templates/_controller.tpl
+++ b/kubernetes/templates/_controller.tpl
@@ -14,12 +14,17 @@
   "Value" "/tmp/powerpi_health"
 ) -}}
 
+{{- $mqttSecret := "mosquitto-controller-secret" -}}
+{{- if not (empty .Params.MqttSecret) -}}
+{{- $mqttSecret = .Params.MqttSecret -}}
+{{- end -}}
+
 {{- $data := (merge
   (dict
     "UseDevicesFile" true
     "RequestMemory" "50Mi"
     "LimitMemory" "100Mi"
-    "MqttSecret" "mosquitto-controller-secret"
+    "MqttSecret" $mqttSecret
     "Env" $env
     "Probe" (dict
       "Command" (list


### PR DESCRIPTION
- Add presence detection sensor to `network-controller`.
  - Listens for ARP changes and registers the devices as they appear.
  - Prunes the devices after a user configurable interval.
  - Use ICMP ping to wake device when not present.
  - Writes state to new topic `presence` with restricted access.
- Add secret and MQTT user with access to the new topic.
- Constrain `persistence` permissions so it can't see the new topic.
- Add capabilities to `network-controller` image and deployment.