### PR TITLE
#114 feat(virtual): Add geofence sensor

### DIFF
--- a/common/pytest/powerpi_common_test/device/additional_state.py
+++ b/common/pytest/powerpi_common_test/device/additional_state.py
@@ -1,5 +1,4 @@
-from datetime import datetime
-from typing import Any, Dict
+from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 from powerpi_common.device import AdditionalStateDevice
@@ -34,7 +33,7 @@ class AdditionalStateDeviceTestBase(DeviceTestBase):
         key = subject._additional_state_keys()[0]
         message = {
             'state': 'on',
-            'timestamp': int(datetime.utcnow().timestamp() * 1000),
+            'timestamp': int(datetime.now(timezone.utc).timestamp() * 1000),
         }
         message[key] = 1
 
@@ -59,7 +58,7 @@ class AdditionalStateDeviceTestBase(DeviceTestBase):
         # capture the published messages
         messages = []
 
-        def capture(_: str, message: Dict[str, Any]):
+        def capture(_: str, message: dict[str, any]):
             messages.append(message)
 
         powerpi_mqtt_producer.side_effect = capture

--- a/common/pytest/powerpi_common_test/device/device.py
+++ b/common/pytest/powerpi_common_test/device/device.py
@@ -1,9 +1,8 @@
-from datetime import datetime
-from typing import Dict
+from datetime import datetime, timezone
 
 from powerpi_common.config import Config
 from powerpi_common.device import Device
-from powerpi_common.mqtt import MQTTClient, MQTTConsumer
+from powerpi_common.mqtt import MQTTClient, MQTTConsumer, MQTTConsumerPriority
 from pytest_mock import MockerFixture
 
 import pytest
@@ -11,7 +10,7 @@ from powerpi_common_test.device.base import BaseDeviceTestBase
 
 
 class DeviceTestBase(BaseDeviceTestBase):
-    _mqtt_consumers: Dict[str, MQTTConsumer] = {}
+    _mqtt_consumers: dict[str, MQTTConsumer] = {}
 
     @property
     def _initial_state_consumer(self):
@@ -34,7 +33,7 @@ class DeviceTestBase(BaseDeviceTestBase):
     async def test_change_message(self, subject: Device, times: int):
         message = {
             'state': 'on',
-            'timestamp': int(datetime.utcnow().timestamp() * 1000)
+            'timestamp': int(datetime.now(timezone.utc).timestamp() * 1000)
         }
 
         initial_state = 'unknown'
@@ -63,7 +62,7 @@ class DeviceTestBase(BaseDeviceTestBase):
     async def test_wrong_change_message(self, subject: Device):
         message = {
             'state': 'on',
-            'timestamp': int(datetime.utcnow().timestamp() * 1000)
+            'timestamp': int(datetime.now(timezone.utc).timestamp() * 1000)
         }
 
         assert subject.state == 'unknown'
@@ -74,7 +73,7 @@ class DeviceTestBase(BaseDeviceTestBase):
     async def test_bad_state_change_message(self, subject: Device):
         message = {
             'state': 'notastate',
-            'timestamp': int(datetime.utcnow().timestamp() * 1000)
+            'timestamp': int(datetime.now(timezone.utc).timestamp() * 1000)
         }
 
         assert subject.state == 'unknown'
@@ -84,7 +83,7 @@ class DeviceTestBase(BaseDeviceTestBase):
     @pytest.mark.asyncio
     async def test_missing_state_change_message(self, subject: Device):
         message = {
-            'timestamp': int(datetime.utcnow().timestamp() * 1000)
+            'timestamp': int(datetime.now(timezone.utc).timestamp() * 1000)
         }
 
         assert subject.state == 'unknown'
@@ -115,7 +114,10 @@ class DeviceTestBase(BaseDeviceTestBase):
 
     @pytest.fixture(autouse=True)
     def powerpi_mqtt_consumers(self, powerpi_mqtt_client: MQTTClient, mocker: MockerFixture):
-        def add_consumer(consumer: MQTTConsumer):
+        def add_consumer(
+            consumer: MQTTConsumer,
+            _priority: MQTTConsumerPriority = MQTTConsumerPriority.VALUE
+        ):
             split = consumer.topic.split('/')
             self._mqtt_consumers[split[-1]] = consumer
 

--- a/common/python/powerpi_common/application.py
+++ b/common/python/powerpi_common/application.py
@@ -1,5 +1,9 @@
-from asyncio import (CancelledError, ensure_future, get_event_loop,
-                     get_running_loop)
+from asyncio import (
+    CancelledError,
+    ensure_future,
+    get_event_loop,
+    get_running_loop
+)
 from signal import SIGINT, SIGTERM
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -69,10 +73,15 @@ class Application(LogMixin):
             # start any custom parts of this app
             await self._app_start()
 
+            # subscriber to all the topics that have been listened to
+            self.__mqtt_client.subscribe()
+
             # loop forever
             await get_running_loop().create_future()
         except CancelledError:
             await self.__cleanup()
+
+            raise
 
     async def __cleanup(self):
         self.__scheduler.shutdown()

--- a/common/python/powerpi_common/condition/__init__.py
+++ b/common/python/powerpi_common/condition/__init__.py
@@ -2,3 +2,4 @@ from .container import ConditionContainer
 from .errors import InvalidArgumentException, InvalidIdentifierException, ParseException, \
     UnexpectedTokenException
 from .parser import ConditionParser, Expression
+from .visitor import ConditionVisitor

--- a/common/python/powerpi_common/condition/parser.py
+++ b/common/python/powerpi_common/condition/parser.py
@@ -10,7 +10,8 @@ from powerpi_common.mqtt import MQTTMessage
 from powerpi_common.variable import VariableManager, VariableType
 
 Number = int | float
-Expression = dict | list | str | bool | Number
+Constant = str | bool | Number
+Expression = dict | list | Constant
 
 
 class ConditionParser:
@@ -53,14 +54,14 @@ class ConditionParser:
         self.__message = message
 
     @classmethod
-    def constant(cls, constant: str | Number):
+    def constant(cls, constant: Constant):
         '''
         Evaluate and return the constant in the parameter.
         '''
         if constant is None:
             return None
 
-        if isinstance(constant, (bool, str, Number)):
+        if isinstance(constant, Constant):
             return constant
 
         raise UnexpectedTokenException(constant)

--- a/common/python/powerpi_common/condition/visitor.py
+++ b/common/python/powerpi_common/condition/visitor.py
@@ -1,0 +1,121 @@
+from abc import ABC
+
+from powerpi_common.condition.parser import Constant, Expression, Lexeme
+from powerpi_common.condition.errors import ParseException
+
+
+class ConditionVisitor(ABC):
+    '''
+    A ConditionVisitor which can be extended to parse a condition expression to find
+    specific nodes in the condition.
+    '''
+
+    __lexeme_mapping = {
+        Lexeme.WHEN: Lexeme.AND,
+        Lexeme.S_AND: Lexeme.AND,
+        Lexeme.EITHER: Lexeme.OR,
+        Lexeme.S_OR: Lexeme.OR,
+        Lexeme.S_NOT: Lexeme.NOT,
+        Lexeme.S_EQUAL: Lexeme.EQUALS,
+        Lexeme.S_GREATER_THAN: Lexeme.GREATER_THAN,
+        Lexeme.S_GREATER_THAN_EQUAL: Lexeme.GREATER_THAN_EQUAL,
+        Lexeme.S_LESS_THAN: Lexeme.LESS_THAN,
+        Lexeme.S_LESS_THAN_EQUAL: Lexeme.LESS_THAN_EQUAL,
+        Lexeme.S_ADD: Lexeme.ADD,
+        Lexeme.S_SUBTRACT: Lexeme.SUBTRACT,
+        Lexeme.S_MULTIPLY: Lexeme.MULTIPLY,
+        Lexeme.S_DIVIDE: Lexeme.DIVIDE
+    }
+
+    def visit(self, node: Expression):
+        if isinstance(node, dict):
+            for key, value in node.items():
+                # convert to the lexeme alias, if there is one
+                lexeme = self.__lexeme_mapping.get(key, key)
+
+                # call the visitor for this key
+                method = getattr(
+                    self, f'visit_{lexeme}', self.generic_visit
+                )
+                method(value)
+        elif isinstance(node, list):
+            # call the visitor for each item in the list
+            for item in node:
+                self.visit(item)
+        elif isinstance(node, Constant):
+            self.visit_constant(node)
+        else:
+            self.generic_visit(node)
+
+    def visit_and(self, expression: Expression):
+        '''
+        Override to consume an and/when expression.
+        '''
+
+    def visit_or(self, expression: Expression):
+        '''
+        Override to consume an or/either expression.
+        '''
+
+    def visit_not(self, expression: Expression):
+        '''
+        Override to consume a not expression.
+        '''
+
+    def visit_equals(self, expression: Expression):
+        '''
+        Override to consume an equals expression.
+        '''
+
+    def visit_greater_than(self, expression: Expression):
+        '''
+        Override to consume a greater_than expression.
+        '''
+
+    def visit_greater_than_equal(self, expression: Expression):
+        '''
+        Override to consume a greater_than_equal expression.
+        '''
+
+    def visit_less_than(self, expression: Expression):
+        '''
+        Override to consume a less_than expression.
+        '''
+
+    def visit_less_than_equal(self, expression: Expression):
+        '''
+        Override to consume a less_than_equal expression.
+        '''
+
+    def visit_add(self, expression: Expression):
+        '''
+        Override to consume an add expression.
+        '''
+
+    def visit_subtract(self, expression: Expression):
+        '''
+        Override to consume a subtract expression.
+        '''
+
+    def visit_multiply(self, expression: Expression):
+        '''
+        Override to consume a multiply expression.
+        '''
+
+    def visit_divide(self, expression: Expression):
+        '''
+        Override to consume a divide expression.
+        '''
+
+    def visit_var(self, expression: Expression):
+        '''
+        Override to consume a var expression.
+        '''
+
+    def visit_constant(self, value: Constant):
+        '''
+        Override to consume a constant.
+        '''
+
+    def generic_visit(self, expression: Expression):
+        raise ParseException()

