### PR TITLE
#757 feat(common): Add support for presence sensor variables in conditions

### DIFF
--- a/common/pytest/powerpi_common_test/variable/variable.py
+++ b/common/pytest/powerpi_common_test/variable/variable.py
@@ -14,6 +14,6 @@ class VariableTestBase:
 
     def test_str(self, subject):
         assert bool(re.match(
-            r'^var\.(device|sensor)\..*=\{.*\}$',
+            r'^var\.(device|sensor|presence)\..*=\{.*\}$',
             str(subject)
         )) is True

--- a/common/pytest/pyproject.toml
+++ b/common/pytest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "powerpi-common-test"
-version = "0.6.1"
+version = "0.7.0"
 description = "PowerPi Common Python Test Library"
 license = "GPL-3.0-only"
 authors = [

--- a/common/python/powerpi_common/condition/parser.py
+++ b/common/python/powerpi_common/condition/parser.py
@@ -88,7 +88,7 @@ class ConditionParser:
                     name, action, prop = split[1:]
                     return self.sensor_identifier(identifier, name, action, prop)
 
-                if identifier_type == VariableType.PRESENCE and len(split) == 2:
+                if identifier_type == VariableType.PRESENCE and len(split) == 3:
                     name, prop = split[1:]
                     return self.presence_identifier(identifier, name, prop)
 

--- a/common/python/powerpi_common/condition/parser.py
+++ b/common/python/powerpi_common/condition/parser.py
@@ -88,6 +88,10 @@ class ConditionParser:
                     name, action, prop = split[1:]
                     return self.sensor_identifier(identifier, name, action, prop)
 
+                if identifier_type == VariableType.PRESENCE and len(split) == 2:
+                    name, prop = split[1:]
+                    return self.presence_identifier(identifier, name, prop)
+
                 if identifier_type == 'message' and len(split) == 2:
                     prop = split[1]
                     return self.message_identifier(identifier, prop)
@@ -128,6 +132,21 @@ class ConditionParser:
                 return variable.value.value
             if prop == 'unit':
                 return variable.value.unit
+            if prop == 'state':
+                return variable.state
+        except AttributeError:
+            pass
+
+        raise InvalidIdentifierException(identifier)
+
+    def presence_identifier(self, identifier: str, name: str, prop: str):
+        '''
+        Return the value of the presence identifier
+        e.g. {'var': 'presence.Person.state'}
+        '''
+        variable = self.__variable_manager.get_presence(name)
+
+        try:
             if prop == 'state':
                 return variable.state
         except AttributeError:

--- a/common/python/powerpi_common/mqtt/__init__.py
+++ b/common/python/powerpi_common/mqtt/__init__.py
@@ -1,3 +1,3 @@
 from .client import MQTTClient
 from .consumer import MQTTConsumer
-from .types import MQTTMessage
+from .types import MQTTMessage, MQTTTopic

--- a/common/python/powerpi_common/mqtt/types.py
+++ b/common/python/powerpi_common/mqtt/types.py
@@ -1,4 +1,11 @@
-from typing import Any, Dict
+from enum import unique, StrEnum
+
+MQTTMessage = dict[str, any]
 
 
-MQTTMessage = Dict[str, Any]
+@unique
+class MQTTTopic(StrEnum):
+    CONFIG = 'config'
+    DEVICE = 'device'
+    EVENT = 'event'
+    PRESENCE = 'presence'

--- a/common/python/powerpi_common/sensor/__init__.py
+++ b/common/python/powerpi_common/sensor/__init__.py
@@ -1,1 +1,2 @@
 from .sensor import Sensor
+from .types import PresenceStatus

--- a/common/python/powerpi_common/sensor/types.py
+++ b/common/python/powerpi_common/sensor/types.py
@@ -1,0 +1,8 @@
+from enum import StrEnum, unique
+
+
+@unique
+class PresenceStatus(StrEnum):
+    PRESENT = 'present'
+    ABSENT = 'absent'
+    UNKNOWN = 'unknown'

--- a/common/python/powerpi_common/variable/container.py
+++ b/common/python/powerpi_common/variable/container.py
@@ -3,6 +3,7 @@ from dependency_injector import containers, providers
 from powerpi_common.variable.device import DeviceVariable
 from powerpi_common.variable.manager import VariableManager
 from powerpi_common.variable.sensor import SensorVariable
+from powerpi_common.variable.presence import PresenceVariable
 
 
 class VariableContainer(containers.DeclarativeContainer):
@@ -39,4 +40,8 @@ class VariableContainer(containers.DeclarativeContainer):
         config=config,
         logger=logger,
         mqtt_client=mqtt_client
+    )
+
+    presence_variable = providers.Factory(
+        PresenceVariable
     )

