### PR TITLE
#757,#720 fix(k8s): MQTT permissions were wrong on controllers

### DIFF
--- a/kubernetes/charts/mosquitto/acl.conf
+++ b/kubernetes/charts/mosquitto/acl.conf
@@ -8,18 +8,15 @@ user config
 topic readwrite powerpi/config/#
 
 user controller
-topic read powerpi/config/devices/change
 topic readwrite powerpi/device/#
 topic readwrite powerpi/event/#
 
 user network_controller
-topic read powerpi/config/devices/change
 topic readwrite powerpi/device/#
 topic readwrite powerpi/event/#
 topic readwrite powerpi/presence/#
 
 user virtual_controller
-topic read powerpi/config/devices/change
 topic readwrite powerpi/device/#
 topic readwrite powerpi/event/#
 topic read powerpi/presence/#

--- a/kubernetes/charts/mosquitto/templates/secret.yaml
+++ b/kubernetes/charts/mosquitto/templates/secret.yaml
@@ -8,10 +8,10 @@
 {{- $passwords := (list
   (print "api:" .Params.ApiSecret)
   (print "controller:" .Params.ControllerSecret)
-  (print "virtual-controller:" .Params.VirtualControllerSecret)
+  (print "virtual_controller:" .Params.VirtualControllerSecret)
 ) -}}
 {{- if eq .Values.global.network true -}}
-{{- $passwords = append $passwords (print "network-controller:" .Params.NetworkControllerSecret) -}}
+{{- $passwords = append $passwords (print "network_controller:" .Params.NetworkControllerSecret) -}}
 {{- end -}}
 {{- if eq .Values.global.config true -}}
 {{- $passwords = append $passwords (print "config:" .Params.ConfigSecret) -}}
@@ -165,7 +165,7 @@ metadata:
   {{- include "powerpi.labels" . }}
 type: Opaque
 data:
-  username: {{ "network-controller" | b64enc | quote }}
+  username: {{ "network_controller" | b64enc | quote }}
   password: {{ $networkControllerSecret | quote }}
 ---
 {{- end -}}
@@ -177,7 +177,7 @@ metadata:
   {{- include "powerpi.labels" . }}
 type: Opaque
 data:
-  username: {{ "virtual-controller" | b64enc | quote }}
+  username: {{ "virtual_controller" | b64enc | quote }}
   password: {{ $virtualControllerSecret | quote }}
 ---
 


### PR DESCRIPTION
#720 - Controllers still had config permissions which they don't need anymore.
#757 - When adding the users for the `virtual-controller` and `network-controller` the username in the secret and the ACL did not match, so they connected to MQTT fine but then were unable to send or receive messages.