--- a/common/python/powerpi_common/condition/visitor.py
+++ b/common/python/powerpi_common/condition/visitor.py
@@ -38,6 +38,9 @@ class ConditionVisitor(ABC):
                     self, f'visit_{lexeme}', self.generic_visit
                 )
                 method(value)
+
+                # and recurse so we see the nested expression too
+                self.visit(value)
         elif isinstance(node, list):
             # call the visitor for each item in the list
             for item in node:
@@ -107,7 +110,7 @@ class ConditionVisitor(ABC):
         Override to consume a divide expression.
         '''
 
-    def visit_var(self, expression: Expression):
+    def visit_var(self, identifier: str):
         '''
         Override to consume a var expression.
         '''

--- a/common/python/powerpi_common/device/device.py
+++ b/common/python/powerpi_common/device/device.py
@@ -5,11 +5,13 @@ from typing import Awaitable, Callable
 from powerpi_common.config import Config
 from powerpi_common.device.types import DeviceStatus
 from powerpi_common.logger import Logger
-from powerpi_common.mqtt import MQTTClient
+from powerpi_common.mqtt import MQTTConsumerPriority, MQTTClient
 
 from .base import BaseDevice
-from .consumers import (DeviceChangeEventConsumer,
-                        DeviceInitialStatusEventConsumer)
+from .consumers import (
+    DeviceChangeEventConsumer,
+    DeviceInitialStatusEventConsumer
+)
 
 
 class Device(BaseDevice, DeviceChangeEventConsumer):
@@ -38,7 +40,7 @@ class Device(BaseDevice, DeviceChangeEventConsumer):
         self.__lock = Lock()
 
         if listener:
-            mqtt_client.add_consumer(self)
+            mqtt_client.add_consumer(self, MQTTConsumerPriority.LOGIC)
 
         # add listener to get the initial state from the queue, if there is one
         DeviceInitialStatusEventConsumer(self, config, logger, mqtt_client)

--- a/common/python/powerpi_common/device/mixin/orchestrator.py
+++ b/common/python/powerpi_common/device/mixin/orchestrator.py
@@ -9,7 +9,7 @@ from powerpi_common.device.consumers.status_event_consumer import \
     DeviceStatusEventConsumer
 from powerpi_common.device.types import DeviceStatus
 from powerpi_common.logger import Logger
-from powerpi_common.mqtt import MQTTClient, MQTTMessage
+from powerpi_common.mqtt import MQTTConsumerPriority, MQTTClient, MQTTMessage
 from powerpi_common.typing import DeviceManagerType, DeviceType
 from powerpi_common.util.data import DataType, Range
 
@@ -165,11 +165,15 @@ class DeviceOrchestratorMixin(InitialisableMixin, CapabilityMixin):
                 self, device, self.__config, self.__logger
             )
 
-            self.__mqtt_client.add_consumer(state_listener)
+            self.__mqtt_client.add_consumer(
+                state_listener, MQTTConsumerPriority.LOGIC
+            )
 
             if self.__capability_enabled:
                 capability_listener = self.ReferencedCapabilityEventListener(
                     self, device, self.__config, self.__logger
                 )
 
-                self.__mqtt_client.add_consumer(capability_listener)
+                self.__mqtt_client.add_consumer(
+                    capability_listener, MQTTConsumerPriority.LOGIC
+                )

--- a/common/python/powerpi_common/mqtt/__init__.py
+++ b/common/python/powerpi_common/mqtt/__init__.py
@@ -1,3 +1,3 @@
 from .client import MQTTClient
 from .consumer import MQTTConsumer
-from .types import MQTTMessage, MQTTTopic
+from .types import MQTTConsumerPriority, MQTTMessage, MQTTTopic

--- a/common/python/powerpi_common/mqtt/client.py
+++ b/common/python/powerpi_common/mqtt/client.py
@@ -51,19 +51,12 @@ class MQTTClient:
     ):
         key = consumer.topic
 
-        new_topic = False
         if key not in self.__consumers:
             self.__consumers[key] = {}
-            new_topic = True
         if priority not in self.__consumers[key]:
             self.__consumers[key][priority] = []
 
         self.__consumers[key][priority].append(consumer)
-
-        if new_topic:
-            topic = f'{self.__config.topic_base}/{key}'
-            self.__logger.info('Subscribing to topic "%s"', topic)
-            self.__client.subscribe(topic)
 
     def remove_consumer(self, consumer: MQTTConsumer):
         key = consumer.topic
@@ -129,6 +122,12 @@ class MQTTClient:
     async def disconnect(self):
         self.__logger.info('Disconnecting from MQTT')
         await self.__client.disconnect()
+
+    def subscribe(self):
+        for key in self.__consumers:
+            topic = f'{self.__config.topic_base}/{key}'
+            self.__logger.info('Subscribing to topic "%s"', topic)
+            self.__client.subscribe(topic)
 
     def __on_connect(self, _, __, result_code: int, ___):
         if result_code == 0:

--- a/common/python/powerpi_common/mqtt/client.py
+++ b/common/python/powerpi_common/mqtt/client.py
@@ -3,8 +3,7 @@ import logging
 import socket
 import sys
 import time
-from datetime import datetime
-from typing import Dict
+from datetime import datetime, timezone
 from urllib.parse import urlparse
 
 import gmqtt
@@ -75,7 +74,9 @@ class MQTTClient:
     def add_producer(self):
         def publish(topic: str, message: MQTTMessage):
             # add the timestamp to the message
-            message['timestamp'] = int(datetime.utcnow().timestamp() * 1000)
+            message['timestamp'] = int(
+                datetime.now(timezone.utc).timestamp() * 1000
+            )
 
             topic = f'{self.__config.topic_base}/{topic}'
 
@@ -145,7 +146,7 @@ class MQTTClient:
         self.__logger.info('MQTT disconnected')
         sys.exit(-1)
 
-    async def __on_message(self, _, topic: str, payload: Dict, __, ___):
+    async def __on_message(self, _, topic: str, payload: dict, __, ___):
         # read the JSON
         message: MQTTMessage = json.loads(payload)
         self.__logger.debug('Received: %s:%s', topic, json.dumps(message))
@@ -166,7 +167,7 @@ class MQTTClient:
                             await consumer.on_message(message, entity, action)
                         except Exception as ex:
                             self.__logger.exception(
-                                Exception(f'{type(consumer)}.on_message', ex)
+                                MQTTMessageException(consumer, ex)
                             )
 
         return gmqtt.constants.PubRecReasonCode.SUCCESS
@@ -187,3 +188,8 @@ class MQTTClient:
             if counter == self.__config.mqtt_connect_timeout:
                 self.__logger.error('Giving up connecting to MQTT')
                 sys.exit(-1)
+
+
+class MQTTMessageException(Exception):
+    def __init__(self, consumer: MQTTConsumer, ex: Exception):
+        Exception.__init__(self, f'{type(consumer)}.on_message', ex)

--- a/common/python/powerpi_common/mqtt/client.py
+++ b/common/python/powerpi_common/mqtt/client.py
@@ -63,7 +63,8 @@ class MQTTClient:
 
         if key in self.__consumers:
             for priority in MQTTConsumerPriority:
-                if priority in self.__consumers[key]:
+                if priority in self.__consumers[key] \
+                        and consumer in self.__consumers[key][priority]:
                     self.__consumers[key][priority].remove(consumer)
 
             if all(len(consumers) == 0 for consumers in self.__consumers[key].values()):

--- a/common/python/powerpi_common/mqtt/client.py
+++ b/common/python/powerpi_common/mqtt/client.py
@@ -4,7 +4,7 @@ import socket
 import sys
 import time
 from datetime import datetime
-from typing import Dict, List
+from typing import Dict
 from urllib.parse import urlparse
 
 import gmqtt
@@ -14,11 +14,11 @@ from powerpi_common.config import Config
 from powerpi_common.logger import Logger
 
 from .consumer import MQTTConsumer
-from .types import MQTTMessage
+from .types import MQTTConsumerPriority, MQTTMessage
 
 
 class MQTTClient:
-    __consumers: Dict[str, List[MQTTConsumer]]
+    __consumers: dict[str, dict[MQTTConsumerPriority, list[MQTTConsumer]]]
 
     def __init__(
         self,
@@ -44,15 +44,21 @@ class MQTTClient:
     def connected(self):
         return self.__connected
 
-    def add_consumer(self, consumer: MQTTConsumer):
+    def add_consumer(
+        self,
+        consumer: MQTTConsumer,
+        priority: MQTTConsumerPriority = MQTTConsumerPriority.VALUE
+    ):
         key = consumer.topic
 
         new_topic = False
-        if not key in self.__consumers:
-            self.__consumers[key] = []
+        if key not in self.__consumers:
+            self.__consumers[key] = {}
             new_topic = True
+        if priority not in self.__consumers[key]:
+            self.__consumers[key][priority] = []
 
-        self.__consumers[key].append(consumer)
+        self.__consumers[key][priority].append(consumer)
 
         if new_topic:
             topic = f'{self.__config.topic_base}/{key}'
@@ -63,12 +69,14 @@ class MQTTClient:
         key = consumer.topic
 
         if key in self.__consumers:
-            self.__consumers[key].remove(consumer)
+            for priority in MQTTConsumerPriority:
+                if priority in self.__consumers[key]:
+                    self.__consumers[key][priority].remove(consumer)
 
-        if len(self.__consumers.get(key, [])) == 0:
-            topic = f'{self.__config.topic_base}/{key}'
-            self.__logger.info('Unsubscribing from topic "%s"', topic)
-            self.__client.unsubscribe(topic)
+            if all(len(consumers) == 0 for consumers in self.__consumers[key].values()):
+                topic = f'{self.__config.topic_base}/{key}'
+                self.__logger.info('Unsubscribing from topic "%s"', topic)
+                self.__client.unsubscribe(topic)
 
     def add_producer(self):
         def publish(topic: str, message: MQTTMessage):
@@ -112,7 +120,7 @@ class MQTTClient:
         self.__client.on_message = self.__on_message
 
         await self.__client.connect(
-            url.hostname, 
+            url.hostname,
             url.port,
             ssl=True if url.scheme == 'mqtts' else False,
             version=gmqtt.constants.MQTTv311
@@ -131,7 +139,6 @@ class MQTTClient:
                 'MQTT connection failed with code %d',
                 result_code
             )
-            return
 
     def __on_disconnect(self, _, __):
         self.__connected = False
@@ -151,14 +158,16 @@ class MQTTClient:
 
         # send the message to the correct consumers
         if listener_key in self.__consumers:
-            for consumer in self.__consumers[listener_key]:
-                # pylint: disable=broad-except
-                try:
-                    await consumer.on_message(message, entity, action)
-                except Exception as ex:
-                    self.__logger.exception(
-                        Exception(f'{type(consumer)}.on_message', ex)
-                    )
+            for priority in MQTTConsumerPriority:
+                if priority in self.__consumers[listener_key]:
+                    for consumer in self.__consumers[listener_key][priority]:
+                        # pylint: disable=broad-except
+                        try:
+                            await consumer.on_message(message, entity, action)
+                        except Exception as ex:
+                            self.__logger.exception(
+                                Exception(f'{type(consumer)}.on_message', ex)
+                            )
 
         return gmqtt.constants.PubRecReasonCode.SUCCESS
 

--- a/common/python/powerpi_common/mqtt/consumer.py
+++ b/common/python/powerpi_common/mqtt/consumer.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from datetime import datetime
+from datetime import datetime, timezone
 
 from powerpi_common.config import Config
 from powerpi_common.logger import Logger, LogMixin
@@ -21,8 +21,8 @@ class MQTTConsumer(ABC, LogMixin):
         raise NotImplementedError
 
     def is_timestamp_valid(self, timestamp: int | None):
-        # check age of message is within cutoff
-        now = int(datetime.utcnow().timestamp() * 1000)
+        # check age of message is within cut-off
+        now = int(datetime.now(timezone.utc).timestamp() * 1000)
         if timestamp < now - (self._config.message_age_cutoff * 1000):
             self._logger.info('Ignoring old message')
             return False

--- a/common/python/powerpi_common/mqtt/types.py
+++ b/common/python/powerpi_common/mqtt/types.py
@@ -9,3 +9,4 @@ class MQTTTopic(StrEnum):
     DEVICE = 'device'
     EVENT = 'event'
     PRESENCE = 'presence'
+    GEOFENCE = 'geofence'

--- a/common/python/powerpi_common/mqtt/types.py
+++ b/common/python/powerpi_common/mqtt/types.py
@@ -1,4 +1,4 @@
-from enum import unique, StrEnum
+from enum import unique, IntEnum, StrEnum
 
 MQTTMessage = dict[str, any]
 
@@ -10,3 +10,11 @@ class MQTTTopic(StrEnum):
     EVENT = 'event'
     PRESENCE = 'presence'
     GEOFENCE = 'geofence'
+
+
+@unique
+class MQTTConsumerPriority(IntEnum):
+    # For a consumer storing the value, e.g. state updates
+    VALUE = 0
+    # For a consumer calculating new values e.g. conditions dependent on variables and change events
+    LOGIC = 1

--- a/common/python/powerpi_common/sensor/consumers/__init__.py
+++ b/common/python/powerpi_common/sensor/consumers/__init__.py
@@ -1,1 +1,2 @@
+from .presence_event_consumer import PresenceEventConsumer
 from .sensor_event_consumer import SensorEventConsumer

--- a/common/python/powerpi_common/sensor/consumers/presence_event_consumer.py
+++ b/common/python/powerpi_common/sensor/consumers/presence_event_consumer.py
@@ -1,0 +1,28 @@
+from powerpi_common.config import Config
+from powerpi_common.logger import Logger
+from powerpi_common.mqtt import MQTTConsumer, MQTTMessage, MQTTTopic
+from powerpi_common.typing import SensorType
+
+
+class PresenceEventConsumer(MQTTConsumer):
+    '''
+    Consumer for reading presence events.
+    '''
+
+    def __init__(
+        self,
+        entity: str,
+        sensor: SensorType,
+        config: Config,
+        logger: Logger
+    ):
+        topic = f'{MQTTTopic.PRESENCE}/{entity}/status'
+        MQTTConsumer.__init__(self, topic, config, logger)
+
+        self._sensor = sensor
+
+    async def on_message(self, message: MQTTMessage, _: str, __: str):
+        state = message.get('state')
+
+        if state is not None:
+            self._sensor.state = state

--- a/common/python/powerpi_common/variable/presence.py
+++ b/common/python/powerpi_common/variable/presence.py
@@ -1,13 +1,13 @@
 from powerpi_common.config import Config
 from powerpi_common.logger import Logger
-from powerpi_common.mqtt import MQTTClient, MQTTTopic
+from powerpi_common.mqtt import MQTTClient
 from powerpi_common.sensor import PresenceStatus
-from powerpi_common.sensor.consumers import SensorEventConsumer
+from powerpi_common.sensor.consumers import PresenceEventConsumer
 from powerpi_common.variable.types import VariableType
 from powerpi_common.variable.variable import Variable
 
 
-class PresenceVariable(Variable, SensorEventConsumer):
+class PresenceVariable(Variable, PresenceEventConsumer):
     '''
     Variable implementation that will receive presence detection events from the message queue.
     '''
@@ -21,9 +21,9 @@ class PresenceVariable(Variable, SensorEventConsumer):
         **kwargs
     ):
         Variable.__init__(self, name, **kwargs)
-        SensorEventConsumer.__init__(
+        PresenceEventConsumer.__init__(
             self,
-            f'{MQTTTopic.PRESENCE}/{name}/status',
+            name,
             self,
             config,
             logger

--- a/common/python/tests/condition/test_visitor.py
+++ b/common/python/tests/condition/test_visitor.py
@@ -1,0 +1,133 @@
+from inspect import currentframe
+
+import pytest
+
+from powerpi_common.condition import ConditionVisitor, ParseException
+from powerpi_common.condition.lexeme import Lexeme
+
+
+class RecordingVisitor(ConditionVisitor):
+    def __init__(self):
+        self.calls: list[tuple[str, object]] = []
+
+    def _record(self, expression):
+        name = currentframe().f_back.f_code.co_name.removeprefix('visit_')
+        self.calls.append((name, expression))
+
+    def visit_and(self, expression):
+        self._record(expression)
+
+    def visit_or(self, expression):
+        self._record(expression)
+
+    def visit_not(self, expression):
+        self._record(expression)
+
+    def visit_equals(self, expression):
+        self._record(expression)
+
+    def visit_greater_than(self, expression):
+        self._record(expression)
+
+    def visit_greater_than_equal(self, expression):
+        self._record(expression)
+
+    def visit_less_than(self, expression):
+        self._record(expression)
+
+    def visit_less_than_equal(self, expression):
+        self._record(expression)
+
+    def visit_add(self, expression):
+        self._record(expression)
+
+    def visit_subtract(self, expression):
+        self._record(expression)
+
+    def visit_multiply(self, expression):
+        self._record(expression)
+
+    def visit_divide(self, expression):
+        self._record(expression)
+
+    def visit_var(self, identifier):
+        self._record(identifier)
+
+    def visit_constant(self, value):
+        self._record(value)
+
+
+_ALIASES = {
+    Lexeme.WHEN: 'and',
+    Lexeme.S_AND: 'and',
+    Lexeme.EITHER: 'or',
+    Lexeme.S_OR: 'or',
+    Lexeme.S_NOT: 'not',
+    Lexeme.S_EQUAL: 'equals',
+    Lexeme.S_GREATER_THAN: 'greater_than',
+    Lexeme.S_GREATER_THAN_EQUAL: 'greater_than_equal',
+    Lexeme.S_LESS_THAN: 'less_than',
+    Lexeme.S_LESS_THAN_EQUAL: 'less_than_equal',
+    Lexeme.S_ADD: 'add',
+    Lexeme.S_SUBTRACT: 'subtract',
+    Lexeme.S_MULTIPLY: 'multiply',
+    Lexeme.S_DIVIDE: 'divide',
+}
+
+
+class TestConditionVisitor:
+
+    @pytest.mark.parametrize('key', list(Lexeme))
+    def test_lexeme_dispatches_to_canonical_visit(self, key: Lexeme):
+        visitor = RecordingVisitor()
+        expected = _ALIASES.get(key, key.value)
+
+        visitor.visit({key: 'payload'})
+
+        assert (expected, 'payload') in visitor.calls
+
+    def test_list_visits_each_item(self):
+        visitor = RecordingVisitor()
+
+        visitor.visit([1, 'two', True])
+
+        assert visitor.calls == [
+            ('constant', 1),
+            ('constant', 'two'),
+            ('constant', True),
+        ]
+
+    @pytest.mark.parametrize('value', ['text', 12, 3.14, False])
+    def test_constant_routes_to_visit_constant(self, value):
+        visitor = RecordingVisitor()
+
+        visitor.visit(value)
+
+        assert visitor.calls == [('constant', value)]
+
+    def test_nested_dict_recurses(self):
+        visitor = RecordingVisitor()
+
+        visitor.visit({
+            Lexeme.WHEN: [
+                {Lexeme.EQUALS: [{Lexeme.VAR: 'device.Light.state'}, 'on']}
+            ]
+        })
+
+        assert ('equals', [
+            {Lexeme.VAR: 'device.Light.state'}, 'on'
+        ]) in visitor.calls
+        assert ('var', 'device.Light.state') in visitor.calls
+        assert ('constant', 'on') in visitor.calls
+
+    def test_unknown_key_raises(self):
+        visitor = RecordingVisitor()
+
+        with pytest.raises(ParseException):
+            visitor.visit({'bogus': 'payload'})
+
+    def test_unknown_type_raises(self):
+        visitor = RecordingVisitor()
+
+        with pytest.raises(ParseException):
+            visitor.visit(object())

--- a/common/python/tests/device/mixin/test_orchestrator.py
+++ b/common/python/tests/device/mixin/test_orchestrator.py
@@ -5,6 +5,7 @@ from powerpi_common_test.device.mixin import DeviceOrchestratorMixinTestBase
 
 from powerpi_common.device import Device, DeviceStatus
 from powerpi_common.device.mixin import DeviceOrchestratorMixin
+from powerpi_common.mqtt import MQTTConsumerPriority
 from powerpi_common.mqtt.consumer import MQTTConsumer
 from powerpi_common.util.data import Range
 
@@ -208,7 +209,10 @@ class TestDeviceOrchestratorMixin(DeviceOrchestratorMixinTestBase):
     def mqtt_client(self, powerpi_mqtt_client):
         self.consumers: Dict[str, MQTTConsumer] = {}
 
-        def add_consumer(consumer: MQTTConsumer):
+        def add_consumer(
+            consumer: MQTTConsumer,
+            _priority: MQTTConsumerPriority = MQTTConsumerPriority.VALUE
+        ):
             self.consumers[consumer.topic] = consumer
 
         powerpi_mqtt_client.add_consumer = add_consumer

--- a/controllers/energenie/pyproject.toml
+++ b/controllers/energenie/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "energenie_controller"
-version = "0.3.7-rc.5"
+version = "0.3.7-rc.6"
 description = "PowerPi Energenie Controller"
 license = "GPL-3.0-only"
 authors = [

--- a/controllers/harmony/pyproject.toml
+++ b/controllers/harmony/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "harmony_controller"
-version = "0.4.10-rc.7"
+version = "0.4.10-rc.8"
 description = "PowerPi Logitech Harmony Controller"
 license = "GPL-3.0-only"
 authors = [

--- a/controllers/lifx/pyproject.toml
+++ b/controllers/lifx/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lifx_controller"
-version = "0.6.6-rc.5"
+version = "0.6.6-rc.6"
 description = "PowerPi LIFX Controller"
 license = "GPL-3.0-only"
 authors = [

--- a/controllers/network/pyproject.toml
+++ b/controllers/network/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "network_controller"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 description = "PowerPi Network Controller"
 license = "GPL-3.0-only"
 authors = [

--- a/controllers/snapcast/pyproject.toml
+++ b/controllers/snapcast/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "snapcast_controller"
-version = "0.0.10-rc.6"
+version = "0.0.10-rc.7"
 description = "PowerPi Snapcast Controller"
 license = "GPL-3.0-only"
 authors = [

--- a/controllers/virtual/pyproject.toml
+++ b/controllers/virtual/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "virtual_controller"
-version = "2.2.2-rc.5"
+version = "2.2.2-rc.6"
 description = "PowerPi Virtual Controller"
 license = "GPL-3.0-only"
 authors = [

--- a/controllers/virtual/tests/conftest.py
+++ b/controllers/virtual/tests/conftest.py
@@ -1,7 +1,11 @@
 # pylint: disable=unused-import
 
 import pytest
-from powerpi_common_test.fixture import (powerpi_config,
-                                         powerpi_device_manager,
-                                         powerpi_logger, powerpi_mqtt_client,
-                                         powerpi_mqtt_producer)
+from powerpi_common_test.fixture import (
+    powerpi_config,
+    powerpi_device_manager,
+    powerpi_logger,
+    powerpi_mqtt_client,
+    powerpi_mqtt_producer,
+    powerpi_variable_manager
+)

--- a/controllers/virtual/tests/sensor/test_geofence.py
+++ b/controllers/virtual/tests/sensor/test_geofence.py
@@ -1,0 +1,230 @@
+from datetime import datetime, timezone
+from unittest.mock import Mock, PropertyMock
+
+import pytest
+
+from powerpi_common.device import DeviceStatus
+from powerpi_common.mqtt import MQTTConsumer, MQTTConsumerPriority
+from powerpi_common_test.sensor import SensorTestBase
+from pytest_mock import MockerFixture
+
+from virtual_controller.sensor.geofence import GeofenceSensor
+
+
+class TestGeofence(SensorTestBase):
+
+    @pytest.mark.asyncio
+    async def test_initialise(
+        self,
+        subject: GeofenceSensor,
+        powerpi_variable_manager: Mock,
+        powerpi_mqtt_producer: Mock,
+        mocker: MockerFixture
+    ):
+        assert subject.state == DeviceStatus.UNKNOWN
+
+        await subject.initialise()
+
+        powerpi_variable_manager.get_device.assert_has_calls([
+            mocker.call('Device')
+        ])
+
+        powerpi_variable_manager.get_presence.assert_has_calls([
+            mocker.call('Presence')
+        ])
+
+        powerpi_variable_manager.get_sensor.assert_has_calls([
+            mocker.call('Sensor', 'motion')
+        ])
+
+        powerpi_mqtt_producer.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_on_message_device(
+        self,
+        subject: GeofenceSensor,
+        powerpi_mqtt_producer: Mock,
+        now: int
+    ):
+        await subject.initialise()
+
+        message = {
+            'state': 'on',
+            'timestamp': now
+        }
+
+        await self.consumers['device/Device/status'] \
+            .on_message(message, 'Device', 'state')
+
+        assert subject.state == DeviceStatus.OFF
+
+        powerpi_mqtt_producer.assert_called_once_with(
+            'geofence/MyGeofence/status',
+            {'state': DeviceStatus.OFF}
+        )
+
+    @pytest.mark.asyncio
+    async def test_on_message_presence(
+        self,
+        subject: GeofenceSensor,
+        powerpi_mqtt_producer: Mock,
+        now: int
+    ):
+        await subject.initialise()
+
+        message = {
+            'state': 'present',
+            'timestamp': now
+        }
+
+        await self.consumers['presence/Presence/status'] \
+            .on_message(message, 'Presence', 'state')
+
+        assert subject.state == DeviceStatus.OFF
+
+        powerpi_mqtt_producer.assert_called_once_with(
+            'geofence/MyGeofence/status',
+            {'state': DeviceStatus.OFF}
+        )
+
+    @pytest.mark.asyncio
+    async def test_on_message_sensor(
+        self,
+        subject: GeofenceSensor,
+        powerpi_mqtt_producer: Mock,
+        now: int
+    ):
+        await subject.initialise()
+
+        message = {
+            'state': 'detected',
+            'timestamp': now
+        }
+
+        await self.consumers['event/Sensor/motion'] \
+            .on_message(message, 'Sensor', 'motion')
+
+        assert subject.state == DeviceStatus.OFF
+
+        powerpi_mqtt_producer.assert_called_once_with(
+            'geofence/MyGeofence/status',
+            {'state': DeviceStatus.OFF}
+        )
+
+    @pytest.mark.asyncio
+    async def test_on_message_old(
+        self,
+        subject: GeofenceSensor,
+        powerpi_mqtt_producer: Mock,
+        now: int
+    ):
+        await subject.initialise()
+
+        message = {
+            'state': 'detected',
+            'timestamp': now - 2 * 60 * 1000
+        }
+
+        await self.consumers['event/Sensor/motion'] \
+            .on_message(message, 'Sensor', 'motion')
+
+        assert subject.state == DeviceStatus.UNKNOWN
+
+        powerpi_mqtt_producer.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_on_message_condition_true(
+        self,
+        subject: GeofenceSensor,
+        powerpi_variable_manager: Mock,
+        powerpi_mqtt_producer: Mock,
+        now: int,
+        mocker: MockerFixture
+    ):
+        device = mocker.MagicMock()
+        type(device).state = PropertyMock(return_value='off')
+
+        presence = mocker.MagicMock()
+        type(presence).state = PropertyMock(return_value='absent')
+
+        sensor = mocker.MagicMock()
+        type(sensor).state = PropertyMock(return_value='detected')
+
+        powerpi_variable_manager.get_device = lambda _: device
+        powerpi_variable_manager.get_presence = lambda _: presence
+        powerpi_variable_manager.get_sensor = lambda *_: sensor
+
+        await subject.initialise()
+
+        message = {
+            'state': 'detected',
+            'timestamp': now
+        }
+
+        await self.consumers['event/Sensor/motion'] \
+            .on_message(message, 'Sensor', 'motion')
+
+        assert subject.state == DeviceStatus.ON
+
+        powerpi_mqtt_producer.assert_called_once_with(
+            'geofence/MyGeofence/status',
+            {'state': DeviceStatus.ON}
+        )
+
+        # repeating the message doesn't rebroadcast
+        await self.consumers['event/Sensor/motion'] \
+            .on_message(message, 'Sensor', 'motion')
+
+        powerpi_mqtt_producer.assert_called_once()
+
+    @pytest.fixture
+    def now(self):
+        return int(
+            datetime.now(timezone.utc).timestamp() * 1000
+        )
+
+    @pytest.fixture
+    def mqtt_client(self, powerpi_mqtt_client):
+        self.consumers: dict[str, MQTTConsumer] = {}
+
+        def add_consumer(
+            consumer: MQTTConsumer,
+            priority: MQTTConsumerPriority
+        ):
+            if consumer.topic in self.consumers:
+                raise KeyError('Repeated consumer')
+
+            self.consumers[consumer.topic] = consumer
+
+            assert priority == MQTTConsumerPriority.LOGIC
+
+        powerpi_mqtt_client.add_consumer = add_consumer
+
+        return powerpi_mqtt_client
+
+    @pytest.fixture
+    def subject(
+        self,
+        powerpi_config,
+        powerpi_logger,
+        mqtt_client,
+        powerpi_variable_manager
+    ):
+        return GeofenceSensor(
+            powerpi_config,
+            powerpi_logger,
+            mqtt_client,
+            powerpi_variable_manager,
+            name='MyGeofence',
+            condition={
+                'when': [
+                    {'equals': [{'var': 'presence.Presence.state'}, 'absent']},
+                    {'equals': [{'var': 'presence.Presence.state'}, 'absent']},
+                    {'equals': [{'var': 'device.Device.state'}, 'off']},
+                    {'equals': [
+                        {'var': 'sensor.Sensor.motion.state'},
+                        'detected'
+                    ]},
+                ]
+            }
+        )

--- a/controllers/virtual/virtual_controller/__main__.py
+++ b/controllers/virtual/virtual_controller/__main__.py
@@ -2,12 +2,14 @@ import sys
 
 from virtual_controller.container import ApplicationContainer
 from virtual_controller.device.container import add_devices
+from virtual_controller.sensor.container import add_sensors
 
 if __name__ == '__main__':
     # initialise DI
     container = ApplicationContainer()
     container.wire(modules=[sys.modules[__name__]])
     add_devices(container)
+    add_sensors(container)
 
     controller = container.common().controller()
     controller.start()

--- a/controllers/virtual/virtual_controller/sensor/container.py
+++ b/controllers/virtual/virtual_controller/sensor/container.py
@@ -1,0 +1,18 @@
+from dependency_injector import providers
+
+from virtual_controller.sensor.geofence import GeofenceSensor
+
+
+def add_sensors(container):
+    device_container = container.common().device()
+
+    setattr(
+        device_container,
+        'geofence_sensor',
+        providers.Factory(
+            GeofenceSensor,
+            logger=container.common.logger,
+            mqtt_client=container.common.mqtt_client,
+            variable_manager=container.common.variable.variable_manager
+        )
+    )

--- a/controllers/virtual/virtual_controller/sensor/container.py
+++ b/controllers/virtual/virtual_controller/sensor/container.py
@@ -11,6 +11,7 @@ def add_sensors(container):
         'geofence_sensor',
         providers.Factory(
             GeofenceSensor,
+            config=container.common.config,
             logger=container.common.logger,
             mqtt_client=container.common.mqtt_client,
             variable_manager=container.common.variable.variable_manager

--- a/controllers/virtual/virtual_controller/sensor/geofence.py
+++ b/controllers/virtual/virtual_controller/sensor/geofence.py
@@ -174,9 +174,10 @@ class GeofenceSensor(Sensor, InitialisableMixin):
             self.__owner = owner
 
         async def on_message(self, message: MQTTMessage, entity: str, action: str):
-            self.__owner.on_message(
-                message,
-                self.__entity_type,
-                entity,
-                action
-            )
+            if self.is_timestamp_valid(message.timestamp):
+                self.__owner.on_message(
+                    message,
+                    self.__entity_type,
+                    entity,
+                    action
+                )

--- a/controllers/virtual/virtual_controller/sensor/geofence.py
+++ b/controllers/virtual/virtual_controller/sensor/geofence.py
@@ -79,7 +79,7 @@ class GeofenceSensor(Sensor, InitialisableMixin):
         # the variable manager is monitoring the referenced devices/sensors
         self.__check_condition()
 
-    def on_message(self, message: MQTTMessage, type: str, entity: str, action: str):
+    def on_message(self):
         # first we check the condition to identify what state we are in
         condition = self.__check_condition()
         new_state = DeviceStatus.ON if condition else DeviceStatus.OFF
@@ -175,9 +175,4 @@ class GeofenceSensor(Sensor, InitialisableMixin):
 
         async def on_message(self, message: MQTTMessage, entity: str, action: str):
             if self.is_timestamp_valid(message.timestamp):
-                self.__owner.on_message(
-                    message,
-                    self.__entity_type,
-                    entity,
-                    action
-                )
+                self.__owner.on_message(self.__entity_type)

--- a/controllers/virtual/virtual_controller/sensor/geofence.py
+++ b/controllers/virtual/virtual_controller/sensor/geofence.py
@@ -143,7 +143,8 @@ class GeofenceSensor(Sensor, InitialisableMixin):
                 return
 
             entity = split[1]
-            data = split[2:]
+            data = split[2]  # either the property or the action
+            # we drop the prop for sensors as we don't monitor that granularity
 
             key = (var_type, entity)
 

--- a/controllers/virtual/virtual_controller/sensor/geofence.py
+++ b/controllers/virtual/virtual_controller/sensor/geofence.py
@@ -72,7 +72,9 @@ class GeofenceSensor(Sensor, InitialisableMixin):
 
                 if consumer is not None:
                     self.__mqtt_client.add_consumer(
-                        consumer, MQTTConsumerPriority.LOGIC)
+                        consumer,
+                        MQTTConsumerPriority.LOGIC
+                    )
 
         # we evaluate the condition during initialisation to ensure
         # the variable manager is monitoring the referenced devices/sensors

--- a/controllers/virtual/virtual_controller/sensor/geofence.py
+++ b/controllers/virtual/virtual_controller/sensor/geofence.py
@@ -1,4 +1,4 @@
-from powerpi_common.condition import ConditionParser, Expression
+from powerpi_common.condition import ConditionParser, ConditionVisitor, Expression
 from powerpi_common.device import DeviceStatus
 from powerpi_common.device.mixin import InitialisableMixin
 from powerpi_common.logger import Logger
@@ -44,6 +44,12 @@ class GeofenceSensor(Sensor, InitialisableMixin):
         return self.__state
 
     async def initialise(self):
+        # we need the list of variables, to register listeners
+        visitor = self._Visitor()
+        visitor.visit(self.__condition)
+        variables = visitor.variables
+        self.log_info('Found variables %s', variables)
+
         # we evaluate the condition during initialisation to ensure
         # the variable manager is monitoring the referenced devices/sensors
         self.__check_condition()
@@ -69,3 +75,17 @@ class GeofenceSensor(Sensor, InitialisableMixin):
         message = {'state': state}
 
         self._producer(topic, message)
+
+    class _Visitor(ConditionVisitor):
+        def __init__(self):
+            self.__variables: dict[str, list[str]] = {}
+
+        @property
+        def variables(self):
+            return self.__variables
+
+        def visit_var(self, identifier: str):
+            split = identifier.split('.')
+            var_type = split[0]
+
+            self.__variables.setdefault(var_type, []).append(split[1:])

--- a/controllers/virtual/virtual_controller/sensor/geofence.py
+++ b/controllers/virtual/virtual_controller/sensor/geofence.py
@@ -78,7 +78,7 @@ class GeofenceSensor(Sensor, InitialisableMixin):
 
     class _Visitor(ConditionVisitor):
         def __init__(self):
-            self.__variables: dict[str, list[str]] = {}
+            self.__variables: dict[tuple[str, str], list[str]] = {}
 
         @property
         def variables(self):
@@ -88,4 +88,15 @@ class GeofenceSensor(Sensor, InitialisableMixin):
             split = identifier.split('.')
             var_type = split[0]
 
-            self.__variables.setdefault(var_type, []).append(split[1:])
+            # messages make no sense for geofence condition
+            if var_type == 'message':
+                return
+
+            entity = split[1]
+            data = split[2:]
+
+            key = (var_type, entity)
+
+            record = self.__variables.setdefault(key, [])
+            if data not in record:
+                record.append(data)

--- a/controllers/virtual/virtual_controller/sensor/geofence.py
+++ b/controllers/virtual/virtual_controller/sensor/geofence.py
@@ -102,8 +102,7 @@ class GeofenceSensor(Sensor, InitialisableMixin):
 
         self._producer(topic, message)
 
-    def __add_device_listener(self, entity: str, value: list[str]):
-        prop = value[0]
+    def __add_device_listener(self, entity: str, prop: str):
         action: str | None = None
 
         if prop == 'state':
@@ -114,16 +113,13 @@ class GeofenceSensor(Sensor, InitialisableMixin):
 
         return None
 
-    def __add_sensor_listener(self, entity: str, value: list[str]):
-        action = value[0]
-
+    def __add_sensor_listener(self, entity: str, action: str):
         if action is not None:
             return self._EventConsumer(self, MQTTTopic.EVENT, entity, action)
 
         return None
 
-    def __add_presence_listener(self, entity: str, value: list[str]):
-        prop = value[0]
+    def __add_presence_listener(self, entity: str, prop: str):
         action: str | None = None
 
         if prop == 'state':
@@ -171,9 +167,8 @@ class GeofenceSensor(Sensor, InitialisableMixin):
             topic = f'{entity_type}/{entity}/{action}'
             MQTTConsumer.__init__(self, topic, owner._config, owner._logger)
 
-            self.__entity_type = entity_type
             self.__owner = owner
 
         async def on_message(self, message: MQTTMessage, entity: str, action: str):
-            if self.is_timestamp_valid(message.timestamp):
-                self.__owner.on_message(self.__entity_type)
+            if self.is_timestamp_valid(message['timestamp']):
+                self.__owner.on_message()

--- a/controllers/virtual/virtual_controller/sensor/geofence.py
+++ b/controllers/virtual/virtual_controller/sensor/geofence.py
@@ -60,8 +60,9 @@ class GeofenceSensor(Sensor, InitialisableMixin):
             for state in states:
                 if key[0] == 'device':
                     consumer = self.__add_device_listener(key[1], state)
-
-                if key[0] == 'presence':
+                elif key[0] == 'sensor':
+                    consumer = self.__add_sensor_listener(key[1], state)
+                elif key[0] == 'presence':
                     consumer = self.__add_presence_listener(key[1], state)
 
                 if consumer is not None:
@@ -102,6 +103,14 @@ class GeofenceSensor(Sensor, InitialisableMixin):
 
         if action is not None:
             return self._EventConsumer(self, MQTTTopic.DEVICE, entity, action)
+
+        return None
+
+    def __add_sensor_listener(self, entity: str, value: list[str]):
+        action = value[0]
+
+        if action is not None:
+            return self._EventConsumer(self, MQTTTopic.EVENT, entity, action)
 
         return None
 

--- a/controllers/virtual/virtual_controller/sensor/geofence.py
+++ b/controllers/virtual/virtual_controller/sensor/geofence.py
@@ -1,8 +1,9 @@
 from powerpi_common.condition import ConditionParser, ConditionVisitor, Expression
+from powerpi_common.config import Config
 from powerpi_common.device import DeviceStatus
 from powerpi_common.device.mixin import InitialisableMixin
 from powerpi_common.logger import Logger
-from powerpi_common.mqtt import MQTTClient, MQTTTopic
+from powerpi_common.mqtt import MQTTClient, MQTTConsumer, MQTTMessage, MQTTTopic
 from powerpi_common.sensor import Sensor
 from powerpi_common.variable import VariableManager
 
@@ -24,6 +25,7 @@ class GeofenceSensor(Sensor, InitialisableMixin):
 
     def __init__(
         self,
+        config: Config,
         logger: Logger,
         mqtt_client: MQTTClient,
         variable_manager: VariableManager,
@@ -32,8 +34,10 @@ class GeofenceSensor(Sensor, InitialisableMixin):
     ):
         Sensor.__init__(self, mqtt_client, **kwargs)
 
+        self._config = config
         self._logger = logger
 
+        self.__mqtt_client = mqtt_client
         self.__variable_manager = variable_manager
         self.__condition = condition
 
@@ -50,11 +54,24 @@ class GeofenceSensor(Sensor, InitialisableMixin):
         variables = visitor.variables
         self.log_info('Found variables %s', variables)
 
+        # now we need to add the listeners
+        consumer: MQTTConsumer | None = None
+        for key, states in variables.items():
+            for state in states:
+                if key[0] == 'device':
+                    consumer = self.__add_device_listener(key[1], state)
+
+                if key[0] == 'presence':
+                    consumer = self.__add_presence_listener(key[1], state)
+
+                if consumer is not None:
+                    self.__mqtt_client.add_consumer(consumer)
+
         # we evaluate the condition during initialisation to ensure
         # the variable manager is monitoring the referenced devices/sensors
         self.__check_condition()
 
-    def on_message(self):
+    def on_message(self, message: MQTTMessage, type: str, entity: str, action: str):
         # first we check the condition to identify what state we are in
         condition = self.__check_condition()
         new_state = DeviceStatus.ON if condition else DeviceStatus.OFF
@@ -75,6 +92,30 @@ class GeofenceSensor(Sensor, InitialisableMixin):
         message = {'state': state}
 
         self._producer(topic, message)
+
+    def __add_device_listener(self, entity: str, value: list[str]):
+        prop = value[0]
+        action: str | None = None
+
+        if prop == 'state':
+            action = 'status'
+
+        if action is not None:
+            return self._EventConsumer(self, MQTTTopic.DEVICE, entity, action)
+
+        return None
+
+    def __add_presence_listener(self, entity: str, value: list[str]):
+        prop = value[0]
+        action: str | None = None
+
+        if prop == 'state':
+            action = 'status'
+
+        if action is not None:
+            return self._EventConsumer(self, MQTTTopic.PRESENCE, entity, action)
+
+        return None
 
     class _Visitor(ConditionVisitor):
         def __init__(self):
@@ -100,3 +141,25 @@ class GeofenceSensor(Sensor, InitialisableMixin):
             record = self.__variables.setdefault(key, [])
             if data not in record:
                 record.append(data)
+
+    class _EventConsumer(MQTTConsumer):
+        def __init__(
+            self,
+            owner: 'GeofenceSensor',
+            entity_type: str,
+            entity: str,
+            action: str,
+        ):
+            topic = f'{entity_type}/{entity}/{action}'
+            MQTTConsumer.__init__(self, topic, owner._config, owner._logger)
+
+            self.__entity_type = entity_type
+            self.__owner = owner
+
+        async def on_message(self, message: MQTTMessage, entity: str, action: str):
+            self.__owner.on_message(
+                message,
+                self.__entity_type,
+                entity,
+                action
+            )

--- a/controllers/virtual/virtual_controller/sensor/geofence.py
+++ b/controllers/virtual/virtual_controller/sensor/geofence.py
@@ -1,3 +1,5 @@
+from powerpi_common.condition import ConditionParser, Expression
+from powerpi_common.device import DeviceStatus
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
 from powerpi_common.sensor import Sensor
@@ -7,6 +9,16 @@ from powerpi_common.variable import VariableManager
 class GeofenceSensor(Sensor):
     '''
     Sensor implementing the conditions to activate, or deactivate a Geofence.