--- a/common/python/powerpi_common/variable/container.py
+++ b/common/python/powerpi_common/variable/container.py
@@ -43,5 +43,8 @@ class VariableContainer(containers.DeclarativeContainer):
     )
 
     presence_variable = providers.Factory(
-        PresenceVariable
+        PresenceVariable,
+        config=config,
+        logger=logger,
+        mqtt_client=mqtt_client
     )

--- a/common/python/powerpi_common/variable/manager.py
+++ b/common/python/powerpi_common/variable/manager.py
@@ -45,6 +45,12 @@ class VariableManager(LogMixin):
         '''
         return self.__get(VariableType.SENSOR, name, action)
 
+    def get_presence(self, name: str) -> 'SensorVariable | SensorType':
+        '''
+        Returns the presence sensor variable if it exists, or the actual sensor if that exists.
+        '''
+        return self.__get(VariableType.PRESENCE, name)
+
     def add(self, variable: Variable):
         variable_type = variable.variable_type
         kwargs = {}
@@ -94,7 +100,7 @@ class VariableManager(LogMixin):
             if variable_type == VariableType.DEVICE:
                 return self.__device_manager.get_device(name)
 
-            if variable_type == VariableType.SENSOR:
+            if variable_type in (VariableType.SENSOR, VariableType.PRESENCE):
                 return self.__device_manager.get_sensor(name)
         except DeviceNotFoundException:
             pass

--- a/common/python/powerpi_common/variable/manager.py
+++ b/common/python/powerpi_common/variable/manager.py
@@ -4,6 +4,7 @@ from powerpi_common.device import DeviceManager, DeviceNotFoundException
 from powerpi_common.logger import Logger, LogMixin
 from powerpi_common.typing import DeviceType, SensorType
 from powerpi_common.variable.device import DeviceVariable
+from powerpi_common.variable.presence import PresenceVariable
 from powerpi_common.variable.sensor import SensorVariable
 from powerpi_common.variable.types import VariableType
 from powerpi_common.variable.variable import Variable
@@ -45,7 +46,7 @@ class VariableManager(LogMixin):
         '''
         return self.__get(VariableType.SENSOR, name, action)
 
-    def get_presence(self, name: str) -> 'SensorVariable | SensorType':
+    def get_presence(self, name: str) -> 'PresenceVariable | SensorType':
         '''
         Returns the presence sensor variable if it exists, or the actual sensor if that exists.
         '''
@@ -110,7 +111,7 @@ class VariableManager(LogMixin):
 
     @classmethod
     def __key(cls, variable_type: VariableType, name: str, action: str | None = None):
-        if variable_type == VariableType.DEVICE:
+        if variable_type in (VariableType.DEVICE, VariableType.PRESENCE):
             return name
         if variable_type == VariableType.SENSOR and action is not None:
             return f'{name}/{action}'

--- a/common/python/powerpi_common/variable/presence.py
+++ b/common/python/powerpi_common/variable/presence.py
@@ -1,0 +1,33 @@
+from powerpi_common.variable.types import VariableType
+from powerpi_common.variable.variable import Variable
+
+
+class PresenceVariable(Variable):
+    def __init__(
+        self,
+        name: str,
+        **kwargs
+    ):
+        Variable.__init__(self, name, **kwargs)
+
+        self.__state = None
+
+    @property
+    def variable_type(self):
+        return VariableType.PRESENCE
+
+    @property
+    def state(self):
+        return self.__state
+
+    @state.setter
+    def state(self, new_state: str):
+        self.__state = new_state
+
+    @property
+    def json(self):
+        return {'state': self.__state}
+
+    @property
+    def suffix(self):
+        return f'{self._name}'