+    A Geofence is a conditional sensor which outputs "on" or "off" depending
+    on whether the condition is true or false. It is expected that the condition
+    include presence sensors; but is otherwise user configurable.
+    e.g.:
+    {
+        'either': [
+            {'var': 'presence.Person1.state', 'present'},
+            {'var': 'presence.Person2.state', 'present'}
+        ]
+    }
     '''
 
     def __init__(
@@ -14,6 +26,7 @@ class GeofenceSensor(Sensor):
         logger: Logger,
         mqtt_client: MQTTClient,
         variable_manager: VariableManager,
+        condition: Expression,
         **kwargs
     ):
         Sensor.__init__(self, mqtt_client, **kwargs)
@@ -21,3 +34,32 @@ class GeofenceSensor(Sensor):
         self._logger = logger
 
         self.__variable_manager = variable_manager
+        self.__condition = condition
+
+        self.__state = DeviceStatus.UNKNOWN
+
+    @property
+    def state(self):
+        return self.__state
+
+    def on_message(self):
+        # first we check the condition to identify what state we are in
+        condition = self.__check_condition()
+        new_state = DeviceStatus.ON if condition else DeviceStatus.OFF
+
+        # if the state has changed, then we need to broadcast that
+        if new_state != self.__state:
+            self.__state = new_state
+
+            self.__broadcast(new_state)
+
+    def __check_condition(self):
+        parser = ConditionParser(self.__variable_manager, {})
+        return parser.conditional_expression(self.__condition)
+
+    def __broadcast(self, state: DeviceStatus):
+        topic = f'geofence/{self.entity}/status'
+
+        message = {'state': state}
+
+        self._producer(topic, message)

--- a/controllers/virtual/virtual_controller/sensor/geofence.py
+++ b/controllers/virtual/virtual_controller/sensor/geofence.py
@@ -1,12 +1,13 @@
 from powerpi_common.condition import ConditionParser, Expression
 from powerpi_common.device import DeviceStatus
+from powerpi_common.device.mixin import InitialisableMixin
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
 from powerpi_common.sensor import Sensor
 from powerpi_common.variable import VariableManager
 
 
-class GeofenceSensor(Sensor):
+class GeofenceSensor(Sensor, InitialisableMixin):
     '''
     Sensor implementing the conditions to activate, or deactivate a Geofence.
     A Geofence is a conditional sensor which outputs "on" or "off" depending
@@ -41,6 +42,11 @@ class GeofenceSensor(Sensor):
     @property
     def state(self):
         return self.__state
+
+    async def initialise(self):
+        # we evaluate the condition during initialisation to ensure
+        # the variable manager is monitoring the referenced devices/sensors
+        self.__check_condition()
 
     def on_message(self):
         # first we check the condition to identify what state we are in

--- a/controllers/virtual/virtual_controller/sensor/geofence.py
+++ b/controllers/virtual/virtual_controller/sensor/geofence.py
@@ -58,7 +58,6 @@ class GeofenceSensor(Sensor, InitialisableMixin):
         visitor = self._Visitor()
         visitor.visit(self.__condition)
         variables = visitor.variables
-        self.log_info('Found variables %s', variables)
 
         # now we need to add the listeners
         consumer: MQTTConsumer | None = None

--- a/controllers/virtual/virtual_controller/sensor/geofence.py
+++ b/controllers/virtual/virtual_controller/sensor/geofence.py
@@ -2,7 +2,7 @@ from powerpi_common.condition import ConditionParser, Expression
 from powerpi_common.device import DeviceStatus
 from powerpi_common.device.mixin import InitialisableMixin
 from powerpi_common.logger import Logger
-from powerpi_common.mqtt import MQTTClient
+from powerpi_common.mqtt import MQTTClient, MQTTTopic
 from powerpi_common.sensor import Sensor
 from powerpi_common.variable import VariableManager
 