--- a/common/python/powerpi_common/variable/presence.py
+++ b/common/python/powerpi_common/variable/presence.py
@@ -1,16 +1,36 @@
+from powerpi_common.config import Config
+from powerpi_common.logger import Logger
+from powerpi_common.mqtt import MQTTClient, MQTTTopic
+from powerpi_common.sensor.consumers import SensorEventConsumer
 from powerpi_common.variable.types import VariableType
 from powerpi_common.variable.variable import Variable
 
 
-class PresenceVariable(Variable):
+class PresenceVariable(Variable, SensorEventConsumer):
+    '''
+    Variable implementation that will receive presence detection events from the message queue.
+    '''
+
     def __init__(
         self,
+        config: Config,
+        logger: Logger,
+        mqtt_client: MQTTClient,
         name: str,
         **kwargs
     ):
         Variable.__init__(self, name, **kwargs)
+        SensorEventConsumer.__init__(
+            self,
+            f'{MQTTTopic.PRESENCE}/{name}/status',
+            self,
+            config,
+            logger
+        )
 
         self.__state = None
+
+        mqtt_client.add_consumer(self)
 
     @property
     def variable_type(self):

--- a/common/python/powerpi_common/variable/presence.py
+++ b/common/python/powerpi_common/variable/presence.py
@@ -1,6 +1,7 @@
 from powerpi_common.config import Config
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient, MQTTTopic
+from powerpi_common.sensor import PresenceStatus
 from powerpi_common.sensor.consumers import SensorEventConsumer
 from powerpi_common.variable.types import VariableType
 from powerpi_common.variable.variable import Variable
@@ -28,7 +29,7 @@ class PresenceVariable(Variable, SensorEventConsumer):
             logger
         )
 
-        self.__state = None
+        self.__state: PresenceStatus | None = None
 
         mqtt_client.add_consumer(self)
 

--- a/common/python/powerpi_common/variable/types.py
+++ b/common/python/powerpi_common/variable/types.py
@@ -4,3 +4,4 @@ from enum import StrEnum
 class VariableType(StrEnum):
     DEVICE = 'device'
     SENSOR = 'sensor'
+    PRESENCE = 'presence'

--- a/common/python/pyproject.toml
+++ b/common/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "powerpi-common"
-version = "0.7.4"
+version = "0.8.0"
 description = "PowerPi Common Python Library"
 license = "GPL-3.0-only"
 authors = [

--- a/common/python/tests/condition/test_parser.py
+++ b/common/python/tests/condition/test_parser.py
@@ -21,6 +21,11 @@ class SensorVariableImpl:
         self.value = SensorValue(f'{name}/{action}', f'{action}/{name}')
 
 
+class PresenceVariableImpl:
+    def __init__(self, name: str):
+        self.state = name
+
+
 SubjectBuilder = Callable[[dict[str, Any] | None], ConditionParser]
 
 
@@ -48,6 +53,7 @@ class TestConditionParser:
         ('device.light.brightness', 'light'),
         ('sensor.office.temperature.value', 'office/temperature'),
         ('sensor.office.temperature.unit', 'temperature/office'),
+        {'presence.person.state', 'person'},
         ('message.timestamp', 1337),
         ('message.whatever', None),
     ])
@@ -74,6 +80,8 @@ class TestConditionParser:
         'sensor.office',
         'sensor.office.temperature',
         'sensor.office.temperature.whatever',
+        'presence.person',
+        'presence.person.other',
         'message',
         'message.timestamp'
     ])
@@ -242,6 +250,7 @@ class TestConditionParser:
         def build(message: dict[str, Any] | None = None):
             powerpi_variable_manager.get_device = DeviceVariableImpl
             powerpi_variable_manager.get_sensor = SensorVariableImpl
+            powerpi_variable_manager.get_presence = PresenceVariableImpl
 
             return ConditionParser(powerpi_variable_manager, message)
 