@@ -64,7 +64,7 @@ class GeofenceSensor(Sensor, InitialisableMixin):
         return parser.conditional_expression(self.__condition)
 
     def __broadcast(self, state: DeviceStatus):
-        topic = f'geofence/{self.entity}/status'
+        topic = f'{MQTTTopic.GEOFENCE}/{self.entity}/status'
 
         message = {'state': state}
 

--- a/controllers/virtual/virtual_controller/sensor/geofence.py
+++ b/controllers/virtual/virtual_controller/sensor/geofence.py
@@ -1,0 +1,23 @@
+from powerpi_common.logger import Logger
+from powerpi_common.mqtt import MQTTClient
+from powerpi_common.sensor import Sensor
+from powerpi_common.variable import VariableManager
+
+
+class GeofenceSensor(Sensor):
+    '''
+    Sensor implementing the conditions to activate, or deactivate a Geofence.
+    '''
+
+    def __init__(
+        self,
+        logger: Logger,
+        mqtt_client: MQTTClient,
+        variable_manager: VariableManager,
+        **kwargs
+    ):
+        Sensor.__init__(self, mqtt_client, **kwargs)
+
+        self._logger = logger
+
+        self.__variable_manager = variable_manager

--- a/controllers/virtual/virtual_controller/sensor/geofence.py
+++ b/controllers/virtual/virtual_controller/sensor/geofence.py
@@ -3,7 +3,13 @@ from powerpi_common.config import Config
 from powerpi_common.device import DeviceStatus
 from powerpi_common.device.mixin import InitialisableMixin
 from powerpi_common.logger import Logger
-from powerpi_common.mqtt import MQTTClient, MQTTConsumer, MQTTMessage, MQTTTopic
+from powerpi_common.mqtt import (
+    MQTTClient,
+    MQTTConsumer,
+    MQTTConsumerPriority,
+    MQTTMessage,
+    MQTTTopic
+)
 from powerpi_common.sensor import Sensor
 from powerpi_common.variable import VariableManager
 
@@ -66,7 +72,8 @@ class GeofenceSensor(Sensor, InitialisableMixin):
                     consumer = self.__add_presence_listener(key[1], state)
 
                 if consumer is not None:
-                    self.__mqtt_client.add_consumer(consumer)
+                    self.__mqtt_client.add_consumer(
+                        consumer, MQTTConsumerPriority.LOGIC)
 
         # we evaluate the condition during initialisation to ensure
         # the variable manager is monitoring the referenced devices/sensors

--- a/controllers/zigbee/pyproject.toml
+++ b/controllers/zigbee/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zigbee_controller"
-version = "0.8.0-rc.9"
+version = "0.8.0-rc.10"
 description = "PowerPi ZigBee Controller"
 license = "GPL-3.0-only"
 authors = [

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -29,7 +29,7 @@ dependencies:
     repository: oci://ghcr.io/stakater/charts
     condition: global.reloader
   - name: scheduler
-    version: 0.2.19
+    version: 0.2.20
     condition: global.scheduler
   - name: smarter-device-manager
     version: 0.1.3

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -39,7 +39,7 @@ dependencies:
     version: 0.3.17
     condition: global.voiceAssistant
   - name: energenie-controller
-    version: 0.1.18
+    version: 0.1.19
     condition: global.energenie
   - name: harmony-controller
     version: 0.1.25

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
     version: 0.1.17
     condition: global.energyMonitor
   - name: event
-    version: 0.0.8
+    version: 0.0.9
     condition: global.event
   - name: mosquitto
     version: 0.3.4

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -45,7 +45,7 @@ dependencies:
     version: 0.1.26
     condition: global.harmony
   - name: lifx-controller
-    version: 0.1.18
+    version: 0.1.19
     condition: global.lifx
   - name: network-controller
     version: 0.1.19

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -42,7 +42,7 @@ dependencies:
     version: 0.1.19
     condition: global.energenie
   - name: harmony-controller
-    version: 0.1.25
+    version: 0.1.26
     condition: global.harmony
   - name: lifx-controller
     version: 0.1.18

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -51,7 +51,7 @@ dependencies:
     version: 0.1.19
     condition: global.network
   - name: snapcast-controller
-    version: 0.0.15
+    version: 0.0.16
     condition: global.snapcast
   - name: virtual-controller
     version: 0.2.14

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -56,5 +56,5 @@ dependencies:
   - name: virtual-controller
     version: 0.2.14
   - name: zigbee-controller
-    version: 0.2.10
+    version: 0.2.11
     condition: global.zigbee

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -54,7 +54,7 @@ dependencies:
     version: 0.0.15
     condition: global.snapcast
   - name: virtual-controller
-    version: 0.2.13
+    version: 0.2.14
   - name: zigbee-controller
     version: 0.2.10
     condition: global.zigbee

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -48,7 +48,7 @@ dependencies:
     version: 0.1.18
     condition: global.lifx
   - name: network-controller
-    version: 0.1.18
+    version: 0.1.19
     condition: global.network
   - name: snapcast-controller
     version: 0.0.15

--- a/kubernetes/charts/energenie-controller/Chart.yaml
+++ b/kubernetes/charts/energenie-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: energenie-controller
 description: A Helm chart for the PowerPi Energenie device controller
 type: application
-version: 0.1.18
-appVersion: 0.3.7-rc.5
+version: 0.1.19
+appVersion: 0.3.7-rc.6

--- a/kubernetes/charts/event/Chart.yaml
+++ b/kubernetes/charts/event/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: event
 description: A Helm chart for the PowerPi event service
 type: application
-version: 0.0.8
-appVersion: 0.0.4-rc.5
+version: 0.0.9
+appVersion: 0.0.4-rc.6

--- a/kubernetes/charts/harmony-controller/Chart.yaml
+++ b/kubernetes/charts/harmony-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: harmony-controller
 description: A Helm chart for the PowerPi Logitech Harmony device controller
 type: application
-version: 0.1.25
-appVersion: 0.4.10-rc.7
+version: 0.1.26
+appVersion: 0.4.10-rc.8

--- a/kubernetes/charts/lifx-controller/Chart.yaml
+++ b/kubernetes/charts/lifx-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lifx-controller
 description: A Helm chart for the PowerPi LIFX device controller
 type: application
-version: 0.1.18
-appVersion: 0.6.6-rc.5
+version: 0.1.19
+appVersion: 0.6.6-rc.6

--- a/kubernetes/charts/mosquitto/acl.conf
+++ b/kubernetes/charts/mosquitto/acl.conf
@@ -15,7 +15,6 @@ user network_controller
 topic readwrite powerpi/device/#
 topic readwrite powerpi/event/#
 topic readwrite powerpi/presence/#
-topic readw powerpi/geofence/#
 
 user virtual_controller
 topic readwrite powerpi/device/#

--- a/kubernetes/charts/mosquitto/acl.conf
+++ b/kubernetes/charts/mosquitto/acl.conf
@@ -15,11 +15,13 @@ user network_controller
 topic readwrite powerpi/device/#
 topic readwrite powerpi/event/#
 topic readwrite powerpi/presence/#
+topic readw powerpi/geofence/#
 
 user virtual_controller
 topic readwrite powerpi/device/#
 topic readwrite powerpi/event/#
 topic read powerpi/presence/#
+topic readwrite powerpi/geofence/#
 
 user device
 topic read powerpi/device/+/change
@@ -32,6 +34,7 @@ topic read powerpi/event/#
 topic readwrite powerpi/device/+/change
 topic readwrite powerpi/device/+/scene
 topic read powerpi/presence/#
+topic read powerpi/geofence/#
 
 user persistence
 topic read powerpi/config/#
@@ -43,6 +46,7 @@ topic read powerpi/device/#
 topic read powerpi/event/#
 topic readwrite powerpi/device/+/change
 topic read powerpi/presence/#
+topic read powerpi/geofence/#
 
 user sensor
 topic read powerpi/config/#

--- a/kubernetes/charts/network-controller/Chart.yaml
+++ b/kubernetes/charts/network-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: network-controller
 description: A Helm chart for the PowerPi Network device controller
 type: application
-version: 0.1.18
-appVersion: 0.3.0-rc.2
+version: 0.1.19
+appVersion: 0.3.0-rc.3

--- a/kubernetes/charts/scheduler/Chart.yaml
+++ b/kubernetes/charts/scheduler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: scheduler
 description: A Helm chart for the PowerPi scheduler service
 type: application
-version: 0.2.19
-appVersion: 1.5.2-rc.5
+version: 0.2.20
+appVersion: 1.5.2-rc.6

--- a/kubernetes/charts/snapcast-controller/Chart.yaml
+++ b/kubernetes/charts/snapcast-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: snapcast-controller
 description: A Helm chart for the PowerPi snapcast device controller
 type: application
-version: 0.0.15
-appVersion: 0.0.10-rc.6
+version: 0.0.16
+appVersion: 0.0.10-rc.7

--- a/kubernetes/charts/virtual-controller/Chart.yaml
+++ b/kubernetes/charts/virtual-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: virtual-controller
 description: A Helm chart for the PowerPi virtual device controller
 type: application
-version: 0.2.13
-appVersion: 2.2.2-rc.5
+version: 0.2.14
+appVersion: 2.2.2-rc.6

--- a/kubernetes/charts/zigbee-controller/Chart.yaml
+++ b/kubernetes/charts/zigbee-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: zigbee-controller
 description: A Helm chart for the PowerPi ZigBee device controller
 type: application
-version: 0.2.10
-appVersion: 0.8.0-rc.9
+version: 0.2.11
+appVersion: 0.8.0-rc.10

--- a/services/event/pyproject.toml
+++ b/services/event/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "event"
-version = "0.0.4-rc.5"
+version = "0.0.4-rc.6"
 description = "PowerPi Event Service"
 license = "GPL-3.0-only"
 authors = [

--- a/services/event/tests/services/test_consumer.py
+++ b/services/event/tests/services/test_consumer.py
@@ -51,7 +51,7 @@ class TestEventConsumer:
             message['timestamp'] = timestamp
 
         with patch('powerpi_common.mqtt.consumer.datetime') as mock_datetime:
-            mock_datetime.utcnow.return_value = datetime(
+            mock_datetime.now.return_value = datetime(
                 2023, 6, 4, 20, 35, 8
             )
 

--- a/services/scheduler/pyproject.toml
+++ b/services/scheduler/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scheduler"
-version = "1.5.2-rc.5"
+version = "1.5.2-rc.6"
 description = "PowerPi Scheduler Service"
 license = "GPL-3.0-only"
 authors = [


### PR DESCRIPTION
- Add `geofence` topic permissions for `virtual-controller`, `event` and `scheduler`.
- Add `ConditionVisitor` which allows traversal of a condition to pick out useful facts, like the list of referenced variables.
- Add `GeofenceSensor` monitoring the topics in the condition to trigger updates.
  - If the state changes broadcast.
  - Ignore old messages so it won't broadcast while getting the initial states messages during startup.
- Support consumer priority in `MQTTClient` so we can ensure the variables are updated before the sensor receives the trigger.
  - Update change messages, and orchestrator devices to register appropriate priority so they don't have that issue either.
 
Fixes:
- `MQTTClient` would subscribe right away, meaning subsequent subscribers may miss initially messages if they arrive before they are registered.