--- a/common/python/tests/condition/test_parser.py
+++ b/common/python/tests/condition/test_parser.py
@@ -53,7 +53,7 @@ class TestConditionParser:
         ('device.light.brightness', 'light'),
         ('sensor.office.temperature.value', 'office/temperature'),
         ('sensor.office.temperature.unit', 'temperature/office'),
-        {'presence.person.state', 'person'},
+        ('presence.person.state', 'person'),
         ('message.timestamp', 1337),
         ('message.whatever', None),
     ])

--- a/common/python/tests/variable/test_manager.py
+++ b/common/python/tests/variable/test_manager.py
@@ -17,9 +17,18 @@ class SensorVariableImpl:
         self.variable_type = VariableType.SENSOR
 
 
+class PresenceVariableImpl:
+    def __init__(self, name: str):
+        self.name = name
+        self.variable_type = VariableType.PRESENCE
+
+
 class TestVariableManager:
 
-    @pytest.mark.parametrize('variable_type', [VariableType.DEVICE, VariableType.SENSOR])
+    @pytest.mark.parametrize(
+        'variable_type',
+        [VariableType.DEVICE, VariableType.SENSOR, VariableType.PRESENCE]
+    )
     def test_get_x_adds(
         self,
         subject: VariableManager,
@@ -31,20 +40,30 @@ class TestVariableManager:
             raise DeviceNotFoundException(DeviceConfigType.DEVICE, name)
         powerpi_device_manager.get_device = not_found
         powerpi_device_manager.get_sensor = not_found
+        powerpi_device_manager.get_presence = not_found
 
         powerpi_service_provider.device_variable = DeviceVariableImpl
         powerpi_service_provider.sensor_variable = SensorVariableImpl
+        powerpi_service_provider.presence_variable = PresenceVariableImpl
 
         name = 'new_variable'
 
-        result = subject.get_device(name) if variable_type == VariableType.DEVICE \
-            else subject.get_sensor(name, 'action')
+        getters = {
+            VariableType.DEVICE: lambda: subject.get_device(name),
+            VariableType.SENSOR: lambda: subject.get_sensor(name, 'action'),
+            VariableType.PRESENCE: lambda: subject.get_presence(name),
+        }
+
+        result = getters[variable_type]()
 
         assert result is not None
         assert result.name == name
         assert result.variable_type == variable_type
 
-    @pytest.mark.parametrize('variable_type', [VariableType.DEVICE, VariableType.SENSOR])
+    @pytest.mark.parametrize(
+        'variable_type',
+        [VariableType.DEVICE, VariableType.SENSOR, VariableType.PRESENCE]
+    )
     def test_get_x_from_manager(
         self,
         subject: VariableManager,
@@ -55,7 +74,7 @@ class TestVariableManager:
         powerpi_device_manager.get_device = DeviceVariableImpl
         powerpi_device_manager.get_sensor = lambda name: SensorVariableImpl(
             name, 'action'
-        )
+        ) if variable_type == VariableType.SENSOR else PresenceVariableImpl(name)
 
         name = 'found_device'
 
@@ -68,8 +87,12 @@ class TestVariableManager:
 
         powerpi_service_provider.device_variable.assert_not_called()
         powerpi_service_provider.sensor_variable.assert_not_called()
+        powerpi_service_provider.presence_variable.assert_not_called()
 
-    @pytest.mark.parametrize('variable_type', [VariableType.DEVICE, VariableType.SENSOR])
+    @pytest.mark.parametrize(
+        'variable_type',
+        [VariableType.DEVICE, VariableType.SENSOR, VariableType.PRESENCE]
+    )
     def test_get_x_exists(
         self,
         subject: VariableManager,
@@ -79,23 +102,35 @@ class TestVariableManager:
     ):
         name = 'found_variable'
 
-        variable = DeviceVariableImpl(name) if variable_type == VariableType.DEVICE \
-            else SensorVariableImpl(name, 'action')
+        variables = {
+            VariableType.DEVICE: lambda: DeviceVariableImpl(name),
+            VariableType.SENSOR: lambda: SensorVariableImpl(name, 'action'),
+            VariableType.PRESENCE: lambda: PresenceVariableImpl(name),
+        }
+
+        variable = variables[variable_type]()
 
         # ensure it's already there
         subject.add(variable)
 
-        result = subject.get_device(name) if variable_type == VariableType.DEVICE \
-            else subject.get_sensor(name, 'action')
+        getters = {
+            VariableType.DEVICE: lambda: subject.get_device(name),
+            VariableType.SENSOR: lambda: subject.get_sensor(name, 'action'),
+            VariableType.PRESENCE: lambda: subject.get_presence(name),
+        }
+
+        result = getters[variable_type]()
 
         assert result is not None
         assert result == variable
 
         powerpi_device_manager.get_device.assert_not_called()
         powerpi_device_manager.get_sensor.assert_not_called()
+        powerpi_device_manager.get_presence.assert_not_called()
 
         powerpi_service_provider.device_variable.assert_not_called()
         powerpi_service_provider.sensor_variable.assert_not_called()
+        powerpi_service_provider.presence_variable.assert_not_called()
 
     @pytest.fixture
     def subject(self, powerpi_logger, powerpi_device_manager, powerpi_service_provider):

--- a/common/python/tests/variable/test_presence.py
+++ b/common/python/tests/variable/test_presence.py
@@ -1,0 +1,27 @@
+import pytest
+from powerpi_common_test.variable.variable import VariableTestBase
+
+from powerpi_common.variable.presence import PresenceVariable
+
+
+class TestPresenceVariable(VariableTestBase):
+
+    def test_topic(self, subject: PresenceVariable):
+        assert subject.topic == 'presence/TestPresence/status'
+
+    @pytest.mark.asyncio
+    async def test_on_message_updates(self, subject: PresenceVariable):
+        message = {'state': 'absent'}
+
+        assert subject.state is None
+
+        await subject.on_message(message, 'TestPresence', 'status')
+
+        assert subject.state == 'absent'
+
+    @pytest.fixture
+    def subject(self, powerpi_config, powerpi_logger, powerpi_mqtt_client):
+        return PresenceVariable(
+            powerpi_config, powerpi_logger, powerpi_mqtt_client,
+            name='TestPresence'
+        )

--- a/common/python/tests/variable/test_presence.py
+++ b/common/python/tests/variable/test_presence.py
@@ -1,6 +1,7 @@
 import pytest
 from powerpi_common_test.variable.variable import VariableTestBase
 
+from powerpi_common.sensor import PresenceStatus
 from powerpi_common.variable.presence import PresenceVariable
 
 
@@ -17,7 +18,7 @@ class TestPresenceVariable(VariableTestBase):
 
         await subject.on_message(message, 'TestPresence', 'status')
 
-        assert subject.state == 'absent'
+        assert subject.state == PresenceStatus.ABSENT
 
     @pytest.fixture
     def subject(self, powerpi_config, powerpi_logger, powerpi_mqtt_client):

--- a/controllers/energenie/pyproject.toml
+++ b/controllers/energenie/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "energenie_controller"
-version = "0.3.7-rc.4"
+version = "0.3.7-rc.5"
 description = "PowerPi Energenie Controller"
 license = "GPL-3.0-only"
 authors = [

--- a/controllers/harmony/pyproject.toml
+++ b/controllers/harmony/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "harmony_controller"
-version = "0.4.10-rc.6"
+version = "0.4.10-rc.7"
 description = "PowerPi Logitech Harmony Controller"
 license = "GPL-3.0-only"
 authors = [

--- a/controllers/lifx/pyproject.toml
+++ b/controllers/lifx/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lifx_controller"
-version = "0.6.6-rc.4"
+version = "0.6.6-rc.5"
 description = "PowerPi LIFX Controller"
 license = "GPL-3.0-only"
 authors = [

--- a/controllers/network/network_controller/sensor/presence.py
+++ b/controllers/network/network_controller/sensor/presence.py
@@ -1,22 +1,15 @@
 from dataclasses import dataclass
-from enum import StrEnum, unique
 from time import time
 
 from powerpi_common.logger import Logger
-from powerpi_common.mqtt import MQTTClient
+from powerpi_common.mqtt import MQTTClient, MQTTTopic
 from powerpi_common.sensor import Sensor
 from powerpi_common.device.mixin import PollableMixin
+from powerpi_common.sensor import PresenceStatus
 
 from network_controller.config import NetworkConfig
 from network_controller.services.arp import ARPProviderFactory, ARPProvider, HostAddress
 from network_controller.util import ping
-
-
-@unique
-class PresenceStatus(StrEnum):
-    PRESENT = 'present'
-    ABSENT = 'absent'
-    UNKNOWN = 'unknown'
 
 
 @dataclass
@@ -111,7 +104,7 @@ class PresenceSensor(Sensor, PollableMixin):
             self.__set_new_state(PresenceStatus.PRESENT)
 
     def __broadcast(self, state: PresenceStatus):
-        topic = f'presence/{self.entity}/status'
+        topic = f'{MQTTTopic.PRESENCE}/{self.entity}/status'
 
         message = {'state': state}
 

--- a/controllers/network/pyproject.toml
+++ b/controllers/network/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "network_controller"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 description = "PowerPi Network Controller"
 license = "GPL-3.0-only"
 authors = [

--- a/controllers/snapcast/pyproject.toml
+++ b/controllers/snapcast/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "snapcast_controller"
-version = "0.0.10-rc.5"
+version = "0.0.10-rc.6"
 description = "PowerPi Snapcast Controller"
 license = "GPL-3.0-only"
 authors = [

--- a/controllers/virtual/pyproject.toml
+++ b/controllers/virtual/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "virtual_controller"
-version = "2.2.2-rc.4"
+version = "2.2.2-rc.5"
 description = "PowerPi Virtual Controller"
 license = "GPL-3.0-only"
 authors = [

--- a/controllers/zigbee/pyproject.toml
+++ b/controllers/zigbee/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zigbee_controller"
-version = "0.8.0-rc.8"
+version = "0.8.0-rc.9"
 description = "PowerPi ZigBee Controller"
 license = "GPL-3.0-only"
 authors = [

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -48,7 +48,7 @@ dependencies:
     version: 0.1.17
     condition: global.lifx
   - name: network-controller
-    version: 0.1.17
+    version: 0.1.18
     condition: global.network
   - name: snapcast-controller
     version: 0.0.14

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -39,7 +39,7 @@ dependencies:
     version: 0.3.17
     condition: global.voiceAssistant
   - name: energenie-controller
-    version: 0.1.17
+    version: 0.1.18
     condition: global.energenie
   - name: harmony-controller
     version: 0.1.24

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -42,7 +42,7 @@ dependencies:
     version: 0.1.18
     condition: global.energenie
   - name: harmony-controller
-    version: 0.1.24
+    version: 0.1.25
     condition: global.harmony
   - name: lifx-controller
     version: 0.1.17

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -54,7 +54,7 @@ dependencies:
     version: 0.0.14
     condition: global.snapcast
   - name: virtual-controller
-    version: 0.2.12
+    version: 0.2.13
   - name: zigbee-controller
     version: 0.2.10
     condition: global.zigbee

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -51,7 +51,7 @@ dependencies:
     version: 0.1.18
     condition: global.network
   - name: snapcast-controller
-    version: 0.0.14
+    version: 0.0.15
     condition: global.snapcast
   - name: virtual-controller
     version: 0.2.13

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
     version: 0.1.17
     condition: global.energyMonitor
   - name: event
-    version: 0.0.7
+    version: 0.0.8
     condition: global.event
   - name: mosquitto
     version: 0.3.4

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -45,7 +45,7 @@ dependencies:
     version: 0.1.25
     condition: global.harmony
   - name: lifx-controller
-    version: 0.1.17
+    version: 0.1.18
     condition: global.lifx
   - name: network-controller
     version: 0.1.18

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -29,7 +29,7 @@ dependencies:
     repository: oci://ghcr.io/stakater/charts
     condition: global.reloader
   - name: scheduler
-    version: 0.2.18
+    version: 0.2.19
     condition: global.scheduler
   - name: smarter-device-manager
     version: 0.1.3

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -56,5 +56,5 @@ dependencies:
   - name: virtual-controller
     version: 0.2.12
   - name: zigbee-controller
-    version: 0.2.9
+    version: 0.2.10
     condition: global.zigbee

--- a/kubernetes/charts/energenie-controller/Chart.yaml
+++ b/kubernetes/charts/energenie-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: energenie-controller
 description: A Helm chart for the PowerPi Energenie device controller
 type: application
-version: 0.1.17
-appVersion: 0.3.7-rc.4
+version: 0.1.18
+appVersion: 0.3.7-rc.5

--- a/kubernetes/charts/event/Chart.yaml
+++ b/kubernetes/charts/event/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: event
 description: A Helm chart for the PowerPi event service
 type: application
-version: 0.0.7
-appVersion: 0.0.4-rc.4
+version: 0.0.8
+appVersion: 0.0.4-rc.5

--- a/kubernetes/charts/harmony-controller/Chart.yaml
+++ b/kubernetes/charts/harmony-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: harmony-controller
 description: A Helm chart for the PowerPi Logitech Harmony device controller
 type: application
-version: 0.1.24
-appVersion: 0.4.10-rc.6
+version: 0.1.25
+appVersion: 0.4.10-rc.7

--- a/kubernetes/charts/lifx-controller/Chart.yaml
+++ b/kubernetes/charts/lifx-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lifx-controller
 description: A Helm chart for the PowerPi LIFX device controller
 type: application
-version: 0.1.17
-appVersion: 0.6.6-rc.4
+version: 0.1.18
+appVersion: 0.6.6-rc.5

--- a/kubernetes/charts/mosquitto/acl.conf
+++ b/kubernetes/charts/mosquitto/acl.conf
@@ -18,6 +18,12 @@ topic readwrite powerpi/device/#
 topic readwrite powerpi/event/#
 topic readwrite powerpi/presence/#
 
+user virtual_controller
+topic read powerpi/config/devices/change
+topic readwrite powerpi/device/#
+topic readwrite powerpi/event/#
+topic read powerpi/presence/#
+
 user device
 topic read powerpi/device/+/change
 topic readwrite powerpi/device/+/status
@@ -28,6 +34,7 @@ topic read powerpi/device/#
 topic read powerpi/event/#
 topic readwrite powerpi/device/+/change
 topic readwrite powerpi/device/+/scene
+topic read powerpi/presence/#
 
 user persistence
 topic read powerpi/config/#
@@ -38,6 +45,7 @@ user scheduler
 topic read powerpi/device/#
 topic read powerpi/event/#
 topic readwrite powerpi/device/+/change
+topic read powerpi/presence/#
 
 user sensor
 topic read powerpi/config/#

--- a/kubernetes/charts/mosquitto/templates/secret.yaml
+++ b/kubernetes/charts/mosquitto/templates/secret.yaml
@@ -8,6 +8,7 @@
 {{- $passwords := (list
   (print "api:" .Params.ApiSecret)
   (print "controller:" .Params.ControllerSecret)
+  (print "virtual-controller:" .Params.VirtualControllerSecret)
 ) -}}
 {{- if eq .Values.global.network true -}}
 {{- $passwords = append $passwords (print "network-controller:" .Params.NetworkControllerSecret) -}}
@@ -63,6 +64,10 @@
 )) . ) -}}
 {{- end -}}
 
+{{- $virtualControllerSecret := include "powerpi.generate-mosquitto-secret" (merge (dict "Params" (dict
+  "Name" "mosquitto-virtual-controller-secret"
+)) . ) -}}
+
 {{- if eq .Values.global.useSensors true -}}
 {{- $deviceSecret = include "powerpi.generate-mosquitto-secret" (merge (dict "Params" (dict
   "Name" "mosquitto-device-secret"
@@ -99,6 +104,7 @@
   "ConfigSecret" ($configSecret | b64dec)
   "ControllerSecret" ($controllerSecret | b64dec)
   "NetworkControllerSecret" ($networkControllerSecret | b64dec)
+  "VirtualControllerSecret" ($virtualControllerSecret | b64dec)
   "DeviceSecret" ($deviceSecret | b64dec)
   "PersistenceSecret" ($persistenceSecret | b64dec)
   "EventSecret" ($eventSecret | b64dec)
@@ -163,6 +169,17 @@ data:
   password: {{ $networkControllerSecret | quote }}
 ---
 {{- end -}}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mosquitto-virtual-controller-secret
+  {{- include "powerpi.labels" . }}
+type: Opaque
+data:
+  username: {{ "virtual-controller" | b64enc | quote }}
+  password: {{ $virtualControllerSecret | quote }}
+---
 
 {{- if eq .Values.global.useSensors true -}}
 apiVersion: v1

--- a/kubernetes/charts/network-controller/Chart.yaml
+++ b/kubernetes/charts/network-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: network-controller
 description: A Helm chart for the PowerPi Network device controller
 type: application
-version: 0.1.17
-appVersion: 0.3.0-rc.1
+version: 0.1.18
+appVersion: 0.3.0-rc.2

--- a/kubernetes/charts/scheduler/Chart.yaml
+++ b/kubernetes/charts/scheduler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: scheduler
 description: A Helm chart for the PowerPi scheduler service
 type: application
-version: 0.2.18
-appVersion: 1.5.2-rc.4
+version: 0.2.19
+appVersion: 1.5.2-rc.5

--- a/kubernetes/charts/snapcast-controller/Chart.yaml
+++ b/kubernetes/charts/snapcast-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: snapcast-controller
 description: A Helm chart for the PowerPi snapcast device controller
 type: application
-version: 0.0.14
-appVersion: 0.0.10-rc.5
+version: 0.0.15
+appVersion: 0.0.10-rc.6

--- a/kubernetes/charts/virtual-controller/Chart.yaml
+++ b/kubernetes/charts/virtual-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: virtual-controller
 description: A Helm chart for the PowerPi virtual device controller
 type: application
-version: 0.2.12
-appVersion: 2.2.2-rc.4
+version: 0.2.13
+appVersion: 2.2.2-rc.5

--- a/kubernetes/charts/virtual-controller/templates/deployment.yaml
+++ b/kubernetes/charts/virtual-controller/templates/deployment.yaml
@@ -1,1 +1,6 @@
-{{- include "powerpi.controller" (merge (dict "Params" dict) . )}}
+{{-
+    $data := dict
+        "MqttSecret" "mosquitto-virtual-controller-secret"
+-}}
+
+{{- include "powerpi.controller" (merge (dict "Params" $data) . ) -}}

--- a/kubernetes/charts/zigbee-controller/Chart.yaml
+++ b/kubernetes/charts/zigbee-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: zigbee-controller
 description: A Helm chart for the PowerPi ZigBee device controller
 type: application
-version: 0.2.9
-appVersion: 0.8.0-rc.8
+version: 0.2.10
+appVersion: 0.8.0-rc.9

--- a/services/event/pyproject.toml
+++ b/services/event/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "event"
-version = "0.0.4-rc.4"
+version = "0.0.4-rc.5"
 description = "PowerPi Event Service"
 license = "GPL-3.0-only"
 authors = [

--- a/services/scheduler/pyproject.toml
+++ b/services/scheduler/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scheduler"
-version = "1.5.2-rc.4"
+version = "1.5.2-rc.5"
 description = "PowerPi Scheduler Service"
 license = "GPL-3.0-only"
 authors = [


### PR DESCRIPTION
Resolves #757 
- Add support for presence sensor variables in conditions `{'var': 'presence.Person.state'}`.
- Add `PresenceVariable` using sensor consumer to listen to the message queue when registered.
- Move the `PresenceStatus` enum into common.
- Add `MQTTTopic` enum for the base topics.
- Grant permission to the topic for the `event`, `scheduler` and `virtual-controller` services, as these are the only ones that can use conditions.
- `virtual-controller` now needs its own secret for the additional permission.