### PR TITLE
#766 feat: Add geofence checking to devices

### DIFF
--- a/common/pytest/powerpi_common_test/device/device.py
+++ b/common/pytest/powerpi_common_test/device/device.py
@@ -1,7 +1,9 @@
 from datetime import datetime, timezone
+from unittest.mock import PropertyMock
 
 from powerpi_common.config import Config
 from powerpi_common.device import Device
+from powerpi_common.device.geofence import Geofence
 from powerpi_common.mqtt import MQTTClient, MQTTConsumer, MQTTConsumerPriority
 from pytest_mock import MockerFixture
 
@@ -27,6 +29,46 @@ class DeviceTestBase(BaseDeviceTestBase):
         assert subject.state == 'unknown'
         await subject.turn_off()
         assert subject.state == 'off'
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('active', [True, False])
+    async def test_turn_on_geofence(
+        self,
+        subject_geofence: Device,
+        geofence,
+        active: bool
+    ):
+        type(geofence).state = PropertyMock(
+            return_value='on' if active else 'off'
+        )
+
+        assert subject_geofence.state == 'unknown'
+        await subject_geofence.turn_on()
+
+        if active:
+            assert subject_geofence.state == 'unknown'
+        else:
+            assert subject_geofence.state == 'on'
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('active', [True, False])
+    async def test_turn_off_geofence(
+        self,
+        subject_geofence: Device,
+        geofence,
+        active: bool
+    ):
+        type(geofence).state = PropertyMock(
+            return_value='on' if active else 'off'
+        )
+
+        assert subject_geofence.state == 'unknown'
+        await subject_geofence.turn_off()
+
+        if active:
+            assert subject_geofence.state == 'unknown'
+        else:
+            assert subject_geofence.state == 'off'
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize('times', [1, 2])
@@ -107,6 +149,34 @@ class DeviceTestBase(BaseDeviceTestBase):
         message['state'] = 'off'
         await self._initial_state_consumer.on_message(message, subject.name, 'status')
         assert subject.state == 'on'
+
+    @pytest.fixture()
+    def subject_geofence(
+        self,
+        subject: Device,
+        powerpi_variable_manager
+    ):
+        # pylint:disable=protected-access
+        subject._Device__geofence = Geofence(
+            powerpi_variable_manager,
+            'TestGeofence'
+        )
+
+        return subject
+
+    @pytest.fixture()
+    def geofence(
+        self,
+        powerpi_variable_manager,
+        mocker: MockerFixture
+    ):
+        geofence = mocker.MagicMock()
+        type(geofence).state = PropertyMock(return_value='off')
+
+        powerpi_variable_manager.get_sensor = \
+            lambda name, __: geofence if name == 'TestGeofence' else None
+
+        return geofence
 
     @pytest.fixture(autouse=True)
     def message_age_cutoff(self, powerpi_config: Config, mocker: MockerFixture):

--- a/common/pytest/powerpi_common_test/device/device.py
+++ b/common/pytest/powerpi_common_test/device/device.py
@@ -173,8 +173,8 @@ class DeviceTestBase(BaseDeviceTestBase):
         geofence = mocker.MagicMock()
         type(geofence).state = PropertyMock(return_value='off')
 
-        powerpi_variable_manager.get_sensor = \
-            lambda name, __: geofence if name == 'TestGeofence' else None
+        powerpi_variable_manager.get_geofence = \
+            lambda name: geofence if name == 'TestGeofence' else None
 
         return geofence
 

--- a/common/pytest/powerpi_common_test/variable/variable.py
+++ b/common/pytest/powerpi_common_test/variable/variable.py
@@ -14,6 +14,6 @@ class VariableTestBase:
 
     def test_str(self, subject):
         assert bool(re.match(
-            r'^var\.(device|sensor|presence)\..*=\{.*\}$',
+            r'^var\.(device|sensor|presence|geofence)\..*=\{.*\}$',
             str(subject)
         )) is True

--- a/common/python/powerpi_common/application.py
+++ b/common/python/powerpi_common/application.py
@@ -50,6 +50,11 @@ class Application(LogMixin):
     def _log_start(self):
         pass
 
+    def _register(self):
+        '''
+        Override to perform custom DI registrations.
+        '''
+
     async def _app_start(self):
         raise NotImplementedError('Application start should be implemented')
 
@@ -61,6 +66,9 @@ class Application(LogMixin):
         self._log_start()
 
         try:
+            # perform custom DI registrations
+            self._register()
+
             # start the scheduler
             self.__scheduler.start()
 

--- a/common/python/powerpi_common/container.py
+++ b/common/python/powerpi_common/container.py
@@ -81,6 +81,7 @@ class Container(containers.DeclarativeContainer):
         device_status_checker=device.device_status_checker,
         scheduler=scheduler,
         health=health,
+        container=__self__,
         app_name=app_name,
         version=version
     )

--- a/common/python/powerpi_common/controller.py
+++ b/common/python/powerpi_common/controller.py
@@ -1,7 +1,13 @@
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from dependency_injector import containers
 
 from powerpi_common.application import Application
-from powerpi_common.device import DeviceManager, DeviceStatusChecker
+from powerpi_common.device import (
+    DeviceManager,
+    DeviceStatusChecker,
+    bind_common_device_dependencies,
+    bind_common_sensor_dependencies
+)
 from powerpi_common.health import HealthService
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
@@ -18,6 +24,7 @@ class Controller(Application):
         device_status_checker: DeviceStatusChecker,
         scheduler: AsyncIOScheduler,
         health: HealthService,
+        container: containers.DeclarativeContainer,
         app_name: str,
         version: str
     ):
@@ -26,8 +33,13 @@ class Controller(Application):
             scheduler, health, app_name, version
         )
 
+        self.__container = container
         self.__device_manager = device_manager
         self.__device_status_checker = device_status_checker
+
+    def _register(self):
+        bind_common_device_dependencies(self.__container)
+        bind_common_sensor_dependencies(self.__container)
 
     async def _initialise_devices(self):
         pass

--- a/common/python/powerpi_common/device/__init__.py
+++ b/common/python/powerpi_common/device/__init__.py
@@ -1,5 +1,9 @@
 from .additional_state import AdditionalStateDevice
-from .container import DeviceContainer
+from .container import (
+    DeviceContainer,
+    bind_common_device_dependencies,
+    bind_common_sensor_dependencies
+)
 from .device import Device
 from .factory import DeviceFactory
 from .manager import DeviceManager, DeviceNotFoundException

--- a/common/python/powerpi_common/device/additional_state.py
+++ b/common/python/powerpi_common/device/additional_state.py
@@ -30,7 +30,14 @@ class AdditionalStateDevice(Device, AdditionalStateMixin):
     ):
         self.__additional_state = SceneState()
 
-        Device.__init__(self, config, logger, mqtt_client, listener, **kwargs)
+        Device.__init__(
+            self,
+            config=config,
+            logger=logger,
+            mqtt_client=mqtt_client,
+            listener=listener,
+            **kwargs
+        )
 
         if listener:
             # add listener for scene changes

--- a/common/python/powerpi_common/device/container.py
+++ b/common/python/powerpi_common/device/container.py
@@ -1,8 +1,15 @@
+from typing import TYPE_CHECKING
+
 from dependency_injector import containers, providers
+from powerpi_common.device import Device
+from powerpi_common.sensor import Sensor
 
 from .factory import DeviceFactory
 from .manager import DeviceManager
 from .status import DeviceStatusChecker
+
+if TYPE_CHECKING:
+    from powerpi_common.container import Container as CommonContainer
 
 
 class DeviceContainer(containers.DeclarativeContainer):
@@ -39,3 +46,36 @@ class DeviceContainer(containers.DeclarativeContainer):
         device_manager=device_manager,
         scheduler=scheduler
     )
+
+
+def bind_common_device_dependencies(container: 'CommonContainer'):
+    dependencies = {
+        'config': container.config,
+        'logger': container.logger,
+        'mqtt_client': container.mqtt_client,
+        'variable_manager': container.variable.variable_manager
+    }
+
+    for provider in container.device().traverse():
+        if not isinstance(provider, providers.Factory) \
+                or not isinstance(provider.cls, type) \
+                or not issubclass(provider.cls, Device):
+            continue
+
+        provider.add_kwargs(**dependencies)
+
+
+def bind_common_sensor_dependencies(container: 'CommonContainer'):
+    dependencies = {
+        'config': container.config,
+        'logger': container.logger,
+        'mqtt_client': container.mqtt_client
+    }
+
+    for provider in container.device().traverse():
+        if not isinstance(provider, providers.Factory) \
+                or not isinstance(provider.cls, type) \
+                or not issubclass(provider.cls, Sensor):
+            continue
+
+        provider.add_kwargs(**dependencies)

--- a/common/python/powerpi_common/device/container.py
+++ b/common/python/powerpi_common/device/container.py
@@ -1,9 +1,9 @@
 from typing import TYPE_CHECKING
 
 from dependency_injector import containers, providers
-from powerpi_common.device import Device
 from powerpi_common.sensor import Sensor
 
+from .device import Device
 from .factory import DeviceFactory
 from .manager import DeviceManager
 from .status import DeviceStatusChecker

--- a/common/python/powerpi_common/device/device.py
+++ b/common/python/powerpi_common/device/device.py
@@ -6,12 +6,14 @@ from powerpi_common.config import Config
 from powerpi_common.device.types import DeviceStatus
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTConsumerPriority, MQTTClient
+from powerpi_common.variable import VariableManager
 
 from .base import BaseDevice
 from .consumers import (
     DeviceChangeEventConsumer,
     DeviceInitialStatusEventConsumer
 )
+from .geofence import Geofence
 
 
 class Device(BaseDevice, DeviceChangeEventConsumer):
@@ -26,13 +28,18 @@ class Device(BaseDevice, DeviceChangeEventConsumer):
         config: Config,
         logger: Logger,
         mqtt_client: MQTTClient,
+        variable_manager: VariableManager,
         listener=True,
+        geofence: str | None = None,
         **kwargs
     ):
         BaseDevice.__init__(self, **kwargs)
         DeviceChangeEventConsumer.__init__(self, self, config, logger)
 
         self._logger = logger
+
+        self.__geofence = Geofence(variable_manager, geofence)
+
         self.__state = DeviceStatus.UNKNOWN
 
         self._producer = mqtt_client.add_producer()
@@ -88,13 +95,13 @@ class Device(BaseDevice, DeviceChangeEventConsumer):
         '''
         Turn this device on, and broadcast the state change to the message queue if successful.
         '''
-        await self.__change_power_handler(self._turn_on, DeviceStatus.ON)
+        return await self.__change_power_handler(self._turn_on, DeviceStatus.ON)
 
     async def turn_off(self):
         '''
         Turn this device off, and broadcast the state change to the message queue if successful.
         '''
-        await self.__change_power_handler(self._turn_off, DeviceStatus.OFF)
+        return await self.__change_power_handler(self._turn_off, DeviceStatus.OFF)
 
     async def change_power(self, new_state: DeviceStatus):
         '''
@@ -103,9 +110,9 @@ class Device(BaseDevice, DeviceChangeEventConsumer):
         '''
         if new_state is not None:
             if new_state == DeviceStatus.ON:
-                await self.turn_on()
-            else:
-                await self.turn_off()
+                return await self.turn_on()
+
+            return await self.turn_off()
 
     @abstractmethod
     async def _turn_on(self) -> bool:
@@ -144,7 +151,14 @@ class Device(BaseDevice, DeviceChangeEventConsumer):
         self,
         func: Callable[[], Awaitable[bool]],
         new_status: DeviceStatus
-    ):
+    ) -> bool:
+        # first we check the geofence, if it's active we don't do anything
+        if self.__geofence.active:
+            self.log_info(
+                f'Geofence blocking state change {new_status} device {self}'
+            )
+            return False
+
         # pylint: disable=broad-except
         try:
             async with self.__lock:
@@ -156,9 +170,13 @@ class Device(BaseDevice, DeviceChangeEventConsumer):
                     self.state = new_status
                 else:
                     self.log_info(f'Failed to turn {new_status} device {self}')
+
+                return success
         except Exception as ex:
             self.log_exception(ex)
             self.state = DeviceStatus.UNKNOWN
+
+            return False
 
     def __str__(self):
         return f'{type(self).__name__}({self._display_name}, {self._format_state()})'

--- a/common/python/powerpi_common/device/device.py
+++ b/common/python/powerpi_common/device/device.py
@@ -1,12 +1,10 @@
 from abc import abstractmethod
 from asyncio import Lock
-from typing import Awaitable, Callable
+from typing import Awaitable, Callable, TYPE_CHECKING
 
 from powerpi_common.config import Config
-from powerpi_common.device.types import DeviceStatus
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTConsumerPriority, MQTTClient
-from powerpi_common.variable import VariableManager
 
 from .base import BaseDevice
 from .consumers import (
@@ -14,6 +12,10 @@ from .consumers import (
     DeviceInitialStatusEventConsumer
 )
 from .geofence import Geofence
+from .types import DeviceStatus
+
+if TYPE_CHECKING:
+    from powerpi_common.variable import VariableManager
 
 
 class Device(BaseDevice, DeviceChangeEventConsumer):
@@ -28,7 +30,7 @@ class Device(BaseDevice, DeviceChangeEventConsumer):
         config: Config,
         logger: Logger,
         mqtt_client: MQTTClient,
-        variable_manager: VariableManager,
+        variable_manager: 'VariableManager',
         listener=True,
         geofence: str | None = None,
         **kwargs

--- a/common/python/powerpi_common/device/device.py
+++ b/common/python/powerpi_common/device/device.py
@@ -78,6 +78,13 @@ class Device(BaseDevice, DeviceChangeEventConsumer):
         '''
         return self.__lock.locked()
 
+    @property
+    def geofence(self):
+        '''
+        Returns the geofence object for this device.
+        '''
+        return self.__geofence
+
     def update_state_no_broadcast(self, new_state: DeviceStatus):
         '''
         Update this devices' state but do not broadcast to the message queue.

--- a/common/python/powerpi_common/device/geofence.py
+++ b/common/python/powerpi_common/device/geofence.py
@@ -1,0 +1,33 @@
+from powerpi_common.device import DeviceStatus
+from powerpi_common.variable import VariableManager
+
+
+class Geofence:
+    '''
+    Wrapper around variable manager and the geofence sensor identifier to check
+    whether the geofence is active or not.
+    '''
+
+    def __init__(
+        self,
+        variable_manager: VariableManager,
+        geofence: str | None = None
+    ):
+        self.__variable_manager = variable_manager
+        self.__geofence = geofence
+
+    @property
+    def active(self):
+        '''
+        Returns whether the geofence is currently active, and therefore a device
+        should not respond to commands.
+        '''
+        if self.__geofence is None:
+            return False
+
+        sensor = self.__variable_manager.get_sensor(self.__geofence, 'status')
+        if sensor is None:
+            # a misconfigured geofence is always active for security
+            return True
+
+        return sensor.state == DeviceStatus.ON

--- a/common/python/powerpi_common/device/geofence.py
+++ b/common/python/powerpi_common/device/geofence.py
@@ -30,7 +30,7 @@ class Geofence:
         if self.__geofence is None:
             return False
 
-        sensor = self.__variable_manager.get_sensor(self.__geofence, 'status')
+        sensor = self.__variable_manager.get_geofence(self.__geofence)
         if sensor is None:
             # a misconfigured geofence is always active for security
             return True

--- a/common/python/powerpi_common/device/geofence.py
+++ b/common/python/powerpi_common/device/geofence.py
@@ -1,5 +1,10 @@
-from powerpi_common.device import DeviceStatus
-from powerpi_common.variable import VariableManager
+from typing import TYPE_CHECKING
+
+from .types import DeviceStatus
+
+
+if TYPE_CHECKING:
+    from powerpi_common.variable import VariableManager
 
 
 class Geofence:
@@ -10,7 +15,7 @@ class Geofence:
 
     def __init__(
         self,
-        variable_manager: VariableManager,
+        variable_manager: 'VariableManager',
         geofence: str | None = None
     ):
         self.__variable_manager = variable_manager

--- a/common/python/powerpi_common/device/geofence.py
+++ b/common/python/powerpi_common/device/geofence.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING
 
+from powerpi_common.device.mixin import InitialisableMixin
+
 from .types import DeviceStatus
 
 
@@ -7,7 +9,7 @@ if TYPE_CHECKING:
     from powerpi_common.variable import VariableManager
 
 
-class Geofence:
+class Geofence(InitialisableMixin):
     '''
     Wrapper around variable manager and the geofence sensor identifier to check
     whether the geofence is active or not.
@@ -30,9 +32,16 @@ class Geofence:
         if self.__geofence is None:
             return False
 
-        sensor = self.__variable_manager.get_geofence(self.__geofence)
+        sensor = self.__get_sensor()
         if sensor is None:
             # a misconfigured geofence is always active for security
             return True
 
         return sensor.state == DeviceStatus.ON
+
+    async def initialise(self):
+        if self.__geofence is not None:
+            _ = self.__get_sensor()
+
+    def __get_sensor(self):
+        return self.__variable_manager.get_geofence(self.__geofence)

--- a/common/python/powerpi_common/device/manager.py
+++ b/common/python/powerpi_common/device/manager.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-from typing import Any, Dict, List
 
 from powerpi_common.config import Config
 from powerpi_common.device.types import DeviceConfigType
@@ -22,24 +21,24 @@ class DeviceManager(InitialisableMixin):
         self.__logger = logger
         self.__factory = factory
 
-        self.__devices: Dict[
+        self.__devices: dict[
             DeviceConfigType,
-            Dict[str, 'DeviceType | SensorType']
+            dict[str, 'DeviceType | SensorType']
         ] = {}
 
         for device_type in DeviceConfigType:
             self.__devices[device_type] = {}
 
     @property
-    def devices_and_sensors(self) -> List['DeviceType | SensorType']:
+    def devices_and_sensors(self) -> list['DeviceType | SensorType']:
         return list(self.devices.values()) + list(self.sensors.values())
 
     @property
-    def devices(self) -> Dict[str, DeviceType]:
+    def devices(self) -> dict[str, DeviceType]:
         return self.__devices[DeviceConfigType.DEVICE]
 
     @property
-    def sensors(self) -> Dict[str, SensorType]:
+    def sensors(self) -> dict[str, SensorType]:
         return self.__devices[DeviceConfigType.SENSOR]
 
     def get_device(self, name: str) -> DeviceType:
@@ -81,7 +80,7 @@ class DeviceManager(InitialisableMixin):
             raise DeviceNotFoundException(device_type, name) from ex
 
     def __load(self, device_type: DeviceConfigType):
-        devices: List[Dict[str, Any]] \
+        devices: list[dict[str, any]] \
             = self.__config.devices[f'{device_type}s']
 
         for device in devices:

--- a/common/python/powerpi_common/device/manager.py
+++ b/common/python/powerpi_common/device/manager.py
@@ -3,11 +3,14 @@ from copy import deepcopy
 from powerpi_common.config import Config
 from powerpi_common.device.types import DeviceConfigType
 from powerpi_common.logger import Logger
-from powerpi_common.typing import DeviceType, SensorType
+from powerpi_common.sensor import Sensor
 from powerpi_common.util import ismixin
 
+from .device import Device
 from .factory import DeviceFactory
 from .mixin import InitialisableMixin
+
+DeviceOrSensor = Device | Sensor
 
 
 class DeviceManager(InitialisableMixin):
@@ -23,28 +26,28 @@ class DeviceManager(InitialisableMixin):
 
         self.__devices: dict[
             DeviceConfigType,
-            dict[str, 'DeviceType | SensorType']
+            dict[str, DeviceOrSensor]
         ] = {}
 
         for device_type in DeviceConfigType:
             self.__devices[device_type] = {}
 
     @property
-    def devices_and_sensors(self) -> list['DeviceType | SensorType']:
+    def devices_and_sensors(self) -> list[DeviceOrSensor]:
         return list(self.devices.values()) + list(self.sensors.values())
 
     @property
-    def devices(self) -> dict[str, DeviceType]:
+    def devices(self) -> dict[str, Device]:
         return self.__devices[DeviceConfigType.DEVICE]
 
     @property
-    def sensors(self) -> dict[str, SensorType]:
+    def sensors(self) -> dict[str, Sensor]:
         return self.__devices[DeviceConfigType.SENSOR]
 
-    def get_device(self, name: str) -> DeviceType:
+    def get_device(self, name: str) -> Device:
         return self.__get(DeviceConfigType.DEVICE, name)
 
-    def get_sensor(self, name: str) -> SensorType:
+    def get_sensor(self, name: str) -> Sensor:
         return self.__get(DeviceConfigType.SENSOR, name)
 
     async def load(self):
@@ -54,6 +57,10 @@ class DeviceManager(InitialisableMixin):
         await self.initialise()
 
     async def initialise(self):
+        # initialise the geofences for all the devices
+        for device in self.__devices[DeviceConfigType.DEVICE].values():
+            await device.geofence.initialise()
+
         for device_type in DeviceConfigType:
             filtered = filter(
                 lambda device: ismixin(device, InitialisableMixin),

--- a/common/python/powerpi_common/device/manager.py
+++ b/common/python/powerpi_common/device/manager.py
@@ -58,7 +58,10 @@ class DeviceManager(InitialisableMixin):
 
     async def initialise(self):
         # initialise the geofences for all the devices
-        for device in self.__devices[DeviceConfigType.DEVICE].values():
+        for device in [
+            device for device in self.__devices[DeviceConfigType.DEVICE].values()
+            if isinstance(device, Device)
+        ]:
             await device.geofence.initialise()
 
         for device_type in DeviceConfigType:

--- a/common/python/powerpi_common/mqtt/client.py
+++ b/common/python/powerpi_common/mqtt/client.py
@@ -34,6 +34,7 @@ class MQTTClient:
         self.__logger.set_logger_level(gmqtt.__name__, logging.WARNING)
 
         self.__client = Client | None
+        self.__subscribed = False
 
     @property
     def client_id(self):
@@ -50,12 +51,20 @@ class MQTTClient:
     ):
         key = consumer.topic
 
+        new_topic = False
+
         if key not in self.__consumers:
             self.__consumers[key] = {}
+            new_topic = True
         if priority not in self.__consumers[key]:
             self.__consumers[key][priority] = []
 
         self.__consumers[key][priority].append(consumer)
+
+        # if we've already run the subscriptions, and this is a new topic
+        # we also need to subscribe to it
+        if self.__subscribed and new_topic:
+            self.__subscribe(key)
 
     def remove_consumer(self, consumer: MQTTConsumer):
         key = consumer.topic
@@ -126,10 +135,17 @@ class MQTTClient:
         await self.__client.disconnect()
 
     def subscribe(self):
-        for key in self.__consumers:
-            topic = f'{self.__config.topic_base}/{key}'
-            self.__logger.info('Subscribing to topic "%s"', topic)
-            self.__client.subscribe(topic)
+        topics = set(self.__consumers)
+
+        for topic in topics:
+            self.__subscribe(topic)
+
+        self.__subscribed = True
+
+    def __subscribe(self, topic: str):
+        full_topic = f'{self.__config.topic_base}/{topic}'
+        self.__logger.info('Subscribing to topic "%s"', full_topic)
+        self.__client.subscribe(full_topic)
 
     def __on_connect(self, _, __, result_code: int, ___):
         if result_code == 0:

--- a/common/python/powerpi_common/sensor/consumers/__init__.py
+++ b/common/python/powerpi_common/sensor/consumers/__init__.py
@@ -1,2 +1,3 @@
+from .geofence_event_consumer import GeofenceEventConsumer
 from .presence_event_consumer import PresenceEventConsumer
 from .sensor_event_consumer import SensorEventConsumer

--- a/common/python/powerpi_common/sensor/consumers/geofence_event_consumer.py
+++ b/common/python/powerpi_common/sensor/consumers/geofence_event_consumer.py
@@ -1,0 +1,28 @@
+from powerpi_common.config import Config
+from powerpi_common.logger import Logger
+from powerpi_common.mqtt import MQTTConsumer, MQTTMessage, MQTTTopic
+from powerpi_common.typing import SensorType
+
+
+class GeofenceEventConsumer(MQTTConsumer):
+    '''
+    Consumer for reading geofence events.
+    '''
+
+    def __init__(
+        self,
+        entity: str,
+        sensor: SensorType,
+        config: Config,
+        logger: Logger
+    ):
+        topic = f'{MQTTTopic.GEOFENCE}/{entity}/status'
+        MQTTConsumer.__init__(self, topic, config, logger)
+
+        self._sensor = sensor
+
+    async def on_message(self, message: MQTTMessage, _: str, __: str):
+        state = message.get('state')
+
+        if state is not None:
+            self._sensor.state = state

--- a/common/python/powerpi_common/sensor/sensor.py
+++ b/common/python/powerpi_common/sensor/sensor.py
@@ -1,4 +1,5 @@
 from powerpi_common.device.base import BaseDevice
+from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
 
 
@@ -11,12 +12,15 @@ class Sensor(BaseDevice):
 
     def __init__(
         self,
+        logger: Logger,
         mqtt_client: MQTTClient,
         entity: str | None = None,
         action: str | None = None,
         **kwargs
     ):
         BaseDevice.__init__(self, **kwargs)
+
+        self._logger = logger
 
         self.__entity = entity
         self.__action = action

--- a/common/python/powerpi_common/variable/container.py
+++ b/common/python/powerpi_common/variable/container.py
@@ -1,9 +1,10 @@
 from dependency_injector import containers, providers
 
 from powerpi_common.variable.device import DeviceVariable
+from powerpi_common.variable.geofence import GeofenceVariable
 from powerpi_common.variable.manager import VariableManager
-from powerpi_common.variable.sensor import SensorVariable
 from powerpi_common.variable.presence import PresenceVariable
+from powerpi_common.variable.sensor import SensorVariable
 
 
 class VariableContainer(containers.DeclarativeContainer):
@@ -44,6 +45,13 @@ class VariableContainer(containers.DeclarativeContainer):
 
     presence_variable = providers.Factory(
         PresenceVariable,
+        config=config,
+        logger=logger,
+        mqtt_client=mqtt_client
+    )
+
+    geofence_variable = providers.Factory(
+        GeofenceVariable,
         config=config,
         logger=logger,
         mqtt_client=mqtt_client

--- a/common/python/powerpi_common/variable/geofence.py
+++ b/common/python/powerpi_common/variable/geofence.py
@@ -1,15 +1,15 @@
 from powerpi_common.config import Config
+from powerpi_common.device import DeviceStatus
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
-from powerpi_common.sensor import PresenceStatus
-from powerpi_common.sensor.consumers import PresenceEventConsumer
+from powerpi_common.sensor.consumers import GeofenceEventConsumer
 from powerpi_common.variable.types import VariableType
 from powerpi_common.variable.variable import Variable
 
 
-class PresenceVariable(Variable, PresenceEventConsumer):
+class GeofenceVariable(Variable, GeofenceEventConsumer):
     '''
-    Variable implementation that will receive presence detection events from the message queue.
+    Variable implementation that will receive geofence activation events from the message queue.
     '''
 
     def __init__(
@@ -21,7 +21,7 @@ class PresenceVariable(Variable, PresenceEventConsumer):
         **kwargs
     ):
         Variable.__init__(self, name, **kwargs)
-        PresenceEventConsumer.__init__(
+        GeofenceEventConsumer.__init__(
             self,
             name,
             self,
@@ -29,7 +29,7 @@ class PresenceVariable(Variable, PresenceEventConsumer):
             logger
         )
 
-        self.__state: PresenceStatus | None = None
+        self.__state: DeviceStatus = DeviceStatus.UNKNOWN
 
         mqtt_client.add_consumer(self)
 
@@ -42,7 +42,7 @@ class PresenceVariable(Variable, PresenceEventConsumer):
         return self.__state
 
     @state.setter
-    def state(self, new_state: PresenceStatus):
+    def state(self, new_state: DeviceStatus):
         self.__state = new_state
 
     @property

--- a/common/python/powerpi_common/variable/geofence.py
+++ b/common/python/powerpi_common/variable/geofence.py
@@ -35,7 +35,7 @@ class GeofenceVariable(Variable, GeofenceEventConsumer):
 
     @property
     def variable_type(self):
-        return VariableType.PRESENCE
+        return VariableType.GEOFENCE
 
     @property
     def state(self):

--- a/common/python/powerpi_common/variable/manager.py
+++ b/common/python/powerpi_common/variable/manager.py
@@ -4,6 +4,7 @@ from powerpi_common.device import DeviceManager, DeviceNotFoundException
 from powerpi_common.logger import Logger, LogMixin
 from powerpi_common.typing import DeviceType, SensorType
 from powerpi_common.variable.device import DeviceVariable
+from powerpi_common.variable.geofence import GeofenceVariable
 from powerpi_common.variable.presence import PresenceVariable
 from powerpi_common.variable.sensor import SensorVariable
 from powerpi_common.variable.types import VariableType
@@ -34,23 +35,29 @@ class VariableManager(LogMixin):
         for variable_type in VariableType:
             self.__variables[variable_type] = {}
 
-    def get_device(self, name: str) -> 'DeviceVariable | DeviceType':
+    def get_device(self, name: str) -> DeviceVariable | 'DeviceType':
         '''
         Returns the device variable if it exists, or the actual device if that exists.
         '''
         return self.__get(VariableType.DEVICE, name)
 
-    def get_sensor(self, name: str, action: str) -> 'SensorVariable | SensorType':
+    def get_sensor(self, name: str, action: str) -> SensorVariable | 'SensorType':
         '''
         Returns the sensor variable if it exists, or the actual sensor if that exists.
         '''
         return self.__get(VariableType.SENSOR, name, action)
 
-    def get_presence(self, name: str) -> 'PresenceVariable | SensorType':
+    def get_presence(self, name: str) -> PresenceVariable | 'SensorType':
         '''
         Returns the presence sensor variable if it exists, or the actual sensor if that exists.
         '''
         return self.__get(VariableType.PRESENCE, name)
+
+    def get_geofence(self, name: str) -> GeofenceVariable | 'SensorType':
+        '''
+        Returns the geofence sensor variable if it exists, or the actual sensor if that exists.
+        '''
+        return self.__get(VariableType.GEOFENCE, name)
 
     def add(self, variable: Variable):
         variable_type = variable.variable_type
@@ -101,7 +108,7 @@ class VariableManager(LogMixin):
             if variable_type == VariableType.DEVICE:
                 return self.__device_manager.get_device(name)
 
-            if variable_type in (VariableType.SENSOR, VariableType.PRESENCE):
+            if variable_type in (VariableType.SENSOR, VariableType.PRESENCE, VariableType.GEOFENCE):
                 return self.__device_manager.get_sensor(name)
         except DeviceNotFoundException:
             pass
@@ -111,7 +118,7 @@ class VariableManager(LogMixin):
 
     @classmethod
     def __key(cls, variable_type: VariableType, name: str, action: str | None = None):
-        if variable_type in (VariableType.DEVICE, VariableType.PRESENCE):
+        if variable_type in (VariableType.DEVICE, VariableType.PRESENCE, VariableType.GEOFENCE):
             return name
         if variable_type == VariableType.SENSOR and action is not None:
             return f'{name}/{action}'

--- a/common/python/powerpi_common/variable/manager.py
+++ b/common/python/powerpi_common/variable/manager.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from powerpi_common.device import DeviceManager, DeviceNotFoundException
 from powerpi_common.logger import Logger, LogMixin
 from powerpi_common.typing import DeviceType, SensorType
@@ -27,9 +25,9 @@ class VariableManager(LogMixin):
         self.__device_manager = device_manager
         self.__service_provider = service_provider
 
-        self.__variables: Dict[
+        self.__variables: dict[
             VariableType,
-            Dict[str, DeviceVariable | SensorVariable]
+            dict[str, DeviceVariable | SensorVariable]
         ] = {}
 
         for variable_type in VariableType:

--- a/common/python/powerpi_common/variable/manager.py
+++ b/common/python/powerpi_common/variable/manager.py
@@ -35,25 +35,25 @@ class VariableManager(LogMixin):
         for variable_type in VariableType:
             self.__variables[variable_type] = {}
 
-    def get_device(self, name: str) -> DeviceVariable | 'DeviceType':
+    def get_device(self, name: str) -> 'DeviceVariable | DeviceType':
         '''
         Returns the device variable if it exists, or the actual device if that exists.
         '''
         return self.__get(VariableType.DEVICE, name)
 
-    def get_sensor(self, name: str, action: str) -> SensorVariable | 'SensorType':
+    def get_sensor(self, name: str, action: str) -> 'SensorVariable | SensorType':
         '''
         Returns the sensor variable if it exists, or the actual sensor if that exists.
         '''
         return self.__get(VariableType.SENSOR, name, action)
 
-    def get_presence(self, name: str) -> PresenceVariable | 'SensorType':
+    def get_presence(self, name: str) -> 'PresenceVariable | SensorType':
         '''
         Returns the presence sensor variable if it exists, or the actual sensor if that exists.
         '''
         return self.__get(VariableType.PRESENCE, name)
 
-    def get_geofence(self, name: str) -> GeofenceVariable | 'SensorType':
+    def get_geofence(self, name: str) -> 'GeofenceVariable | SensorType':
         '''
         Returns the geofence sensor variable if it exists, or the actual sensor if that exists.
         '''

--- a/common/python/powerpi_common/variable/types.py
+++ b/common/python/powerpi_common/variable/types.py
@@ -3,5 +3,6 @@ from enum import StrEnum
 
 class VariableType(StrEnum):
     DEVICE = 'device'
-    SENSOR = 'sensor'
+    GEOFENCE = 'geofence'
     PRESENCE = 'presence'
+    SENSOR = 'sensor'

--- a/common/python/tests/device/mixin/test_capability.py
+++ b/common/python/tests/device/mixin/test_capability.py
@@ -9,12 +9,13 @@ from powerpi_common.device.mixin import CapabilityMixin
 from powerpi_common.logger import Logger
 from powerpi_common.mqtt import MQTTClient
 from powerpi_common.util.data import Range
+from powerpi_common.variable.manager import VariableManager
 
 
 class DeviceImpl(Device, CapabilityMixin):
     # pylint: disable=too-many-ancestors, invalid-overridden-method
-    def __init__(self, *args, **kwargs):
-        Device.__init__(self, *args, **kwargs)
+    def __init__(self, **kwargs):
+        Device.__init__(self, **kwargs)
 
         self.__brightness = False
         self.__temperature = False
@@ -125,9 +126,13 @@ class TestCapabilityMixin:
         self,
         powerpi_config: Config,
         powerpi_logger: Logger,
-        powerpi_mqtt_client: MQTTClient
+        powerpi_mqtt_client: MQTTClient,
+        powerpi_variable_manager: VariableManager
     ):
         return DeviceImpl(
-            powerpi_config, powerpi_logger, powerpi_mqtt_client,
+            config=powerpi_config,
+            logger=powerpi_logger,
+            mqtt_client=powerpi_mqtt_client,
+            variable_manager=powerpi_variable_manager,
             name='CapabilityDevice'
         )

--- a/common/python/tests/device/mixin/test_initialisable.py
+++ b/common/python/tests/device/mixin/test_initialisable.py
@@ -20,8 +20,17 @@ class DeviceImpl(Device, InitialisableMixin):
 class TestInitialisableMixin(DeviceTestBase, InitialisableMixinTestBase):
 
     @pytest.fixture
-    def subject(self, powerpi_config, powerpi_logger, powerpi_mqtt_client):
+    def subject(
+        self,
+        powerpi_config,
+        powerpi_logger,
+        powerpi_mqtt_client,
+        powerpi_variable_manager
+    ):
         return DeviceImpl(
-            powerpi_config, powerpi_logger, powerpi_mqtt_client,
+            config=powerpi_config,
+            logger=powerpi_logger,
+            mqtt_client=powerpi_mqtt_client,
+            variable_manager=powerpi_variable_manager,
             name='initialisable'
         )

--- a/common/python/tests/device/mixin/test_orchestrator.py
+++ b/common/python/tests/device/mixin/test_orchestrator.py
@@ -12,11 +12,9 @@ from powerpi_common.util.data import Range
 
 class DeviceImpl(Device, DeviceOrchestratorMixin):
     # pylint: disable=too-many-ancestors
-    def __init__(self, config, logger, mqtt_client, device_manager, **kwargs):
-        Device.__init__(self, config, logger, mqtt_client, **kwargs)
-        DeviceOrchestratorMixin.__init__(
-            self, config, logger, mqtt_client, device_manager, **kwargs
-        )
+    def __init__(self, **kwargs):
+        Device.__init__(self, **kwargs)
+        DeviceOrchestratorMixin.__init__(self, **kwargs)
 
         self.current_device = None
 
@@ -195,12 +193,17 @@ class TestDeviceOrchestratorMixin(DeviceOrchestratorMixinTestBase):
         powerpi_config,
         powerpi_logger,
         mqtt_client,
+        powerpi_variable_manager,
         device_manager,
         devices,
     ):
         # pylint: disable=too-many-arguments
         return DeviceImpl(
-            powerpi_config, powerpi_logger, mqtt_client, device_manager,
+            config=powerpi_config,
+            logger=powerpi_logger,
+            mqtt_client=mqtt_client,
+            variable_manager=powerpi_variable_manager,
+            device_manager=device_manager,
             name='orchestrator',
             devices=devices
         )

--- a/common/python/tests/device/mixin/test_pollable.py
+++ b/common/python/tests/device/mixin/test_pollable.py
@@ -9,9 +9,16 @@ from powerpi_common.device.mixin import PollableMixin
 class DeviceImpl(Device, PollableMixin):
     # pylint: disable=too-many-ancestors
 
-    def __init__(self, config, logger, mqtt_client, name: str, poll_frequency=60):
+    def __init__(self, config, logger, mqtt_client, variable_manager, name: str, poll_frequency=60):
         # pylint: disable=too-many-arguments
-        Device.__init__(self, config, logger, mqtt_client, name=name)
+        Device.__init__(
+            self,
+            config,
+            logger,
+            mqtt_client,
+            variable_manager,
+            name=name
+        )
         PollableMixin.__init__(self, config, poll_frequency)
 
     async def poll(self):
@@ -26,10 +33,20 @@ class DeviceImpl(Device, PollableMixin):
 
 class TestPollableMixin(DeviceTestBase, PollableMixinTestBase):
 
-    def test_poll_frequency_default(self, powerpi_config, powerpi_logger, powerpi_mqtt_client):
+    def test_poll_frequency_default(
+        self,
+        powerpi_config,
+        powerpi_logger,
+        powerpi_mqtt_client,
+        powerpi_variable_manager
+    ):
         device = DeviceImpl(
-            powerpi_config, powerpi_logger, powerpi_mqtt_client,
-            name='pollable', poll_frequency=120
+            powerpi_config,
+            powerpi_logger,
+            powerpi_mqtt_client,
+            powerpi_variable_manager,
+            name='pollable',
+            poll_frequency=120
         )
 
         assert device.polling_enabled is True
@@ -37,11 +54,20 @@ class TestPollableMixin(DeviceTestBase, PollableMixinTestBase):
 
     @pytest.mark.parametrize('value', [1, 9])
     def test_poll_frequency_too_small(
-        self, powerpi_config, powerpi_logger, powerpi_mqtt_client, value: int
+        self,
+        powerpi_config,
+        powerpi_logger,
+        powerpi_mqtt_client,
+        powerpi_variable_manager,
+        value: int
     ):
         device = DeviceImpl(
-            powerpi_config, powerpi_logger, powerpi_mqtt_client,
-            name='pollable', poll_frequency=value
+            powerpi_config,
+            powerpi_logger,
+            powerpi_mqtt_client,
+            powerpi_variable_manager,
+            name='pollable',
+            poll_frequency=value
         )
 
         assert device.polling_enabled is True
@@ -49,18 +75,36 @@ class TestPollableMixin(DeviceTestBase, PollableMixinTestBase):
 
     @pytest.mark.parametrize('value', [-1, 0])
     def test_poll_frequency_disable(
-        self, powerpi_config, powerpi_logger, powerpi_mqtt_client, value: int
+        self,
+        powerpi_config,
+        powerpi_logger,
+        powerpi_mqtt_client,
+        powerpi_variable_manager,
+        value: int
     ):
         device = DeviceImpl(
-            powerpi_config, powerpi_logger, powerpi_mqtt_client,
-            name='pollable', poll_frequency=value
+            powerpi_config,
+            powerpi_logger,
+            powerpi_mqtt_client,
+            powerpi_variable_manager,
+            name='pollable',
+            poll_frequency=value
         )
 
         assert device.polling_enabled is False
 
     @pytest.fixture
-    def subject(self, powerpi_config, powerpi_logger, powerpi_mqtt_client):
+    def subject(
+        self,
+        powerpi_config,
+        powerpi_logger,
+        powerpi_mqtt_client,
+        powerpi_variable_manager
+    ):
         return DeviceImpl(
-            powerpi_config, powerpi_logger, powerpi_mqtt_client,
+            powerpi_config,
+            powerpi_logger,
+            powerpi_mqtt_client,
+            powerpi_variable_manager,
             name='pollable'
         )

--- a/common/python/tests/device/test_additional_state.py
+++ b/common/python/tests/device/test_additional_state.py
@@ -8,9 +8,19 @@ from powerpi_common.device import AdditionalStateDevice, ReservedScenes
 
 # pylint: disable=too-many-ancestors
 class DeviceImpl(AdditionalStateDevice):
-    def __init__(self, config, logger, mqtt_client):
+    def __init__(
+        self,
+        config,
+        logger,
+        mqtt_client,
+        variable_manager
+    ):
         AdditionalStateDevice.__init__(
-            self, config, logger, mqtt_client,
+            self,
+            config=config,
+            logger=logger,
+            mqtt_client=mqtt_client,
+            variable_manager=variable_manager,
             name='test'
         )
 
@@ -78,5 +88,16 @@ class TestAdditionalStateDevice(AdditionalStateDeviceTestBase):
         assert result.get('brightness', None) == 55
 
     @pytest.fixture
-    def subject(self, powerpi_config, powerpi_logger, powerpi_mqtt_client):
-        return DeviceImpl(powerpi_config, powerpi_logger, powerpi_mqtt_client)
+    def subject(
+        self,
+        powerpi_config,
+        powerpi_logger,
+        powerpi_mqtt_client,
+        powerpi_variable_manager
+    ):
+        return DeviceImpl(
+            powerpi_config,
+            powerpi_logger,
+            powerpi_mqtt_client,
+            powerpi_variable_manager
+        )

--- a/common/python/tests/device/test_device.py
+++ b/common/python/tests/device/test_device.py
@@ -5,9 +5,13 @@ from powerpi_common.device import Device, DeviceStatus
 
 
 class DeviceImpl(Device):
-    def __init__(self, config, logger, mqtt_client):
+    def __init__(self, config, logger, mqtt_client, variable_manager):
         Device.__init__(
-            self, config, logger, mqtt_client,
+            self,
+            config=config,
+            logger=logger,
+            mqtt_client=mqtt_client,
+            variable_manager=variable_manager,
             name='test'
         )
 
@@ -21,14 +25,29 @@ class DeviceImpl(Device):
 class TestDevice(DeviceTestBase):
 
     @pytest.fixture
-    def subject(self, powerpi_config, powerpi_logger, powerpi_mqtt_client):
-        return DeviceImpl(powerpi_config, powerpi_logger, powerpi_mqtt_client)
+    def subject(
+        self,
+        powerpi_config,
+        powerpi_logger,
+        powerpi_mqtt_client,
+        powerpi_variable_manager
+    ):
+        return DeviceImpl(
+            powerpi_config,
+            powerpi_logger,
+            powerpi_mqtt_client,
+            powerpi_variable_manager
+        )
 
 
 class BadDeviceImpl(Device):
-    def __init__(self, config, logger, mqtt_client):
+    def __init__(self, config, logger, mqtt_client, variable_manager):
         Device.__init__(
-            self, config, logger, mqtt_client,
+            self,
+            config=config,
+            logger=logger,
+            mqtt_client=mqtt_client,
+            variable_manager=variable_manager,
             name='test'
         )
 
@@ -58,5 +77,16 @@ class TestBadDevice:
         assert subject.state == DeviceStatus.UNKNOWN
 
     @pytest.fixture
-    def subject(self, powerpi_config, powerpi_logger, powerpi_mqtt_client):
-        return BadDeviceImpl(powerpi_config, powerpi_logger, powerpi_mqtt_client)
+    def subject(
+        self,
+        powerpi_config,
+        powerpi_logger,
+        powerpi_mqtt_client,
+        powerpi_variable_manager
+    ):
+        return BadDeviceImpl(
+            powerpi_config,
+            powerpi_logger,
+            powerpi_mqtt_client,
+            powerpi_variable_manager
+        )

--- a/common/python/tests/device/test_geofence.py
+++ b/common/python/tests/device/test_geofence.py
@@ -32,6 +32,20 @@ class TestGeofence:
 
         assert subject.active is False
 
+    @pytest.mark.asyncio
+    async def test_initialise(
+        self,
+        subject: Geofence,
+        powerpi_variable_manager: MagicMock,
+        mocker: MockerFixture
+    ):
+        get_geofence = mocker.MagicMock()
+        powerpi_variable_manager.get_geofence = get_geofence
+
+        await subject.initialise()
+
+        get_geofence.assert_called_once_with('TestGeofence')
+
     @pytest.fixture
     def subject(self, powerpi_variable_manager):
         return Geofence(powerpi_variable_manager, 'TestGeofence')

--- a/common/python/tests/device/test_geofence.py
+++ b/common/python/tests/device/test_geofence.py
@@ -1,0 +1,50 @@
+from unittest.mock import MagicMock, PropertyMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from powerpi_common.device.geofence import Geofence
+
+
+class TestGeofence:
+
+    def test_active_on(self, subject: Geofence, sensor: MagicMock):
+        type(sensor).state = PropertyMock(return_value='on')
+
+        assert subject.active is True
+
+    def test_active_off(self, subject: Geofence, sensor: MagicMock):
+        type(sensor).state = PropertyMock(return_value='off')
+
+        assert subject.active is False
+
+    def test_active_unknown(self, subject: Geofence, sensor: MagicMock):
+        type(sensor).state = PropertyMock(return_value='unknown')
+
+        assert subject.active is False
+
+    def test_active_sensor_not_found(self, powerpi_variable_manager):
+        subject = Geofence(powerpi_variable_manager, 'OtherGeofence')
+        assert subject.active is True
+
+    def test_active_no_sensor_configured(self, powerpi_variable_manager):
+        subject = Geofence(powerpi_variable_manager, None)
+
+        assert subject.active is False
+
+    @pytest.fixture
+    def subject(self, powerpi_variable_manager):
+        return Geofence(powerpi_variable_manager, 'TestGeofence')
+
+    @pytest.fixture(autouse=True)
+    def sensor(
+        self,
+        powerpi_variable_manager,
+        mocker: MockerFixture
+    ):
+        sensor = mocker.MagicMock()
+
+        powerpi_variable_manager.get_sensor = \
+            lambda name, action: sensor if name == 'TestGeofence' and action == 'status' else None
+
+        return sensor

--- a/common/python/tests/device/test_geofence.py
+++ b/common/python/tests/device/test_geofence.py
@@ -44,7 +44,7 @@ class TestGeofence:
     ):
         sensor = mocker.MagicMock()
 
-        powerpi_variable_manager.get_sensor = \
-            lambda name, action: sensor if name == 'TestGeofence' and action == 'status' else None
+        powerpi_variable_manager.get_geofence = \
+            lambda name: sensor if name == 'TestGeofence' else None
 
         return sensor

--- a/common/python/tests/device/test_manager.py
+++ b/common/python/tests/device/test_manager.py
@@ -6,6 +6,7 @@ from pytest import raises
 from pytest_mock import MockerFixture
 
 from powerpi_common.device import (
+    Device,
     DeviceConfigType,
     DeviceManager,
     DeviceNotFoundException
@@ -13,7 +14,7 @@ from powerpi_common.device import (
 from powerpi_common.device.mixin import InitialisableMixin
 
 
-class DummyDevice:
+class DummyDevice(Device):
     def __init__(
         self,
         device_type: DeviceConfigType,
@@ -22,18 +23,31 @@ class DummyDevice:
         name: str,
         **kwargs
     ):
+        Device.__init__(
+            self,
+            config=mocker.MagicMock(),
+            logger=mocker.MagicMock(),
+            mqtt_client=mocker.MagicMock(),
+            variable_manager=mocker.MagicMock(),
+            name=name,
+            **kwargs
+        )
+
         self.device_type = device_type
         self.instance_type = instance_type
-        self.name = name
         self.kwargs = kwargs
         self.initialised = False
         self.deinitialised = False
 
-        self.geofence = mocker.MagicMock()
-        self.geofence.initialise = mocker.MagicMock()
+        self.__geofence = mocker.MagicMock()
+        self.__geofence.initialise = mocker.MagicMock()
         future = Future()
         future.set_result(True)
-        self.geofence.initialise.return_value = future
+        self.__geofence.initialise.return_value = future
+
+    @property
+    def geofence(self):
+        return self.__geofence
 
     async def initialise(self):
         # this is implemented here to prove it's not called for the wrong devices
@@ -42,6 +56,12 @@ class DummyDevice:
     async def deinitialise(self):
         # this is implemented here to prove it's not called for the wrong devices
         self.deinitialised = True
+
+    async def _turn_on(self):
+        pass
+
+    async def _turn_off(self):
+        pass
 
 
 class InitialisationDummyDevice(DummyDevice, InitialisableMixin):

--- a/common/python/tests/device/test_manager.py
+++ b/common/python/tests/device/test_manager.py
@@ -1,21 +1,39 @@
+from asyncio import Future
+
 import pytest
 from powerpi_common_test.device.mixin import InitialisableMixinTestBase
 from pytest import raises
 from pytest_mock import MockerFixture
 
-from powerpi_common.device import (DeviceConfigType, DeviceManager,
-                                   DeviceNotFoundException)
+from powerpi_common.device import (
+    DeviceConfigType,
+    DeviceManager,
+    DeviceNotFoundException
+)
 from powerpi_common.device.mixin import InitialisableMixin
 
 
 class DummyDevice:
-    def __init__(self, device_type: DeviceConfigType, instance_type: str, name: str, **kwargs):
+    def __init__(
+        self,
+        device_type: DeviceConfigType,
+        instance_type: str,
+        mocker: MockerFixture,
+        name: str,
+        **kwargs
+    ):
         self.device_type = device_type
         self.instance_type = instance_type
         self.name = name
         self.kwargs = kwargs
         self.initialised = False
         self.deinitialised = False
+
+        self.geofence = mocker.MagicMock()
+        self.geofence.initialise = mocker.MagicMock()
+        future = Future()
+        future.set_result(True)
+        self.geofence.initialise.return_value = future
 
     async def initialise(self):
         # this is implemented here to prove it's not called for the wrong devices
@@ -87,8 +105,8 @@ class TestDeviceManager(InitialisableMixinTestBase):
     ):
         def build(device_type: DeviceConfigType, instance_type: str, **kwargs):
             if instance_type.startswith('another'):
-                return InitialisationDummyDevice(device_type, instance_type, **kwargs)
-            return DummyDevice(device_type, instance_type, **kwargs)
+                return InitialisationDummyDevice(device_type, instance_type, mocker, **kwargs)
+            return DummyDevice(device_type, instance_type, mocker, **kwargs)
         device_factory.build = build
 
         mocker.patch.object(powerpi_config, 'devices', {
@@ -117,6 +135,7 @@ class TestDeviceManager(InitialisableMixinTestBase):
             assert device.name == device_name
             assert device.initialised == initialised
             assert device.deinitialised is False
+            device.geofence.initialise.assert_called_once()
 
             if additional:
                 assert device.kwargs == {'something': 'else'}
@@ -131,7 +150,8 @@ class TestDeviceManager(InitialisableMixinTestBase):
             assert sensor.instance_type == instance_type
             assert sensor.name == sensor_name
             assert sensor.initialised == initialised
-            assert device.deinitialised is False
+            assert sensor.deinitialised is False
+            sensor.geofence.initialise.assert_not_called()
 
             if additional:
                 assert sensor.kwargs == {'yet_another_arg': 'more'}
@@ -148,8 +168,8 @@ class TestDeviceManager(InitialisableMixinTestBase):
     ):
         def build(device_type: DeviceConfigType, instance_type: str, **kwargs):
             if instance_type.startswith('another'):
-                return InitialisationDummyDevice(device_type, instance_type, **kwargs)
-            return DummyDevice(device_type, instance_type, **kwargs)
+                return InitialisationDummyDevice(device_type, instance_type, mocker, **kwargs)
+            return DummyDevice(device_type, instance_type, mocker, **kwargs)
         device_factory.build = build
 
         mocker.patch.object(powerpi_config, 'devices', {

--- a/common/python/tests/sensor/mixin/test_battery.py
+++ b/common/python/tests/sensor/mixin/test_battery.py
@@ -2,26 +2,22 @@ import pytest
 from powerpi_common_test.sensor import SensorTestBase
 from powerpi_common_test.sensor.mixin import BatteryMixinTestBase
 
-from powerpi_common.mqtt.client import MQTTClient
 from powerpi_common.sensor.mixin import BatteryMixin
 from powerpi_common.sensor.sensor import Sensor
 
 
 class SensorImpl(Sensor, BatteryMixin):
-    def __init__(
-        self,
-        mqtt_client: MQTTClient,
-        **kwargs
-    ):
-        Sensor.__init__(self, mqtt_client, **kwargs)
+    def __init__(self, **kwargs):
+        Sensor.__init__(self, **kwargs)
         BatteryMixin.__init__(self)
 
 
 class TestBatteryMixin(SensorTestBase, BatteryMixinTestBase):
 
     @pytest.fixture
-    def subject(self, powerpi_mqtt_client):
+    def subject(self, powerpi_logger, powerpi_mqtt_client):
         return SensorImpl(
-            powerpi_mqtt_client,
+            logger=powerpi_logger,
+            mqtt_client=powerpi_mqtt_client,
             name='TestBattery'
         )

--- a/common/python/tests/sensor/test_sensor.py
+++ b/common/python/tests/sensor/test_sensor.py
@@ -1,19 +1,12 @@
 import pytest
 from powerpi_common_test.sensor import SensorTestBase
 
-from powerpi_common.mqtt import MQTTClient
 from powerpi_common.sensor import Sensor
 
 
 class SensorImpl(Sensor):
-    def __init__(
-        self,
-        mqtt_client: MQTTClient,
-        entity: str | None,
-        action: str | None,
-        **kwargs
-    ):
-        Sensor.__init__(self, mqtt_client, entity, action, **kwargs)
+    def __init__(self, **kwargs):
+        Sensor.__init__(self, **kwargs)
 
 
 class TestSensor(SensorTestBase):
@@ -65,10 +58,13 @@ class TestSensor(SensorTestBase):
         powerpi_mqtt_producer.assert_called_once_with(topic, message)
 
     @pytest.fixture
-    def subject_builder(self, powerpi_mqtt_client):
+    def subject_builder(self, powerpi_logger, powerpi_mqtt_client):
         def build(entity: str | None = None, action: str | None = None):
             return SensorImpl(
-                powerpi_mqtt_client, entity, action,
+                logger=powerpi_logger,
+                mqtt_client=powerpi_mqtt_client,
+                entity=entity,
+                action=action,
                 name='TestSensor'
             )
 

--- a/common/python/tests/variable/test_device.py
+++ b/common/python/tests/variable/test_device.py
@@ -8,6 +8,12 @@ from powerpi_common.variable.device import DeviceVariable
 
 class TestDeviceVariable(VariableTestBase):
 
+    def test_topic(self, subject: DeviceVariable):
+        assert subject.topic == 'device/TestVariable/status'
+
+    def test_variable_type(self, subject: DeviceVariable):
+        assert subject.variable_type == 'device'
+
     @pytest.mark.asyncio
     async def test_on_status_change(self, subject: DeviceVariable):
         assert subject.scene == ReservedScenes.DEFAULT

--- a/common/python/tests/variable/test_geofence.py
+++ b/common/python/tests/variable/test_geofence.py
@@ -1,0 +1,28 @@
+import pytest
+from powerpi_common_test.variable.variable import VariableTestBase
+
+from powerpi_common.device import DeviceStatus
+from powerpi_common.variable.geofence import GeofenceVariable
+
+
+class TestGeofenceVariable(VariableTestBase):
+
+    def test_topic(self, subject: GeofenceVariable):
+        assert subject.topic == 'geofence/TestGeofence/status'
+
+    @pytest.mark.asyncio
+    async def test_on_message_updates(self, subject: GeofenceVariable):
+        message = {'state': DeviceStatus.OFF}
+
+        assert subject.state == DeviceStatus.UNKNOWN
+
+        await subject.on_message(message, 'TestGeofence', 'status')
+
+        assert subject.state == DeviceStatus.OFF
+
+    @pytest.fixture
+    def subject(self, powerpi_config, powerpi_logger, powerpi_mqtt_client):
+        return GeofenceVariable(
+            powerpi_config, powerpi_logger, powerpi_mqtt_client,
+            name='TestGeofence'
+        )

--- a/common/python/tests/variable/test_geofence.py
+++ b/common/python/tests/variable/test_geofence.py
@@ -10,6 +10,9 @@ class TestGeofenceVariable(VariableTestBase):
     def test_topic(self, subject: GeofenceVariable):
         assert subject.topic == 'geofence/TestGeofence/status'
 
+    def test_variable_type(self, subject: GeofenceVariable):
+        assert subject.variable_type == 'geofence'
+
     @pytest.mark.asyncio
     async def test_on_message_updates(self, subject: GeofenceVariable):
         message = {'state': DeviceStatus.OFF}

--- a/common/python/tests/variable/test_manager.py
+++ b/common/python/tests/variable/test_manager.py
@@ -23,6 +23,12 @@ class PresenceVariableImpl:
         self.variable_type = VariableType.PRESENCE
 
 
+class GeofenceVariableImpl:
+    def __init__(self, name: str):
+        self.name = name
+        self.variable_type = VariableType.GEOFENCE
+
+
 class TestVariableManager:
 
     @pytest.mark.parametrize(
@@ -41,10 +47,12 @@ class TestVariableManager:
         powerpi_device_manager.get_device = not_found
         powerpi_device_manager.get_sensor = not_found
         powerpi_device_manager.get_presence = not_found
+        powerpi_device_manager.get_geofence = not_found
 
         powerpi_service_provider.device_variable = DeviceVariableImpl
         powerpi_service_provider.sensor_variable = SensorVariableImpl
         powerpi_service_provider.presence_variable = PresenceVariableImpl
+        powerpi_service_provider.geofence_variable = GeofenceVariableImpl
 
         name = 'new_variable'
 
@@ -52,6 +60,7 @@ class TestVariableManager:
             VariableType.DEVICE: lambda: subject.get_device(name),
             VariableType.SENSOR: lambda: subject.get_sensor(name, 'action'),
             VariableType.PRESENCE: lambda: subject.get_presence(name),
+            VariableType.GEOFENCE: lambda: subject.get_geofence(name),
         }
 
         result = getters[variable_type]()
@@ -62,7 +71,12 @@ class TestVariableManager:
 
     @pytest.mark.parametrize(
         'variable_type',
-        [VariableType.DEVICE, VariableType.SENSOR, VariableType.PRESENCE]
+        [
+            VariableType.DEVICE,
+            VariableType.SENSOR,
+            VariableType.PRESENCE,
+            VariableType.GEOFENCE
+        ]
     )
     def test_get_x_from_manager(
         self,
@@ -72,9 +86,16 @@ class TestVariableManager:
         variable_type: VariableType
     ):
         powerpi_device_manager.get_device = DeviceVariableImpl
-        powerpi_device_manager.get_sensor = lambda name: SensorVariableImpl(
-            name, 'action'
-        ) if variable_type == VariableType.SENSOR else PresenceVariableImpl(name)
+
+        def get_sensor(name: str):
+            if variable_type == VariableType.SENSOR:
+                return SensorVariableImpl(name, 'action')
+            if variable_type == VariableType.PRESENCE:
+                return PresenceVariableImpl(name)
+            if variable_type == VariableType.GEOFENCE:
+                return GeofenceVariableImpl(name)
+            return None
+        powerpi_device_manager.get_sensor = get_sensor
 
         name = 'found_device'
 
@@ -88,10 +109,16 @@ class TestVariableManager:
         powerpi_service_provider.device_variable.assert_not_called()
         powerpi_service_provider.sensor_variable.assert_not_called()
         powerpi_service_provider.presence_variable.assert_not_called()
+        powerpi_service_provider.geofence_variable.assert_not_called()
 
     @pytest.mark.parametrize(
         'variable_type',
-        [VariableType.DEVICE, VariableType.SENSOR, VariableType.PRESENCE]
+        [
+            VariableType.DEVICE,
+            VariableType.SENSOR,
+            VariableType.PRESENCE,
+            VariableType.GEOFENCE
+        ]
     )
     def test_get_x_exists(
         self,
@@ -106,6 +133,7 @@ class TestVariableManager:
             VariableType.DEVICE: lambda: DeviceVariableImpl(name),
             VariableType.SENSOR: lambda: SensorVariableImpl(name, 'action'),
             VariableType.PRESENCE: lambda: PresenceVariableImpl(name),
+            VariableType.GEOFENCE: lambda: GeofenceVariableImpl(name),
         }
 
         variable = variables[variable_type]()
@@ -117,6 +145,7 @@ class TestVariableManager:
             VariableType.DEVICE: lambda: subject.get_device(name),
             VariableType.SENSOR: lambda: subject.get_sensor(name, 'action'),
             VariableType.PRESENCE: lambda: subject.get_presence(name),
+            VariableType.GEOFENCE: lambda: subject.get_geofence(name),
         }
 
         result = getters[variable_type]()
@@ -126,11 +155,11 @@ class TestVariableManager:
 
         powerpi_device_manager.get_device.assert_not_called()
         powerpi_device_manager.get_sensor.assert_not_called()
-        powerpi_device_manager.get_presence.assert_not_called()
 
         powerpi_service_provider.device_variable.assert_not_called()
         powerpi_service_provider.sensor_variable.assert_not_called()
         powerpi_service_provider.presence_variable.assert_not_called()
+        powerpi_service_provider.geofence_variable.assert_not_called()
 
     @pytest.fixture
     def subject(self, powerpi_logger, powerpi_device_manager, powerpi_service_provider):

--- a/common/python/tests/variable/test_presence.py
+++ b/common/python/tests/variable/test_presence.py
@@ -10,6 +10,9 @@ class TestPresenceVariable(VariableTestBase):
     def test_topic(self, subject: PresenceVariable):
         assert subject.topic == 'presence/TestPresence/status'
 
+    def test_variable_type(self, subject: PresenceVariable):
+        assert subject.variable_type == 'presence'
+
     @pytest.mark.asyncio
     async def test_on_message_updates(self, subject: PresenceVariable):
         message = {'state': 'absent'}

--- a/common/python/tests/variable/test_sensor.py
+++ b/common/python/tests/variable/test_sensor.py
@@ -9,6 +9,9 @@ class TestSensorVariable(VariableTestBase):
     def test_topic(self, subject: SensorVariable):
         assert subject.topic == 'event/TestSensor/detect'
 
+    def test_variable_type(self, subject: SensorVariable):
+        assert subject.variable_type == 'sensor'
+
     @pytest.mark.asyncio
     async def test_on_message_updates(self, subject: SensorVariable):
         message = {'value': 12.34, 'unit': 'doughnuts'}

--- a/controllers/energenie/energenie_controller/container.py
+++ b/controllers/energenie/energenie_controller/container.py
@@ -33,5 +33,6 @@ class ApplicationContainer(containers.DeclarativeContainer):
         mqtt_client=common.mqtt_client,
         device_status_checker=common.device.device_status_checker,
         scheduler=common.scheduler,
-        health=common.health
+        health=common.health,
+        container=common
     )

--- a/controllers/energenie/energenie_controller/controller.py
+++ b/controllers/energenie/energenie_controller/controller.py
@@ -1,4 +1,5 @@
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from dependency_injector import containers
 from powerpi_common.controller import Controller as CommonController
 from powerpi_common.device import DeviceManager, DeviceStatusChecker
 from powerpi_common.health import HealthService
@@ -19,13 +20,20 @@ class Controller(CommonController):
         mqtt_client: MQTTClient,
         device_status_checker: DeviceStatusChecker,
         scheduler: AsyncIOScheduler,
-        health: HealthService
+        health: HealthService,
+        container: containers.DeclarativeContainer
     ):
         CommonController.__init__(
-            self, logger, device_manager,
-            mqtt_client, device_status_checker,
-            scheduler, health,
-            __app_name__, __version__
+            self,
+            logger,
+            device_manager,
+            mqtt_client,
+            device_status_checker,
+            scheduler,
+            health,
+            container,
+            __app_name__,
+            __version__
         )
 
         self.__config = config

--- a/controllers/energenie/energenie_controller/device/container.py
+++ b/controllers/energenie/energenie_controller/device/container.py
@@ -33,9 +33,6 @@ def add_devices(container):
         'energenie_socket_device',
         providers.Factory(
             SocketDevice,
-            config=container.common.config,
-            logger=container.common.logger,
-            mqtt_client=container.common.mqtt_client,
             energenie=container.common.device.energenie
         )
     )
@@ -45,9 +42,6 @@ def add_devices(container):
         'energenie_socket_group_device',
         providers.Factory(
             SocketGroupDevice,
-            config=container.common.config,
-            logger=container.common.logger,
-            mqtt_client=container.common.mqtt_client,
             device_manager=container.common.device.device_manager,
             energenie=container.common.device.energenie
         )
@@ -58,9 +52,6 @@ def add_devices(container):
         'energenie_pairing_device',
         providers.Factory(
             EnergeniePairingDevice,
-            config=container.common.config,
-            logger=container.common.logger,
-            mqtt_client=container.common.mqtt_client,
             energenie=container.common.device.energenie
         )
     )

--- a/controllers/energenie/energenie_controller/device/energenie_pairing.py
+++ b/controllers/energenie/energenie_controller/device/energenie_pairing.py
@@ -5,22 +5,18 @@ from typing import Any, Dict, List
 from energenie_controller.config import EnergenieConfig
 from energenie_controller.energenie import EnergenieInterface
 from powerpi_common.device import Device, DeviceStatus
-from powerpi_common.logger import Logger
-from powerpi_common.mqtt import MQTTClient
 
 
 class EnergeniePairingDevice(Device):
-    #pylint: disable=too-many-arguments
+
     def __init__(
         self,
         config: EnergenieConfig,
-        logger: Logger,
-        mqtt_client: MQTTClient,
         energenie: EnergenieInterface,
         timeout: float = 120,
         **kwargs
     ):
-        Device.__init__(self, config, logger, mqtt_client, **kwargs)
+        Device.__init__(self, config=config, **kwargs)
 
         self.__config = config
         self.__energenie = energenie

--- a/controllers/energenie/energenie_controller/device/socket.py
+++ b/controllers/energenie/energenie_controller/device/socket.py
@@ -2,19 +2,13 @@ from asyncio import sleep
 from typing import Callable
 
 from energenie_controller.energenie import EnergenieInterface
-from powerpi_common.config import Config
-from powerpi_common.logger import Logger
 from powerpi_common.device import Device
-from powerpi_common.mqtt import MQTTClient
 
 
 class SocketDevice(Device):
-    #pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments
     def __init__(
         self,
-        config: Config,
-        logger: Logger,
-        mqtt_client: MQTTClient,
         energenie: EnergenieInterface,
         device_id=0,  # for individual socket in group,
         home_id=0,  # for ENER314
@@ -22,7 +16,7 @@ class SocketDevice(Device):
         delay=0.2,
         **kwargs
     ):
-        Device.__init__(self, config, logger, mqtt_client, **kwargs)
+        Device.__init__(self, **kwargs)
 
         self.__energenie = energenie
         self.__retries = retries

--- a/controllers/energenie/energenie_controller/device/socket_group.py
+++ b/controllers/energenie/energenie_controller/device/socket_group.py
@@ -1,34 +1,25 @@
 from asyncio import sleep
-from typing import Callable, List
+from typing import Callable
 
 from energenie_controller.energenie import EnergenieInterface
-from powerpi_common.config import Config
-from powerpi_common.logger import Logger
-from powerpi_common.device import Device, DeviceManager, DeviceStatus
+from powerpi_common.device import Device, DeviceStatus
 from powerpi_common.device.mixin import DeviceOrchestratorMixin
-from powerpi_common.mqtt import MQTTClient
 
 
-#pylint: disable=too-many-ancestors
+# pylint: disable=too-many-ancestors
 class SocketGroupDevice(Device, DeviceOrchestratorMixin):
-    #pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments
     def __init__(
         self,
-        config: Config,
-        logger: Logger,
-        mqtt_client: MQTTClient,
-        device_manager: DeviceManager,
         energenie: EnergenieInterface,
-        devices: List[str],
+        devices: list[str],
         home_id=0,  # for ENER314
         retries=2,
         delay=0.2,
         **kwargs
     ):
-        Device.__init__(self, config, logger, mqtt_client, **kwargs)
-        DeviceOrchestratorMixin.__init__(
-            self, config, logger, mqtt_client, device_manager, devices
-        )
+        Device.__init__(self,  **kwargs)
+        DeviceOrchestratorMixin.__init__(self, devices=devices, **kwargs)
 
         self.__energenie = energenie
         self.__retries = retries

--- a/controllers/energenie/pyproject.toml
+++ b/controllers/energenie/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "energenie_controller"
-version = "0.3.7-rc.7"
+version = "0.3.7-rc.8"
 description = "PowerPi Energenie Controller"
 license = "GPL-3.0-only"
 authors = [

--- a/controllers/energenie/tests/conftest.py
+++ b/controllers/energenie/tests/conftest.py
@@ -1,7 +1,11 @@
 # pylint: disable=unused-import
 
 import pytest
-from powerpi_common_test.fixture import (powerpi_config,
-                                         powerpi_device_manager,
-                                         powerpi_logger, powerpi_mqtt_client,
-                                         powerpi_mqtt_producer)
+from powerpi_common_test.fixture import (
+    powerpi_config,
+    powerpi_device_manager,
+    powerpi_logger,
+    powerpi_mqtt_client,
+    powerpi_mqtt_producer,
+    powerpi_variable_manager
+)

--- a/controllers/energenie/tests/device/test_energenie_pairing.py
+++ b/controllers/energenie/tests/device/test_energenie_pairing.py
@@ -152,14 +152,16 @@ class TestEnergeniePairingDevice(DeviceTestBase):
         powerpi_config,
         powerpi_logger,
         powerpi_mqtt_client,
+        powerpi_variable_manager,
         energenie
     ):
         return EnergeniePairingDevice(
-            powerpi_config,
-            powerpi_logger,
-            powerpi_mqtt_client,
-            energenie,
-            self.__timeout,
+            config=powerpi_config,
+            logger=powerpi_logger,
+            mqtt_client=powerpi_mqtt_client,
+            variable_manager=powerpi_variable_manager,
+            energenie=energenie,
+            timeout=self.__timeout,
             name='EnergeniePairing'
         )
 

--- a/controllers/energenie/tests/device/test_socket.py
+++ b/controllers/energenie/tests/device/test_socket.py
@@ -26,14 +26,18 @@ class TestSocketDevice(DeviceTestBase):
         powerpi_config,
         powerpi_logger,
         powerpi_mqtt_client,
+        powerpi_variable_manager,
         mocker: MockerFixture
     ):
         energenie = mocker.MagicMock()
 
         return SocketDevice(
-            powerpi_config,
-            powerpi_logger,
-            powerpi_mqtt_client,
-            energenie,
-            name='test', retries=2, delay=0
+            config=powerpi_config,
+            logger=powerpi_logger,
+            mqtt_client=powerpi_mqtt_client,
+            variable_manager=powerpi_variable_manager,
+            energenie=energenie,
+            name='test',
+            retries=2,
+            delay=0
         )

--- a/controllers/energenie/tests/device/test_socket_group.py
+++ b/controllers/energenie/tests/device/test_socket_group.py
@@ -11,8 +11,15 @@ from energenie_controller.device.socket_group import SocketGroupDevice
 
 
 class MockSocket(Device):
-    def __init__(self, config, logger, mqtt_client, name):
-        Device.__init__(self, config, logger, mqtt_client, name=name)
+    def __init__(self, config, logger, mqtt_client, variable_manager, name):
+        Device.__init__(
+            self,
+            config=config,
+            logger=logger,
+            mqtt_client=mqtt_client,
+            variable_manager=variable_manager,
+            name=name
+        )
 
     async def _turn_on(self):
         pass
@@ -129,6 +136,7 @@ class TestSocketGroupDevice(DeviceTestBase, DeviceOrchestratorMixinTestBase):
         powerpi_config,
         powerpi_logger,
         powerpi_mqtt_client,
+        powerpi_variable_manager,
         powerpi_device_manager,
         sockets,
         mocker: MockerFixture
@@ -142,11 +150,12 @@ class TestSocketGroupDevice(DeviceTestBase, DeviceOrchestratorMixinTestBase):
         devices = sockets.keys()
 
         return SocketGroupDevice(
-            powerpi_config,
-            powerpi_logger,
-            powerpi_mqtt_client,
-            powerpi_device_manager,
-            energenie,
+            config=powerpi_config,
+            logger=powerpi_logger,
+            mqtt_client=powerpi_mqtt_client,
+            variable_manager=powerpi_variable_manager,
+            device_manager=powerpi_device_manager,
+            energenie=energenie,
             name='socket_group',
             devices=devices,
             retries=2,
@@ -159,7 +168,12 @@ class TestSocketGroupDevice(DeviceTestBase, DeviceOrchestratorMixinTestBase):
         powerpi_config,
         powerpi_logger,
         powerpi_mqtt_client,
+        powerpi_variable_manager
     ):
         return {f'socket{i}': MockSocket(
-            powerpi_config, powerpi_logger, powerpi_mqtt_client, f'socket{i}'
+            powerpi_config,
+            powerpi_logger,
+            powerpi_mqtt_client,
+            powerpi_variable_manager,
+            f'socket{i}'
         ) for i in range(0, 4)}

--- a/controllers/harmony/harmony_controller/device/container.py
+++ b/controllers/harmony/harmony_controller/device/container.py
@@ -28,9 +28,6 @@ def add_devices(container):
         'harmony_hub_device',
         providers.Factory(
             HarmonyHubDevice,
-            config=container.common.config,
-            logger=container.common.logger,
-            mqtt_client=container.common.mqtt_client,
             device_manager=container.common.device.device_manager,
             harmony_client=container.device.harmony_client
         )
@@ -41,9 +38,6 @@ def add_devices(container):
         'harmony_activity_device',
         providers.Factory(
             HarmonyActivityDevice,
-            config=container.common.config,
-            logger=container.common.logger,
-            mqtt_client=container.common.mqtt_client,
             device_manager=container.common.device.device_manager
         )
     )

--- a/controllers/harmony/harmony_controller/device/harmony_activity.py
+++ b/controllers/harmony/harmony_controller/device/harmony_activity.py
@@ -1,9 +1,6 @@
 from lazy import lazy
 
-from powerpi_common.config import Config
-from powerpi_common.logger import Logger
 from powerpi_common.device import Device, DeviceManager
-from powerpi_common.mqtt import MQTTClient
 from .harmony_hub import HarmonyHubDevice
 
 
@@ -11,17 +8,12 @@ class HarmonyActivityDevice(Device):
     # pylint: disable=too-many-arguments
     def __init__(
         self,
-        config: Config,
-        logger: Logger,
-        mqtt_client: MQTTClient,
         device_manager: DeviceManager,
         hub: str,
         activity_name: str = None,
         **kwargs
     ):
-        Device.__init__(
-            self, config, logger, mqtt_client, **kwargs
-        )
+        Device.__init__(self, **kwargs)
 
         self.__device_manager = device_manager
         self.__hub_name = hub

--- a/controllers/harmony/harmony_controller/device/harmony_hub.py
+++ b/controllers/harmony/harmony_controller/device/harmony_hub.py
@@ -1,11 +1,8 @@
 from typing import Dict, NamedTuple
 
 from cache import AsyncTTL
-from powerpi_common.config import Config
 from powerpi_common.device import Device, DeviceManager, DeviceStatus
 from powerpi_common.device.mixin import PollableMixin
-from powerpi_common.logger import Logger
-from powerpi_common.mqtt import MQTTClient
 
 from .harmony_client import HarmonyClient
 
@@ -25,19 +22,14 @@ class HarmonyHubDevice(Device, PollableMixin):
     # pylint: disable=too-many-arguments
     def __init__(
         self,
-        config: Config,
-        logger: Logger,
-        mqtt_client: MQTTClient,
         device_manager: DeviceManager,
         harmony_client: HarmonyClient,
         ip: str | None = None,
         hostname: str | None = None,
         **kwargs
     ):
-        Device.__init__(
-            self, config, logger, mqtt_client, **kwargs
-        )
-        PollableMixin.__init__(self, config, **kwargs)
+        Device.__init__(self, **kwargs)
+        PollableMixin.__init__(self, **kwargs)
 
         self.__device_manager = device_manager
 

--- a/controllers/harmony/pyproject.toml
+++ b/controllers/harmony/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "harmony_controller"
-version = "0.4.10-rc.9"
+version = "0.4.10-rc.10"
 description = "PowerPi Logitech Harmony Controller"
 license = "GPL-3.0-only"
 authors = [

--- a/controllers/harmony/tests/conftest.py
+++ b/controllers/harmony/tests/conftest.py
@@ -1,9 +1,13 @@
 # pylint: disable=unused-import
 
 import pytest
-from powerpi_common_test.fixture import (powerpi_config,
-                                         powerpi_device_manager,
-                                         powerpi_logger, powerpi_mqtt_client,
-                                         powerpi_mqtt_producer)
+from powerpi_common_test.fixture import (
+    powerpi_config,
+    powerpi_device_manager,
+    powerpi_logger,
+    powerpi_mqtt_client,
+    powerpi_mqtt_producer,
+    powerpi_variable_manager
+)
 
 from .fixtures import harmony_client

--- a/controllers/harmony/tests/device/test_harmony_activity.py
+++ b/controllers/harmony/tests/device/test_harmony_activity.py
@@ -61,6 +61,7 @@ class TestHarmonyActivityDevice(DeviceTestBase):
         powerpi_config,
         powerpi_logger,
         powerpi_mqtt_client,
+        powerpi_variable_manager,
         powerpi_device_manager: DeviceManager,
         harmony_hub,
         mocker: MockerFixture
@@ -73,12 +74,13 @@ class TestHarmonyActivityDevice(DeviceTestBase):
         )
 
         return HarmonyActivityDevice(
-            powerpi_config,
-            powerpi_logger,
-            powerpi_mqtt_client,
-            powerpi_device_manager,
-            'hub',
-            'my activity',
+            config=powerpi_config,
+            logger=powerpi_logger,
+            mqtt_client=powerpi_mqtt_client,
+            variable_manager=powerpi_variable_manager,
+            device_manager=powerpi_device_manager,
+            hub='hub',
+            activity_name='my activity',
             name='testactivity'
         )
 

--- a/controllers/harmony/tests/device/test_harmony_hub.py
+++ b/controllers/harmony/tests/device/test_harmony_hub.py
@@ -215,6 +215,7 @@ class TestHarmonyHubDevice(DeviceTestBase, PollableMixinTestBase):
         powerpi_config,
         powerpi_logger,
         powerpi_mqtt_client,
+        powerpi_variable_manager,
         powerpi_device_manager: DeviceManager,
         harmony_client,
         harmony_config,
@@ -225,11 +226,12 @@ class TestHarmonyHubDevice(DeviceTestBase, PollableMixinTestBase):
         # pylint: disable=too-many-arguments
 
         hub = HarmonyHubDevice(
-            powerpi_config,
-            powerpi_logger,
-            powerpi_mqtt_client,
-            powerpi_device_manager,
-            harmony_client,
+            config=powerpi_config,
+            logger=powerpi_logger,
+            mqtt_client=powerpi_mqtt_client,
+            variable_manager=powerpi_variable_manager,
+            device_manager=powerpi_device_manager,
+            harmony_client=harmony_client,
             name=self.__hub_name,
             poll_frequency=120
         )
@@ -267,13 +269,15 @@ class TestHarmonyHubDevice(DeviceTestBase, PollableMixinTestBase):
         powerpi_config,
         powerpi_logger,
         powerpi_mqtt_client,
+        powerpi_variable_manager,
         powerpi_device_manager
     ):
         return [HarmonyActivityDevice(
-            powerpi_config,
-            powerpi_logger,
-            powerpi_mqtt_client,
-            powerpi_device_manager,
+            config=powerpi_config,
+            logger=powerpi_logger,
+            mqtt_client=powerpi_mqtt_client,
+            variable_manager=powerpi_variable_manager,
+            device_manager=powerpi_device_manager,
             name=f'activity{i}',
             activity_name=f'Test Activity {i}',
             hub=self.__hub_name
@@ -285,13 +289,15 @@ class TestHarmonyHubDevice(DeviceTestBase, PollableMixinTestBase):
         powerpi_config,
         powerpi_logger,
         powerpi_mqtt_client,
+        powerpi_variable_manager,
         powerpi_device_manager
     ):
         return HarmonyActivityDevice(
-            powerpi_config,
-            powerpi_logger,
-            powerpi_mqtt_client,
-            powerpi_device_manager,
+            config=powerpi_config,
+            logger=powerpi_logger,
+            mqtt_client=powerpi_mqtt_client,
+            variable_manager=powerpi_variable_manager,
+            device_manager=powerpi_device_manager,
             name='wronghubactivity',
             activity_name='Test Activity 0',
             hub='WrongHub'

--- a/controllers/lifx/lifx_controller/device/container.py
+++ b/controllers/lifx/lifx_controller/device/container.py
@@ -27,9 +27,6 @@ def add_devices(container):
         'lifx_light_device',
         providers.Factory(
             LIFXLightDevice,
-            config=container.common.config,
-            logger=container.common.logger,
-            mqtt_client=container.common.mqtt_client,
             lifx_client=container.device.lifx_client
         )
     )

--- a/controllers/lifx/lifx_controller/device/lifx_light.py
+++ b/controllers/lifx/lifx_controller/device/lifx_light.py
@@ -1,11 +1,11 @@
 from typing import TypedDict
 
-from powerpi_common.config import Config
 from powerpi_common.device import AdditionalStateDevice, DeviceStatus
-from powerpi_common.device.mixin import (CapabilityMixin, InitialisableMixin,
-                                         PollableMixin)
-from powerpi_common.logger import Logger
-from powerpi_common.mqtt import MQTTClient
+from powerpi_common.device.mixin import (
+    CapabilityMixin,
+    InitialisableMixin,
+    PollableMixin
+)
 from powerpi_common.util.data import DataType
 
 from lifx_controller.device.lifx_client import LIFXClient
@@ -28,9 +28,6 @@ class LIFXLightDevice(AdditionalStateDevice, PollableMixin, InitialisableMixin, 
     # pylint: disable=too-many-arguments
     def __init__(
         self,
-        config: Config,
-        logger: Logger,
-        mqtt_client: MQTTClient,
         lifx_client: LIFXClient,
         mac: str,
         ip: str = None,
@@ -39,9 +36,9 @@ class LIFXLightDevice(AdditionalStateDevice, PollableMixin, InitialisableMixin, 
         **kwargs
     ):
         AdditionalStateDevice.__init__(
-            self, config, logger, mqtt_client, **kwargs
+            self, **kwargs
         )
-        PollableMixin.__init__(self, config, **kwargs)
+        PollableMixin.__init__(self, **kwargs)
 
         self.__duration = duration
 

--- a/controllers/lifx/pyproject.toml
+++ b/controllers/lifx/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lifx_controller"
-version = "0.6.6-rc.7"
+version = "0.6.6-rc.8"
 description = "PowerPi LIFX Controller"
 license = "GPL-3.0-only"
 authors = [

--- a/controllers/lifx/tests/conftest.py
+++ b/controllers/lifx/tests/conftest.py
@@ -1,8 +1,12 @@
 # pylint: disable=unused-import
 
 import pytest
-from powerpi_common_test.fixture import (powerpi_config, powerpi_logger,
-                                         powerpi_mqtt_client,
-                                         powerpi_mqtt_producer)
+from powerpi_common_test.fixture import (
+    powerpi_config,
+    powerpi_logger,
+    powerpi_mqtt_client,
+    powerpi_mqtt_producer,
+    powerpi_variable_manager
+)
 
 from .fixtures import lifx_client

--- a/controllers/lifx/tests/device/test_lifx_light.py
+++ b/controllers/lifx/tests/device/test_lifx_light.py
@@ -5,8 +5,10 @@ from unittest.mock import MagicMock, PropertyMock
 import pytest
 from powerpi_common.util.data import Range
 from powerpi_common_test.device import AdditionalStateDeviceTestBase
-from powerpi_common_test.device.mixin import (InitialisableMixinTestBase,
-                                              PollableMixinTestBase)
+from powerpi_common_test.device.mixin import (
+    InitialisableMixinTestBase,
+    PollableMixinTestBase
+)
 from pytest_mock import MockerFixture
 
 from lifx_controller.device.lifx_client import LIFXClient
@@ -171,12 +173,19 @@ class TestLIFXLightDevice(
         powerpi_config,
         powerpi_logger,
         powerpi_mqtt_client,
+        powerpi_variable_manager,
         lifx_client
     ):
         return LIFXLightDevice(
-            powerpi_config, powerpi_logger, powerpi_mqtt_client, lifx_client,
-            '00:00:00:00:00', 'mylight.home',
-            name='light', poll_frequency=120
+            config=powerpi_config,
+            logger=powerpi_logger,
+            mqtt_client=powerpi_mqtt_client,
+            variable_manager=powerpi_variable_manager,
+            lifx_client=lifx_client,
+            mac='00:00:00:00:00',
+            hostname='mylight.home',
+            name='light',
+            poll_frequency=120
         )
 
     def __mock_supports(

--- a/controllers/network/network_controller/container.py
+++ b/controllers/network/network_controller/container.py
@@ -41,5 +41,6 @@ class ApplicationContainer(containers.DeclarativeContainer):
         device_status_checker=common.device.device_status_checker,
         scheduler=common.scheduler,
         health=common.health,
+        container=common,
         arp_provider_factory=services.container.arp_provider_factory
     )

--- a/controllers/network/network_controller/controller.py
+++ b/controllers/network/network_controller/controller.py
@@ -1,4 +1,5 @@
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from dependency_injector import containers
 from powerpi_common.controller import Controller as CommonController
 from powerpi_common.device import DeviceManager, DeviceStatusChecker
 from powerpi_common.health import HealthService
@@ -19,13 +20,20 @@ class Controller(CommonController):
         device_status_checker: DeviceStatusChecker,
         scheduler: AsyncIOScheduler,
         health: HealthService,
+        container: containers.DeclarativeContainer,
         arp_provider_factory: ARPProviderFactory
     ):
         CommonController.__init__(
-            self, logger, device_manager,
-            mqtt_client, device_status_checker,
-            scheduler, health,
-            __app_name__, __version__
+            self,
+            logger,
+            device_manager,
+            mqtt_client,
+            device_status_checker,
+            scheduler,
+            health,
+            container,
+            __app_name__,
+            __version__
         )
 
         self.__arp_provider_factory = arp_provider_factory

--- a/controllers/network/network_controller/device/computer.py
+++ b/controllers/network/network_controller/device/computer.py
@@ -2,11 +2,8 @@ from asyncio import sleep
 
 from powerpi_common.device import Device, DeviceStatus
 from powerpi_common.device.mixin import PollableMixin
-from powerpi_common.logger import Logger
-from powerpi_common.mqtt import MQTTClient
 from wakeonlan import send_magic_packet
 
-from network_controller.config import NetworkConfig
 from network_controller.util import ping
 
 
@@ -19,9 +16,6 @@ class ComputerDevice(Device, PollableMixin):
 
     def __init__(
         self,
-        config: NetworkConfig,
-        logger: Logger,
-        mqtt_client: MQTTClient,
         mac: str,
         ip: str | None = None,
         hostname: str | None = None,
@@ -29,8 +23,8 @@ class ComputerDevice(Device, PollableMixin):
         **kwargs
     ):
         # pylint: disable=too-many-arguments,too-many-positional-arguments
-        Device.__init__(self, config, logger, mqtt_client, **kwargs)
-        PollableMixin.__init__(self, config, **kwargs)
+        Device.__init__(self, **kwargs)
+        PollableMixin.__init__(self, **kwargs)
 
         self.__mac_address = mac
         self.__network_address = ip if ip is not None else hostname

--- a/controllers/network/network_controller/device/container.py
+++ b/controllers/network/network_controller/device/container.py
@@ -10,10 +10,5 @@ def add_devices(container):
     setattr(
         device_container,
         'computer_device',
-        providers.Factory(
-            ComputerDevice,
-            config=container.common.config,
-            logger=container.common.logger,
-            mqtt_client=container.common.mqtt_client
-        )
+        providers.Factory(ComputerDevice)
     )

--- a/controllers/network/network_controller/sensor/container.py
+++ b/controllers/network/network_controller/sensor/container.py
@@ -13,9 +13,6 @@ def add_sensors(container):
         'network_presence_sensor',
         providers.Factory(
             PresenceSensor,
-            config=container.common.config,
-            logger=container.common.logger,
-            mqtt_client=container.common.mqtt_client,
             arp_provider_factory=services_container.arp_provider_factory
         )
     )

--- a/controllers/network/network_controller/sensor/presence.py
+++ b/controllers/network/network_controller/sensor/presence.py
@@ -1,13 +1,11 @@
 from dataclasses import dataclass
 from time import time
 
-from powerpi_common.logger import Logger
-from powerpi_common.mqtt import MQTTClient, MQTTTopic
+from powerpi_common.mqtt import MQTTTopic
 from powerpi_common.sensor import Sensor
 from powerpi_common.device.mixin import PollableMixin
 from powerpi_common.sensor import PresenceStatus
 
-from network_controller.config import NetworkConfig
 from network_controller.services.arp import ARPProviderFactory, ARPProvider, HostAddress
 from network_controller.util import ping
 
@@ -26,9 +24,6 @@ class PresenceSensor(Sensor, PollableMixin):
 
     def __init__(
         self,
-        config: NetworkConfig,
-        logger: Logger,
-        mqtt_client: MQTTClient,
         arp_provider_factory: ARPProviderFactory,
         mac: str | None = None,
         ip: str | None = None,
@@ -37,10 +32,9 @@ class PresenceSensor(Sensor, PollableMixin):
         **kwargs
     ):
         # pylint: disable=too-many-arguments,too-many-positional-arguments
-        Sensor.__init__(self, mqtt_client, **kwargs)
-        PollableMixin.__init__(self, config, **kwargs)
+        Sensor.__init__(self, **kwargs)
+        PollableMixin.__init__(self, **kwargs)
 
-        self._logger = logger
         self.__factory = arp_provider_factory
         self.__provider: ARPProvider | None = None
 

--- a/controllers/network/pyproject.toml
+++ b/controllers/network/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "network_controller"
-version = "0.3.0-rc.4"
+version = "0.3.0-rc.5"
 description = "PowerPi Network Controller"
 license = "GPL-3.0-only"
 authors = [

--- a/controllers/network/tests/conftest.py
+++ b/controllers/network/tests/conftest.py
@@ -1,17 +1,17 @@
 # pylint: disable=unused-import
 
-import sys
-from unittest.mock import MagicMock
-
-# pcap requires libpcap and a C compiler; mock it out since tests never use the real module
-sys.modules['pcap'] = MagicMock()
-
-import pytest
 from powerpi_common_test.fixture import (
     powerpi_config,
     powerpi_device_manager,
     powerpi_logger,
     powerpi_mqtt_client,
     powerpi_mqtt_producer,
+    powerpi_variable_manager,
     powerpi_service_provider,
 )
+import pytest
+import sys
+from unittest.mock import MagicMock
+
+# pcap requires libpcap and a C compiler; mock it out since tests never use the real module
+sys.modules['pcap'] = MagicMock()

--- a/controllers/network/tests/device/test_computer.py
+++ b/controllers/network/tests/device/test_computer.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import PropertyMock, call, patch
 
 import pytest
@@ -101,6 +101,57 @@ class TestComputer(DeviceTestBase, PollableMixinTestBase):
         assert subject.state == DeviceStatus.UNKNOWN
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize('active', [True, False])
+    async def test_turn_on_geofence(
+        self,
+        subject_geofence: ComputerDevice,
+        geofence,
+        mocker: MockerFixture,
+        active: bool
+    ):
+        # pylint: disable=arguments-differ
+
+        type(geofence).state = PropertyMock(
+            return_value=DeviceStatus.ON if active else DeviceStatus.OFF
+        )
+
+        assert subject_geofence.state == DeviceStatus.UNKNOWN
+
+        host = mocker.MagicMock()
+        type(host).is_alive = PropertyMock(return_value=True)
+
+        mocker.patch(
+            'network_controller.device.computer.ping',
+            return_value=host
+        )
+
+        with patch('network_controller.device.computer.send_magic_packet'):
+            await subject_geofence.turn_on()
+
+        if active:
+            assert subject_geofence.state == DeviceStatus.UNKNOWN
+        else:
+            assert subject_geofence.state == DeviceStatus.ON
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('active', [True, False])
+    async def test_turn_off_geofence(
+        self,
+        subject_geofence: ComputerDevice,
+        geofence,
+        active: bool
+    ):
+        type(geofence).state = PropertyMock(
+            return_value=DeviceStatus.ON if active else DeviceStatus.OFF
+        )
+
+        assert subject_geofence.state == DeviceStatus.UNKNOWN
+
+        await subject_geofence.turn_off()
+
+        assert subject_geofence.state == DeviceStatus.UNKNOWN
+
+    @pytest.mark.asyncio
     async def test_change_message(
         self,
         subject: ComputerDevice,
@@ -120,7 +171,7 @@ class TestComputer(DeviceTestBase, PollableMixinTestBase):
 
         message = {
             'state': 'on',
-            'timestamp': int(datetime.utcnow().timestamp() * 1000)
+            'timestamp': int(datetime.now(timezone.utc).timestamp() * 1000)
         }
 
         with patch('network_controller.device.computer.send_magic_packet'):

--- a/controllers/network/tests/device/test_computer.py
+++ b/controllers/network/tests/device/test_computer.py
@@ -133,10 +133,17 @@ class TestComputer(DeviceTestBase, PollableMixinTestBase):
         self,
         powerpi_config,
         powerpi_logger,
-        powerpi_mqtt_client
+        powerpi_mqtt_client,
+        powerpi_variable_manager
     ):
         return ComputerDevice(
-            powerpi_config, powerpi_logger, powerpi_mqtt_client,
-            mac='00:00:00:00:00', hostname='mycomputer.home', delay=0.1,
-            name='computer', poll_frequency=120
+            config=powerpi_config,
+            logger=powerpi_logger,
+            mqtt_client=powerpi_mqtt_client,
+            variable_manager=powerpi_variable_manager,
+            mac='00:00:00:00:00',
+            hostname='mycomputer.home',
+            delay=0.1,
+            name='computer',
+            poll_frequency=120
         )

--- a/controllers/network/tests/sensor/test_presence.py
+++ b/controllers/network/tests/sensor/test_presence.py
@@ -251,7 +251,10 @@ class TestPresenceSensor(SensorTestBase, PollableMixinTestBase):
         arp_factory,
     ):
         return PresenceSensor(
-            powerpi_config, powerpi_logger, powerpi_mqtt_client, arp_factory,
+            config=powerpi_config,
+            logger=powerpi_logger,
+            mqtt_client=powerpi_mqtt_client,
+            arp_provider_factory=arp_factory,
             mac='00:11:22:33:44:55',
             ip='192.168.1.100',
             hostname='mydevice.local',
@@ -269,7 +272,10 @@ class TestPresenceSensor(SensorTestBase, PollableMixinTestBase):
         arp_factory,
     ):
         return PresenceSensor(
-            powerpi_config, powerpi_logger, powerpi_mqtt_client, arp_factory,
+            config=powerpi_config,
+            logger=powerpi_logger,
+            mqtt_client=powerpi_mqtt_client,
+            arp_provider_factory=arp_factory,
             mac='00:11:22:33:44:55',
             hostname='mydevice.local',
             absent_delay=10,

--- a/controllers/snapcast/pyproject.toml
+++ b/controllers/snapcast/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "snapcast_controller"
-version = "0.0.10-rc.8"
+version = "0.0.10-rc.9"
 description = "PowerPi Snapcast Controller"
 license = "GPL-3.0-only"
 authors = [

--- a/controllers/snapcast/snapcast_controller/device/container.py
+++ b/controllers/snapcast/snapcast_controller/device/container.py
@@ -23,9 +23,6 @@ def add_devices(container):
         'snapcast_server_device',
         providers.Factory(
             SnapcastServerDevice,
-            config=container.common.config,
-            logger=container.common.logger,
-            mqtt_client=container.common.mqtt_client,
             device_manager=container.common.device.device_manager,
             snapcast_api=container.common.device.snapcast_api
         )
@@ -36,9 +33,6 @@ def add_devices(container):
         'snapcast_client_device',
         providers.Factory(
             SnapcastClientDevice,
-            config=container.common.config,
-            logger=container.common.logger,
-            mqtt_client=container.common.mqtt_client,
             device_manager=container.common.device.device_manager
         )
     )

--- a/controllers/snapcast/snapcast_controller/device/snapcast_client.py
+++ b/controllers/snapcast/snapcast_controller/device/snapcast_client.py
@@ -1,17 +1,19 @@
 from typing import TypedDict
 
 from lazy import lazy
-from powerpi_common.config import Config
-from powerpi_common.device import (AdditionalStateDevice, DeviceManager,
-                                   DeviceStatus)
+from powerpi_common.device import (
+    AdditionalStateDevice,
+    DeviceManager,
+    DeviceStatus
+)
 from powerpi_common.device.mixin import InitialisableMixin
-from powerpi_common.logger import Logger
-from powerpi_common.mqtt import MQTTClient
 
 from snapcast_controller.device.mixin import StreamCapabilityMixin
 from snapcast_controller.device.snapcast_server import SnapcastServerDevice
-from snapcast_controller.snapcast.listener import (SnapcastClientListener,
-                                                   SnapcastGroupListener)
+from snapcast_controller.snapcast.listener import (
+    SnapcastClientListener,
+    SnapcastGroupListener
+)
 from snapcast_controller.snapcast.typing import Client
 
 
@@ -35,9 +37,6 @@ class SnapcastClientDevice(
 
     def __init__(
         self,
-        config: Config,
-        logger: Logger,
-        mqtt_client: MQTTClient,
         device_manager: DeviceManager,
         server: str,
         mac: str | None = None,
@@ -45,9 +44,7 @@ class SnapcastClientDevice(
         **kwargs
     ):
         # pylint: disable=too-many-arguments
-        AdditionalStateDevice.__init__(
-            self, config, logger, mqtt_client, **kwargs
-        )
+        AdditionalStateDevice.__init__(self, **kwargs)
         StreamCapabilityMixin.__init__(self)
 
         self.__device_manager = device_manager

--- a/controllers/snapcast/snapcast_controller/device/snapcast_server.py
+++ b/controllers/snapcast/snapcast_controller/device/snapcast_server.py
@@ -1,10 +1,7 @@
 from typing import List, Set
 
-from powerpi_common.config import Config
 from powerpi_common.device import Device, DeviceManager, DeviceStatus
 from powerpi_common.device.mixin import InitialisableMixin, NewPollableMixin
-from powerpi_common.logger import Logger
-from powerpi_common.mqtt import MQTTClient
 
 from snapcast_controller.device.mixin import StreamCapabilityMixin
 from snapcast_controller.snapcast.listener import SnapcastServerListener
@@ -22,9 +19,6 @@ class SnapcastServerDevice(Device, InitialisableMixin, NewPollableMixin, Snapcas
 
     def __init__(
         self,
-        config: Config,
-        logger: Logger,
-        mqtt_client: MQTTClient,
         device_manager: DeviceManager,
         snapcast_api: SnapcastAPI,
         ip: str | None = None,
@@ -33,8 +27,8 @@ class SnapcastServerDevice(Device, InitialisableMixin, NewPollableMixin, Snapcas
         **kwargs
     ):
         # pylint: disable=too-many-arguments
-        Device.__init__(self, config, logger, mqtt_client, **kwargs)
-        NewPollableMixin.__init__(self, config, **kwargs)
+        Device.__init__(self, **kwargs)
+        NewPollableMixin.__init__(self, **kwargs)
 
         self.__device_manager = device_manager
         self.__api = snapcast_api

--- a/controllers/snapcast/tests/conftest.py
+++ b/controllers/snapcast/tests/conftest.py
@@ -1,9 +1,13 @@
 # pylint: disable=unused-import
 
 import pytest
-from powerpi_common_test.fixture import (powerpi_config,
-                                         powerpi_device_manager,
-                                         powerpi_logger, powerpi_mqtt_client,
-                                         powerpi_mqtt_producer)
+from powerpi_common_test.fixture import (
+    powerpi_config,
+    powerpi_device_manager,
+    powerpi_logger,
+    powerpi_mqtt_client,
+    powerpi_mqtt_producer,
+    powerpi_variable_manager
+)
 
 from .fixtures import snapcast_api

--- a/controllers/snapcast/tests/device/test_snapcast_client.py
+++ b/controllers/snapcast/tests/device/test_snapcast_client.py
@@ -318,12 +318,17 @@ class TestSnapcastClientDevice(DeviceTestBase, InitialisableMixinTestBase):
         powerpi_config,
         powerpi_logger,
         powerpi_mqtt_client,
+        powerpi_variable_manager,
         powerpi_device_manager,
         request
     ):
         # pylint: disable=too-many-arguments
         return SnapcastClientDevice(
-            powerpi_config, powerpi_logger, powerpi_mqtt_client, powerpi_device_manager,
+            config=powerpi_config,
+            logger=powerpi_logger,
+            mqtt_client=powerpi_mqtt_client,
+            variable_manager=powerpi_variable_manager,
+            device_manager=powerpi_device_manager,
             server='MyServer',
             mac='00:00:00:00:00' if not hasattr(request, 'param') else None,
             host_id=request.param if hasattr(request, 'param') else None,

--- a/controllers/snapcast/tests/device/test_snapcast_client.py
+++ b/controllers/snapcast/tests/device/test_snapcast_client.py
@@ -25,6 +25,17 @@ class TestSnapcastClientDevice(DeviceTestBase, InitialisableMixinTestBase):
 
         assert subject.state == DeviceStatus.UNKNOWN
 
+    @pytest.mark.asyncio
+    async def test_turn_on_geofence(self, subject_geofence: SnapcastClientDevice):
+        # pylint: disable=arguments-differ
+
+        # override as this device doesn't support on
+        assert subject_geofence.state == DeviceStatus.UNKNOWN
+
+        await subject_geofence.turn_on()
+
+        assert subject_geofence.state == DeviceStatus.UNKNOWN
+
     def test_server_name(self, subject: SnapcastClientDevice):
         assert subject.server_name == 'MyServer'
 

--- a/controllers/snapcast/tests/device/test_snapcast_server.py
+++ b/controllers/snapcast/tests/device/test_snapcast_server.py
@@ -5,14 +5,17 @@ from unittest.mock import MagicMock, PropertyMock
 import pytest
 from powerpi_common.device import DeviceStatus
 from powerpi_common_test.device import DeviceTestBase
-from powerpi_common_test.device.mixin import (InitialisableMixinTestBase,
-                                              PollableMixinTestBase)
+from powerpi_common_test.device.mixin import (
+    InitialisableMixinTestBase,
+    PollableMixinTestBase
+)
 from pytest_mock import MockerFixture
 
 from snapcast_controller.device.snapcast_server import SnapcastServerDevice
 
 
 class TestSnapcastServerDevice(DeviceTestBase, InitialisableMixinTestBase, PollableMixinTestBase):
+
     @pytest.mark.asyncio
     async def test_turn_off(self, subject: SnapcastServerDevice):
         # override as this device doesn't support off
@@ -21,6 +24,17 @@ class TestSnapcastServerDevice(DeviceTestBase, InitialisableMixinTestBase, Polla
         await subject.turn_off()
 
         assert subject.state == DeviceStatus.UNKNOWN
+
+    @pytest.mark.asyncio
+    async def test_turn_off_geofence(self, subject_geofence: SnapcastServerDevice):
+        # pylint: disable=arguments-differ
+
+        # override as this device doesn't support off
+        assert subject_geofence.state == DeviceStatus.UNKNOWN
+
+        await subject_geofence.turn_off()
+
+        assert subject_geofence.state == DeviceStatus.UNKNOWN
 
     def test_network_address_ip(self, subject: SnapcastServerDevice):
         assert subject.network_address == '127.0.0.1'

--- a/controllers/snapcast/tests/device/test_snapcast_server.py
+++ b/controllers/snapcast/tests/device/test_snapcast_server.py
@@ -115,17 +115,19 @@ class TestSnapcastServerDevice(DeviceTestBase, InitialisableMixinTestBase, Polla
         powerpi_config,
         powerpi_logger,
         powerpi_mqtt_client,
+        powerpi_variable_manager,
         powerpi_device_manager,
         snapcast_api,
         request: Tuple[str | None, int | None]
     ):
         # pylint: disable=too-many-arguments
         return SnapcastServerDevice(
-            powerpi_config,
-            powerpi_logger,
-            powerpi_mqtt_client,
-            powerpi_device_manager,
-            snapcast_api,
+            config=powerpi_config,
+            logger=powerpi_logger,
+            mqtt_client=powerpi_mqtt_client,
+            variable_manager=powerpi_variable_manager,
+            device_manager=powerpi_device_manager,
+            snapcast_api=snapcast_api,
             ip='127.0.0.1'
             if not hasattr(request, 'param') or request.param[0] is None
             else None,

--- a/controllers/virtual/pyproject.toml
+++ b/controllers/virtual/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "virtual_controller"
-version = "2.2.2-rc.7"
+version = "2.2.2-rc.8"
 description = "PowerPi Virtual Controller"
 license = "GPL-3.0-only"
 authors = [

--- a/controllers/virtual/tests/device/test_condition.py
+++ b/controllers/virtual/tests/device/test_condition.py
@@ -188,7 +188,11 @@ class TestCondition(
     ):
         # pylint: disable=too-many-arguments
         return ConditionDevice(
-            powerpi_config, powerpi_logger, powerpi_mqtt_client, device_manager, variable_manager,
+            config=powerpi_config,
+            logger=powerpi_logger,
+            mqtt_client=powerpi_mqtt_client,
+            variable_manager=variable_manager,
+            device_manager=device_manager,
             name='condition',
             device='test_device',
             on_condition={
@@ -213,7 +217,11 @@ class TestCondition(
     ):
         # pylint: disable=too-many-arguments
         return ConditionDevice(
-            powerpi_config, powerpi_logger, powerpi_mqtt_client, device_manager, variable_manager,
+            config=powerpi_config,
+            logger=powerpi_logger,
+            mqtt_client=powerpi_mqtt_client,
+            variable_manager=variable_manager,
+            device_manager=device_manager,
             name='condition',
             device='test_device',
             poll_frequency=60

--- a/controllers/virtual/tests/device/test_delay.py
+++ b/controllers/virtual/tests/device/test_delay.py
@@ -10,10 +10,14 @@ class TestDelayDevice(DeviceTestBase):
         self,
         powerpi_config,
         powerpi_logger,
-        powerpi_mqtt_client
+        powerpi_mqtt_client,
+        powerpi_variable_manager
     ):
         return DelayDevice(
-            powerpi_config, powerpi_logger, powerpi_mqtt_client,
+            config=powerpi_config,
+            logger=powerpi_logger,
+            mqtt_client=powerpi_mqtt_client,
+            variable_manager=powerpi_variable_manager,
             start=0.1,
             end=0.1,
             name='delay'

--- a/controllers/virtual/tests/device/test_group.py
+++ b/controllers/virtual/tests/device/test_group.py
@@ -213,10 +213,15 @@ class TestGroupDevice(
         powerpi_config,
         powerpi_logger,
         powerpi_mqtt_client,
+        powerpi_variable_manager,
         device_manager
     ):
         return GroupDevice(
-            powerpi_config, powerpi_logger, powerpi_mqtt_client, device_manager,
+            config=powerpi_config,
+            logger=powerpi_logger,
+            mqtt_client=powerpi_mqtt_client,
+            variable_manager=powerpi_variable_manager,
+            device_manager=device_manager,
             devices=['device0', 'device1', 'device2', 'device3'],
             name='group',
             poll_frequency=60

--- a/controllers/virtual/tests/device/test_log.py
+++ b/controllers/virtual/tests/device/test_log.py
@@ -10,10 +10,14 @@ class TestLogDevice(DeviceTestBase):
         self,
         powerpi_config,
         powerpi_logger,
-        powerpi_mqtt_client
+        powerpi_mqtt_client,
+        powerpi_variable_manager
     ):
         return LogDevice(
-            powerpi_config, powerpi_logger, powerpi_mqtt_client,
+            config=powerpi_config,
+            logger=powerpi_logger,
+            mqtt_client=powerpi_mqtt_client,
+            variable_manager=powerpi_variable_manager,
             name='log',
             message='test message'
         )

--- a/controllers/virtual/tests/device/test_mutex.py
+++ b/controllers/virtual/tests/device/test_mutex.py
@@ -84,10 +84,15 @@ class TestMutexDevice(
         powerpi_config,
         powerpi_logger,
         powerpi_mqtt_client,
+        powerpi_variable_manager,
         device_manager
     ):
         return MutexDevice(
-            powerpi_config, powerpi_logger, powerpi_mqtt_client, device_manager,
+            config=powerpi_config,
+            logger=powerpi_logger,
+            mqtt_client=powerpi_mqtt_client,
+            variable_manager=powerpi_variable_manager,
+            device_manager=device_manager,
             off_devices=[0, 1],
             on_devices=[2, 3],
             name='mutex',

--- a/controllers/virtual/tests/device/test_scene.py
+++ b/controllers/virtual/tests/device/test_scene.py
@@ -110,13 +110,15 @@ class TestSceneDevice(
         powerpi_config,
         powerpi_logger,
         powerpi_mqtt_client,
+        powerpi_variable_manager,
         device_manager
     ):
         return SceneDevice(
-            powerpi_config,
-            powerpi_logger,
-            powerpi_mqtt_client,
-            device_manager,
+            config=powerpi_config,
+            logger=powerpi_logger,
+            mqtt_client=powerpi_mqtt_client,
+            variable_manager=powerpi_variable_manager,
+            device_manager=device_manager,
             name='Scene',
             poll_frequency=60,
             devices=['device0', 'device1'],

--- a/controllers/virtual/tests/device/test_variable.py
+++ b/controllers/virtual/tests/device/test_variable.py
@@ -10,9 +10,13 @@ class TestVariableDevice(DeviceTestBase):
         self,
         powerpi_config,
         powerpi_logger,
-        powerpi_mqtt_client
+        powerpi_mqtt_client,
+        powerpi_variable_manager
     ):
         return VariableDevice(
-            powerpi_config, powerpi_logger, powerpi_mqtt_client,
+            config=powerpi_config,
+            logger=powerpi_logger,
+            mqtt_client=powerpi_mqtt_client,
+            variable_manager=powerpi_variable_manager,
             name='variable'
         )

--- a/controllers/virtual/tests/sensor/test_geofence.py
+++ b/controllers/virtual/tests/sensor/test_geofence.py
@@ -211,10 +211,10 @@ class TestGeofence(SensorTestBase):
         powerpi_variable_manager
     ):
         return GeofenceSensor(
-            powerpi_config,
-            powerpi_logger,
-            mqtt_client,
-            powerpi_variable_manager,
+            config=powerpi_config,
+            logger=powerpi_logger,
+            mqtt_client=mqtt_client,
+            variable_manager=powerpi_variable_manager,
             name='MyGeofence',
             condition={
                 'when': [

--- a/controllers/virtual/virtual_controller/device/condition.py
+++ b/controllers/virtual/virtual_controller/device/condition.py
@@ -3,13 +3,13 @@ from asyncio.exceptions import CancelledError as AsyncCancelledError
 from asyncio.exceptions import TimeoutError as AsyncTimeoutError
 from contextlib import suppress
 
-from powerpi_common.condition import (ConditionParser, Expression,
-                                      ParseException)
-from powerpi_common.config import Config
+from powerpi_common.condition import (
+    ConditionParser,
+    Expression,
+    ParseException
+)
 from powerpi_common.device import Device, DeviceManager, DeviceStatus
 from powerpi_common.device.mixin import DeviceOrchestratorMixin, PollableMixin
-from powerpi_common.logger import Logger
-from powerpi_common.mqtt import MQTTClient
 from powerpi_common.variable import VariableManager
 
 
@@ -18,11 +18,8 @@ class ConditionDevice(Device, DeviceOrchestratorMixin, PollableMixin):
     # pylint: disable=too-many-arguments
     def __init__(
         self,
-        config: Config,
-        logger: Logger,
-        mqtt_client: MQTTClient,
-        device_manager: DeviceManager,
         variable_manager: VariableManager,
+        device_manager: DeviceManager,
         device: str,
         on_condition: Expression | None = None,
         off_condition: Expression | None = None,
@@ -31,12 +28,12 @@ class ConditionDevice(Device, DeviceOrchestratorMixin, PollableMixin):
         **kwargs
     ):
         Device.__init__(
-            self, config, logger, mqtt_client, **kwargs
+            self, variable_manager=variable_manager, **kwargs
         )
         DeviceOrchestratorMixin.__init__(
-            self, config, logger, mqtt_client, device_manager, [device]
+            self, device_manager=device_manager, devices=[device], **kwargs
         )
-        PollableMixin.__init__(self, config, **kwargs)
+        PollableMixin.__init__(self, **kwargs)
 
         self.__variable_manager = variable_manager
 

--- a/controllers/virtual/virtual_controller/device/container.py
+++ b/controllers/virtual/virtual_controller/device/container.py
@@ -36,23 +36,14 @@ def add_devices(container):
         'condition_device',
         providers.Factory(
             ConditionDevice,
-            config=container.common.config,
-            logger=container.common.logger,
-            mqtt_client=container.common.mqtt_client,
-            device_manager=container.common.device.device_manager,
-            variable_manager=container.common.variable.variable_manager
+            device_manager=container.common.device.device_manager
         )
     )
 
     setattr(
         device_container,
         'delay_device',
-        providers.Factory(
-            DelayDevice,
-            config=container.common.config,
-            logger=container.common.logger,
-            mqtt_client=container.common.mqtt_client
-        )
+        providers.Factory(DelayDevice)
     )
 
     setattr(
@@ -60,9 +51,6 @@ def add_devices(container):
         'group_device',
         providers.Factory(
             GroupDevice,
-            config=container.common.config,
-            logger=container.common.logger,
-            mqtt_client=container.common.mqtt_client,
             device_manager=container.common.device.device_manager
         )
     )
@@ -70,12 +58,7 @@ def add_devices(container):
     setattr(
         device_container,
         'log_device',
-        providers.Factory(
-            LogDevice,
-            config=container.common.config,
-            logger=container.common.logger,
-            mqtt_client=container.common.mqtt_client
-        )
+        providers.Factory(LogDevice)
     )
 
     setattr(
@@ -83,9 +66,6 @@ def add_devices(container):
         'mutex_device',
         providers.Factory(
             MutexDevice,
-            config=container.common.config,
-            logger=container.common.logger,
-            mqtt_client=container.common.mqtt_client,
             device_manager=container.common.device.device_manager
         )
     )
@@ -106,9 +86,6 @@ def add_devices(container):
         'scene_device',
         providers.Factory(
             SceneDevice,
-            config=container.common.config,
-            logger=container.common.logger,
-            mqtt_client=container.common.mqtt_client,
             device_manager=container.common.device.device_manager
         )
     )
@@ -116,10 +93,5 @@ def add_devices(container):
     setattr(
         device_container,
         'variable_device',
-        providers.Factory(
-            VariableDevice,
-            config=container.common.config,
-            logger=container.common.logger,
-            mqtt_client=container.common.mqtt_client
-        )
+        providers.Factory(VariableDevice)
     )

--- a/controllers/virtual/virtual_controller/device/delay.py
+++ b/controllers/virtual/virtual_controller/device/delay.py
@@ -1,25 +1,16 @@
 from asyncio import sleep
 
-from powerpi_common.config import Config
 from powerpi_common.device import Device
-from powerpi_common.logger import Logger
-from powerpi_common.mqtt import MQTTClient
 
 
 class DelayDevice(Device):
-    #pylint: disable=too-many-arguments
     def __init__(
         self,
-        config: Config,
-        logger: Logger,
-        mqtt_client: MQTTClient,
         start: float = 5,
         end: float = 5,
         **kwargs
     ):
-        Device.__init__(
-            self, config, logger, mqtt_client, **kwargs
-        )
+        Device.__init__(self, **kwargs)
 
         self.__start = start
         self.__end = end

--- a/controllers/virtual/virtual_controller/device/group.py
+++ b/controllers/virtual/virtual_controller/device/group.py
@@ -27,7 +27,10 @@ class GroupDevice(AdditionalStateDevice, DeviceOrchestratorMixin, NewPollableMix
             self, **kwargs
         )
         DeviceOrchestratorMixin.__init__(
-            self, device_manager, devices, **kwargs
+            self,
+            device_manager=device_manager,
+            devices=devices,
+            **kwargs
         )
         NewPollableMixin.__init__(self, **kwargs)
 

--- a/controllers/virtual/virtual_controller/device/group.py
+++ b/controllers/virtual/virtual_controller/device/group.py
@@ -1,13 +1,16 @@
 from typing import List
 
-from powerpi_common.config import Config
-from powerpi_common.device import (AdditionalStateDevice, DeviceManager,
-                                   DeviceStatus)
-from powerpi_common.device.mixin import (AdditionalState, AdditionalStateMixin,
-                                         DeviceOrchestratorMixin,
-                                         NewPollableMixin)
-from powerpi_common.logger import Logger
-from powerpi_common.mqtt import MQTTClient
+from powerpi_common.device import (
+    AdditionalStateDevice,
+    DeviceManager,
+    DeviceStatus
+)
+from powerpi_common.device.mixin import (
+    AdditionalState,
+    AdditionalStateMixin,
+    DeviceOrchestratorMixin,
+    NewPollableMixin
+)
 from powerpi_common.util import ismixin
 
 
@@ -16,20 +19,17 @@ class GroupDevice(AdditionalStateDevice, DeviceOrchestratorMixin, NewPollableMix
     # pylint: disable=too-many-arguments
     def __init__(
         self,
-        config: Config,
-        logger: Logger,
-        mqtt_client: MQTTClient,
         device_manager: DeviceManager,
         devices: List[str],
         **kwargs
     ):
         AdditionalStateDevice.__init__(
-            self, config, logger, mqtt_client, **kwargs
+            self, **kwargs
         )
         DeviceOrchestratorMixin.__init__(
-            self, config, logger, mqtt_client, device_manager, devices
+            self, device_manager, devices, **kwargs
         )
-        NewPollableMixin.__init__(self, config, **kwargs)
+        NewPollableMixin.__init__(self, **kwargs)
 
     async def on_referenced_device_status(self, _: str, __: DeviceStatus):
         await self.poll()

--- a/controllers/virtual/virtual_controller/device/log.py
+++ b/controllers/virtual/virtual_controller/device/log.py
@@ -1,19 +1,13 @@
-from powerpi_common.config import Config
 from powerpi_common.device import Device
-from powerpi_common.logger import Logger
-from powerpi_common.mqtt import MQTTClient
 
 
 class LogDevice(Device):
     def __init__(
         self,
-        config: Config,
-        logger: Logger,
-        mqtt_client: MQTTClient,
         message: str,
         **kwargs
     ):
-        Device.__init__(self, config, logger, mqtt_client, **kwargs)
+        Device.__init__(self, **kwargs)
 
         self.__message = message
 

--- a/controllers/virtual/virtual_controller/device/mutex.py
+++ b/controllers/virtual/virtual_controller/device/mutex.py
@@ -1,30 +1,24 @@
 from typing import List
 
-from powerpi_common.config import Config
 from powerpi_common.device import Device, DeviceManager, DeviceStatus
 from powerpi_common.device.mixin import DeviceOrchestratorMixin, PollableMixin
-from powerpi_common.logger import Logger
-from powerpi_common.mqtt import MQTTClient
 
 
 class MutexDevice(Device, DeviceOrchestratorMixin, PollableMixin):
     def __init__(
         self,
-        config: Config,
-        logger: Logger,
-        mqtt_client: MQTTClient,
         device_manager: DeviceManager,
         on_devices: List[str],
         off_devices: List[str],
         **kwargs
     ):
         Device.__init__(
-            self, config, logger, mqtt_client, **kwargs
+            self, **kwargs
         )
         DeviceOrchestratorMixin.__init__(
-            self, config, logger, mqtt_client, device_manager, on_devices + off_devices
+            self, device_manager, on_devices + off_devices, **kwargs
         )
-        PollableMixin.__init__(self, config, **kwargs)
+        PollableMixin.__init__(self, **kwargs)
 
         self.__device_manager = device_manager
         self.__on_device_names = on_devices

--- a/controllers/virtual/virtual_controller/device/mutex.py
+++ b/controllers/virtual/virtual_controller/device/mutex.py
@@ -16,7 +16,10 @@ class MutexDevice(Device, DeviceOrchestratorMixin, PollableMixin):
             self, **kwargs
         )
         DeviceOrchestratorMixin.__init__(
-            self, device_manager, on_devices + off_devices, **kwargs
+            self,
+            device_manager=device_manager,
+            devices=on_devices + off_devices,
+            **kwargs
         )
         PollableMixin.__init__(self, **kwargs)
 

--- a/controllers/virtual/virtual_controller/device/scene.py
+++ b/controllers/virtual/virtual_controller/device/scene.py
@@ -32,8 +32,8 @@ class SceneDevice(Device, DeviceOrchestratorMixin, NewPollableMixin):
         )
         DeviceOrchestratorMixin.__init__(
             self,
-            device_manager,
-            devices,
+            device_manager=device_manager,
+            devices=devices,
             capability=False,
             **kwargs
         )

--- a/controllers/virtual/virtual_controller/device/scene.py
+++ b/controllers/virtual/virtual_controller/device/scene.py
@@ -1,13 +1,13 @@
 from typing import Awaitable, Callable, List
 
-from powerpi_common.config import Config
 from powerpi_common.device import Device, DeviceManager, DeviceStatus
-from powerpi_common.device.mixin import (AdditionalState, AdditionalStateMixin,
-                                         DeviceOrchestratorMixin,
-                                         NewPollableMixin)
+from powerpi_common.device.mixin import (
+    AdditionalState,
+    AdditionalStateMixin,
+    DeviceOrchestratorMixin,
+    NewPollableMixin
+)
 from powerpi_common.device.scene_state import ReservedScenes
-from powerpi_common.logger import Logger
-from powerpi_common.mqtt import MQTTClient
 from powerpi_common.util import ismixin
 
 
@@ -19,9 +19,6 @@ class SceneDevice(Device, DeviceOrchestratorMixin, NewPollableMixin):
 
     def __init__(
         self,
-        config: Config,
-        logger: Logger,
-        mqtt_client: MQTTClient,
         device_manager: DeviceManager,
         devices: List[str],
         state: AdditionalState,
@@ -31,13 +28,16 @@ class SceneDevice(Device, DeviceOrchestratorMixin, NewPollableMixin):
         # pylint: disable=too-many-arguments
 
         Device.__init__(
-            self, config, logger, mqtt_client, **kwargs
+            self,  **kwargs
         )
         DeviceOrchestratorMixin.__init__(
-            self, config, logger, mqtt_client, device_manager, devices,
-            capability=False
+            self,
+            device_manager,
+            devices,
+            capability=False,
+            **kwargs
         )
-        NewPollableMixin.__init__(self, config, **kwargs)
+        NewPollableMixin.__init__(self, **kwargs)
 
         self.__state = state
         self.__scene = scene

--- a/controllers/virtual/virtual_controller/device/variable.py
+++ b/controllers/virtual/virtual_controller/device/variable.py
@@ -1,20 +1,9 @@
-from powerpi_common.config import Config
 from powerpi_common.device import Device
-from powerpi_common.logger import Logger
-from powerpi_common.mqtt import MQTTClient
 
 
 class VariableDevice(Device):
-    def __init__(
-        self,
-        config: Config,
-        logger: Logger,
-        mqtt_client: MQTTClient,
-        **kwargs
-    ):
-        Device.__init__(
-            self, config, logger, mqtt_client, **kwargs
-        )
+    def __init__(self, **kwargs):
+        Device.__init__(self,  **kwargs)
 
     async def _turn_on(self):
         # doesn't have to do anything special, just broadcast the status change

--- a/controllers/virtual/virtual_controller/sensor/geofence.py
+++ b/controllers/virtual/virtual_controller/sensor/geofence.py
@@ -2,7 +2,6 @@ from powerpi_common.condition import ConditionParser, ConditionVisitor, Expressi
 from powerpi_common.config import Config
 from powerpi_common.device import DeviceStatus
 from powerpi_common.device.mixin import InitialisableMixin
-from powerpi_common.logger import Logger
 from powerpi_common.mqtt import (
     MQTTClient,
     MQTTConsumer,
@@ -32,16 +31,14 @@ class GeofenceSensor(Sensor, InitialisableMixin):
     def __init__(
         self,
         config: Config,
-        logger: Logger,
         mqtt_client: MQTTClient,
         variable_manager: VariableManager,
         condition: Expression,
         **kwargs
     ):
-        Sensor.__init__(self, mqtt_client, **kwargs)
+        Sensor.__init__(self, mqtt_client=mqtt_client, **kwargs)
 
         self._config = config
-        self._logger = logger
 
         self.__mqtt_client = mqtt_client
         self.__variable_manager = variable_manager

--- a/controllers/zigbee/pyproject.toml
+++ b/controllers/zigbee/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zigbee_controller"
-version = "0.8.0-rc.11"
+version = "0.8.0-rc.12"
 description = "PowerPi ZigBee Controller"
 license = "GPL-3.0-only"
 authors = [

--- a/controllers/zigbee/tests/conftest.py
+++ b/controllers/zigbee/tests/conftest.py
@@ -1,9 +1,20 @@
 # pylint: disable=unused-import
 
 import pytest
-from powerpi_common_test.fixture import (powerpi_config, powerpi_logger, powerpi_device_manager,
-                                         powerpi_mqtt_client,
-                                         powerpi_mqtt_producer)
+from powerpi_common_test.fixture import (
+    powerpi_config,
+    powerpi_logger,
+    powerpi_device_manager,
+    powerpi_mqtt_client,
+    powerpi_mqtt_producer,
+    powerpi_variable_manager
+)
 
-from .fixtures import (zigbee_config, zigbee_controller, zigbee_device, zigbee_endpoint,
-                       zigbee_in_cluster, zigbee_out_cluster)
+from .fixtures import (
+    zigbee_config,
+    zigbee_controller,
+    zigbee_device,
+    zigbee_endpoint,
+    zigbee_in_cluster,
+    zigbee_out_cluster
+)

--- a/controllers/zigbee/tests/device/test_zigbee_light.py
+++ b/controllers/zigbee/tests/device/test_zigbee_light.py
@@ -349,12 +349,18 @@ class TestZigbeeLight(
         powerpi_config,
         powerpi_logger,
         powerpi_mqtt_client,
+        powerpi_variable_manager,
         zigbee_controller
     ):
         return ZigbeeLight(
-            powerpi_config, powerpi_logger, powerpi_mqtt_client, zigbee_controller,
-            1234,
-            ieee='00:00:00:00:00:00:00:00', nwk='0xAAAA',
+            config=powerpi_config,
+            logger=powerpi_logger,
+            mqtt_client=powerpi_mqtt_client,
+            variable_manager=powerpi_variable_manager,
+            zigbee_controller=zigbee_controller,
+            duration=1234,
+            ieee='00:00:00:00:00:00:00:00',
+            nwk='0xAAAA',
             name='Light'
         )
 

--- a/controllers/zigbee/tests/device/test_zigbee_pairing.py
+++ b/controllers/zigbee/tests/device/test_zigbee_pairing.py
@@ -44,6 +44,7 @@ class TestZigbeePairingDevice(DeviceTestBase):
         powerpi_config,
         powerpi_logger,
         powerpi_mqtt_client,
+        powerpi_variable_manager,
         zigbee_controller,
         mocker: MockerFixture
     ):
@@ -57,8 +58,13 @@ class TestZigbeePairingDevice(DeviceTestBase):
         )
 
         return ZigbeePairingDevice(
-            powerpi_config, powerpi_logger, powerpi_mqtt_client, zigbee_controller,
-            1, name='ZigBeePairing'
+            config=powerpi_config,
+            logger=powerpi_logger,
+            mqtt_client=powerpi_mqtt_client,
+            variable_manager=powerpi_variable_manager,
+            zigbee_controller=zigbee_controller,
+            timeout=1,
+            name='ZigBeePairing'
         )
 
     @pytest.fixture

--- a/controllers/zigbee/tests/device/test_zigbee_socket.py
+++ b/controllers/zigbee/tests/device/test_zigbee_socket.py
@@ -85,10 +85,22 @@ class TestZigbeeDevice(
         powerpi_mqtt_producer.assert_not_called()
 
     @pytest.fixture
-    def subject(self, powerpi_config, powerpi_logger, powerpi_mqtt_client, zigbee_controller):
+    def subject(
+        self,
+        powerpi_config,
+        powerpi_logger,
+        powerpi_mqtt_client,
+        powerpi_variable_manager,
+        zigbee_controller
+    ):
         return ZigbeeSocket(
-            powerpi_config, powerpi_logger, powerpi_mqtt_client, zigbee_controller,
-            ieee='00:00:00:00:00:00:00:00', nwk='0xAAAA',
+            config=powerpi_config,
+            logger=powerpi_logger,
+            mqtt_client=powerpi_mqtt_client,
+            variable_manager=powerpi_variable_manager,
+            zigbee_controller=zigbee_controller,
+            ieee='00:00:00:00:00:00:00:00',
+            nwk='0xAAAA',
             name='Socket'
         )
 

--- a/controllers/zigbee/tests/sensor/aqara/test_door_window_sensor.py
+++ b/controllers/zigbee/tests/sensor/aqara/test_door_window_sensor.py
@@ -97,8 +97,11 @@ class TestAqaraDoorWindowSensor(SensorTestBase, InitialisableMixinTestBase, Batt
     @pytest.fixture
     def subject(self, powerpi_logger, zigbee_controller, powerpi_mqtt_client):
         return AqaraDoorWindowSensor(
-            powerpi_logger, zigbee_controller, powerpi_mqtt_client,
-            ieee='00:00:00:00:00:00:00:00', nwk='0xAAAA',
+            logger=powerpi_logger,
+            zigbee_controller=zigbee_controller,
+            mqtt_client=powerpi_mqtt_client,
+            ieee='00:00:00:00:00:00:00:00',
+            nwk='0xAAAA',
             name='test',
             metrics={'door': 'visible'},
         )
@@ -106,8 +109,11 @@ class TestAqaraDoorWindowSensor(SensorTestBase, InitialisableMixinTestBase, Batt
     @pytest.fixture
     def subject_window(self, powerpi_logger, zigbee_controller, powerpi_mqtt_client):
         return AqaraDoorWindowSensor(
-            powerpi_logger, zigbee_controller, powerpi_mqtt_client,
-            ieee='00:00:00:00:00:00:00:00', nwk='0xAAAA',
+            logger=powerpi_logger,
+            zigbee_controller=zigbee_controller,
+            mqtt_client=powerpi_mqtt_client,
+            ieee='00:00:00:00:00:00:00:00',
+            nwk='0xAAAA',
             name='test',
             metrics={'window': 'visible'},
         )

--- a/controllers/zigbee/tests/sensor/ikea/test_stybar.py
+++ b/controllers/zigbee/tests/sensor/ikea/test_stybar.py
@@ -99,6 +99,10 @@ class TestIKEAStyrbarSensor(SensorTestBase, InitialisableMixinTestBase):
     @pytest.fixture
     def subject(self, powerpi_logger, zigbee_controller, powerpi_mqtt_client):
         return IKEAStyrbarSensor(
-            powerpi_logger, zigbee_controller, powerpi_mqtt_client,
-            ieee=test_ieee, nwk='0xAAAA', name='test'
+            logger=powerpi_logger,
+            zigbee_controller=zigbee_controller,
+            mqtt_client=powerpi_mqtt_client,
+            ieee=test_ieee,
+            nwk='0xAAAA',
+            name='test'
         )

--- a/controllers/zigbee/tests/sensor/osram/test_switch_mini.py
+++ b/controllers/zigbee/tests/sensor/osram/test_switch_mini.py
@@ -10,9 +10,11 @@ from powerpi_common_test.sensor.mixin import BatteryMixinTestBase
 from pytest_mock import MockerFixture
 from zigpy.zcl import Cluster
 
-from zigbee_controller.sensor.osram.switch_mini import (Button,
-                                                        OsramSwitchMiniSensor,
-                                                        PressType)
+from zigbee_controller.sensor.osram.switch_mini import (
+    Button,
+    OsramSwitchMiniSensor,
+    PressType
+)
 
 
 class TestOsramSwitchMiniSensor(SensorTestBase, InitialisableMixinTestBase, BatteryMixinTestBase):
@@ -119,8 +121,12 @@ class TestOsramSwitchMiniSensor(SensorTestBase, InitialisableMixinTestBase, Batt
     @pytest.fixture
     def subject(self, powerpi_logger, zigbee_controller, powerpi_mqtt_client):
         return OsramSwitchMiniSensor(
-            powerpi_logger, zigbee_controller, powerpi_mqtt_client,
-            ieee='00:00:00:00:00:00:00:00', nwk='0xAAAA', name='test'
+            logger=powerpi_logger,
+            zigbee_controller=zigbee_controller,
+            mqtt_client=powerpi_mqtt_client,
+            ieee='00:00:00:00:00:00:00:00',
+            nwk='0xAAAA',
+            name='test'
         )
 
     @pytest.fixture(autouse=True)

--- a/controllers/zigbee/tests/sensor/sonoff/test_switch.py
+++ b/controllers/zigbee/tests/sensor/sonoff/test_switch.py
@@ -44,6 +44,10 @@ class TestSonoffSwitchSensor(SensorTestBase, InitialisableMixinTestBase):
     @pytest.fixture
     def subject(self, powerpi_logger, zigbee_controller, powerpi_mqtt_client):
         return SonoffSwitchSensor(
-            powerpi_logger, zigbee_controller, powerpi_mqtt_client,
-            ieee='00:00:00:00:00:00:00:00', nwk='0xAAAA', name='test'
+            logger=powerpi_logger,
+            zigbee_controller=zigbee_controller,
+            mqtt_client=powerpi_mqtt_client,
+            ieee='00:00:00:00:00:00:00:00',
+            nwk='0xAAAA',
+            name='test'
         )

--- a/controllers/zigbee/tests/sensor/test_zigbee_energy_monitor.py
+++ b/controllers/zigbee/tests/sensor/test_zigbee_energy_monitor.py
@@ -131,7 +131,9 @@ class TestZigbeeEnergyMonitor(SensorTestBase, InitialisableMixinTestBase):
     ])
     def test_on_report_disabled(
         self,
-        powerpi_logger, zigbee_controller, powerpi_mqtt_client,
+        powerpi_logger,
+        zigbee_controller,
+        powerpi_mqtt_client,
         powerpi_mqtt_producer: MagicMock,
         cluster: Cluster,
         mocker: MockerFixture,
@@ -141,11 +143,12 @@ class TestZigbeeEnergyMonitor(SensorTestBase, InitialisableMixinTestBase):
         voltage: str
     ):
         subject = ZigbeeEnergyMonitorSensor(
-            powerpi_logger,
-            powerpi_mqtt_client,
-            zigbee_controller,
+            logger=powerpi_logger,
+            mqtt_client=powerpi_mqtt_client,
+            zigbee_controller=zigbee_controller,
             metrics={'power': power, 'current': current, 'voltage': voltage},
-            ieee='00:00:00:00:00:00:00:00', nwk='0xAAAA',
+            ieee='00:00:00:00:00:00:00:00',
+            nwk='0xAAAA',
             name='test'
         )
 
@@ -180,11 +183,12 @@ class TestZigbeeEnergyMonitor(SensorTestBase, InitialisableMixinTestBase):
     @pytest.fixture
     def subject(self, powerpi_logger, zigbee_controller, powerpi_mqtt_client):
         return ZigbeeEnergyMonitorSensor(
-            powerpi_logger,
-            powerpi_mqtt_client,
-            zigbee_controller,
+            logger=powerpi_logger,
+            mqtt_client=powerpi_mqtt_client,
+            zigbee_controller=zigbee_controller,
             metrics={'power': 'visible', 'current': 'read', 'voltage': 'read'},
-            ieee='00:00:00:00:00:00:00:00', nwk='0xAAAA',
+            ieee='00:00:00:00:00:00:00:00',
+            nwk='0xAAAA',
             name='test'
         )
 

--- a/controllers/zigbee/zigbee_controller/container.py
+++ b/controllers/zigbee/zigbee_controller/container.py
@@ -57,5 +57,6 @@ class ApplicationContainer(containers.DeclarativeContainer):
         device_status_checker=common.device.device_status_checker,
         scheduler=common.scheduler,
         health=common.health,
-        zigbee_controller=zigbee_controller
+        zigbee_controller=zigbee_controller,
+        container=__self__
     )

--- a/controllers/zigbee/zigbee_controller/container.py
+++ b/controllers/zigbee/zigbee_controller/container.py
@@ -57,6 +57,6 @@ class ApplicationContainer(containers.DeclarativeContainer):
         device_status_checker=common.device.device_status_checker,
         scheduler=common.scheduler,
         health=common.health,
-        zigbee_controller=zigbee_controller,
-        container=__self__
+        container=common,
+        zigbee_controller=zigbee_controller
     )

--- a/controllers/zigbee/zigbee_controller/controller.py
+++ b/controllers/zigbee/zigbee_controller/controller.py
@@ -1,4 +1,5 @@
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from dependency_injector import containers
 from powerpi_common.controller import Controller as CommonController
 from powerpi_common.device import DeviceManager, DeviceStatusChecker
 from powerpi_common.health import HealthService
@@ -21,12 +22,13 @@ class Controller(CommonController):
         device_status_checker: DeviceStatusChecker,
         scheduler: AsyncIOScheduler,
         health: HealthService,
-        zigbee_controller: ZigbeeController
+        zigbee_controller: ZigbeeController,
+        container: containers.DeclarativeContainer
     ):
         CommonController.__init__(
             self, logger, device_manager,
             mqtt_client, device_status_checker,
-            scheduler, health,
+            scheduler, health, container,
             __app_name__, __version__
         )
 

--- a/controllers/zigbee/zigbee_controller/controller.py
+++ b/controllers/zigbee/zigbee_controller/controller.py
@@ -22,14 +22,20 @@ class Controller(CommonController):
         device_status_checker: DeviceStatusChecker,
         scheduler: AsyncIOScheduler,
         health: HealthService,
+        container: containers.DeclarativeContainer,
         zigbee_controller: ZigbeeController,
-        container: containers.DeclarativeContainer
     ):
         CommonController.__init__(
-            self, logger, device_manager,
-            mqtt_client, device_status_checker,
-            scheduler, health, container,
-            __app_name__, __version__
+            self,
+            logger,
+            device_manager,
+            mqtt_client,
+            device_status_checker,
+            scheduler,
+            health,
+            container,
+            __app_name__,
+            __version__
         )
 
         self.__config = config

--- a/controllers/zigbee/zigbee_controller/device/container.py
+++ b/controllers/zigbee/zigbee_controller/device/container.py
@@ -32,9 +32,6 @@ def add_devices(container):
         'zigbee_pairing_device',
         providers.Factory(
             ZigbeePairingDevice,
-            config=container.common.config,
-            logger=container.common.logger,
-            mqtt_client=container.common.mqtt_client,
             zigbee_controller=container.zigbee_controller
         )
     )
@@ -44,9 +41,6 @@ def add_devices(container):
         'zigbee_light_device',
         providers.Factory(
             ZigbeeLight,
-            config=container.common.config,
-            logger=container.common.logger,
-            mqtt_client=container.common.mqtt_client,
             controller=container.zigbee_controller
         )
     )
@@ -56,9 +50,6 @@ def add_devices(container):
         'zigbee_socket_device',
         providers.Factory(
             ZigbeeSocket,
-            config=container.common.config,
-            logger=container.common.logger,
-            mqtt_client=container.common.mqtt_client,
             controller=container.zigbee_controller
         )
     )

--- a/controllers/zigbee/zigbee_controller/device/container.py
+++ b/controllers/zigbee/zigbee_controller/device/container.py
@@ -41,7 +41,7 @@ def add_devices(container):
         'zigbee_light_device',
         providers.Factory(
             ZigbeeLight,
-            controller=container.zigbee_controller
+            zigbee_controller=container.zigbee_controller
         )
     )
 
@@ -50,6 +50,6 @@ def add_devices(container):
         'zigbee_socket_device',
         providers.Factory(
             ZigbeeSocket,
-            controller=container.zigbee_controller
+            zigbee_controller=container.zigbee_controller
         )
     )

--- a/controllers/zigbee/zigbee_controller/device/zigbee_light.py
+++ b/controllers/zigbee/zigbee_controller/device/zigbee_light.py
@@ -2,12 +2,12 @@ import math
 from asyncio import ensure_future
 from typing import List, Tuple
 
-from powerpi_common.config import Config
 from powerpi_common.device import AdditionalStateDevice, DeviceStatus
-from powerpi_common.device.mixin import (AdditionalState, CapabilityMixin,
-                                         NewPollableMixin)
-from powerpi_common.logger import Logger
-from powerpi_common.mqtt import MQTTClient
+from powerpi_common.device.mixin import (
+    AdditionalState,
+    CapabilityMixin,
+    NewPollableMixin
+)
 from powerpi_common.util.data import DataType, Range, Ranges, Standardiser
 from zigpy.device import Device as ZigPyDevice
 from zigpy.exceptions import DeliveryError
@@ -16,7 +16,7 @@ from zigpy.zcl import Cluster
 from zigpy.zcl.clusters.general import LevelControl as LevelControlCluster
 from zigpy.zcl.clusters.lighting import Color as ColorCluster
 
-from zigbee_controller.zigbee import DeviceAnnounceListener, ZigbeeController, ZigbeeMixin
+from zigbee_controller.zigbee import DeviceAnnounceListener, ZigbeeMixin
 from zigbee_controller.zigbee.mixins import ZigbeeOnOffMixin
 
 
@@ -66,21 +66,16 @@ class ZigbeeLight(
         ),
     })
 
-    # pylint: disable=too-many-arguments
     def __init__(
         self,
-        config: Config,
-        logger: Logger,
-        mqtt_client: MQTTClient,
-        controller: ZigbeeController,
         duration: int = 500,
         **kwargs
     ):
         AdditionalStateDevice.__init__(
-            self, config, logger, mqtt_client, **kwargs
+            self, **kwargs
         )
-        NewPollableMixin.__init__(self, config, **kwargs)
-        ZigbeeMixin.__init__(self, controller, **kwargs)
+        NewPollableMixin.__init__(self, **kwargs)
+        ZigbeeMixin.__init__(self, **kwargs)
 
         self.__duration = duration
 

--- a/controllers/zigbee/zigbee_controller/device/zigbee_pairing.py
+++ b/controllers/zigbee/zigbee_controller/device/zigbee_pairing.py
@@ -1,10 +1,7 @@
 import asyncio
 
-from powerpi_common.config import Config
 from powerpi_common.device import Device
 from powerpi_common.device.mixin import InitialisableMixin
-from powerpi_common.logger import Logger
-from powerpi_common.mqtt import MQTTClient
 from zigpy.device import Device as ZigPyDevice
 from zigpy.types import EUI64
 
@@ -17,17 +14,13 @@ class ZigbeePairingDevice(Device, InitialisableMixin):
     Device to allow new devices to be paired to the ZigBee controller managed by this service.
     '''
 
-    # pylint: disable=too-many-arguments
     def __init__(
         self,
-        config: Config,
-        logger: Logger,
-        mqtt_client: MQTTClient,
         zigbee_controller: ZigbeeController,
         timeout: int = 120,
         **kwargs
     ):
-        Device.__init__(self, config, logger, mqtt_client, **kwargs)
+        Device.__init__(self, **kwargs)
 
         self.__zigbee_controller = zigbee_controller
         self.__timeout = timeout

--- a/controllers/zigbee/zigbee_controller/device/zigbee_socket.py
+++ b/controllers/zigbee/zigbee_controller/device/zigbee_socket.py
@@ -1,11 +1,8 @@
-from powerpi_common.config import Config
 from powerpi_common.device import Device, DeviceStatus
 from powerpi_common.device.mixin import NewPollableMixin
-from powerpi_common.logger import Logger
-from powerpi_common.mqtt import MQTTClient
 from zigpy.zcl.clusters.general import OnOff as OnOffCluster
 
-from zigbee_controller.zigbee import ZigbeeController, ZigbeeMixin
+from zigbee_controller.zigbee import ZigbeeMixin
 from zigbee_controller.zigbee.mixins import ZigbeeOnOffMixin
 from zigbee_controller.zigbee.constants import OnOff
 
@@ -18,15 +15,11 @@ class ZigbeeSocket(Device, NewPollableMixin, ZigbeeMixin, ZigbeeOnOffMixin):
 
     def __init__(
         self,
-        config: Config,
-        logger: Logger,
-        mqtt_client: MQTTClient,
-        controller: ZigbeeController,
         **kwargs
     ):
-        Device.__init__(self, config, logger, mqtt_client, **kwargs)
-        NewPollableMixin.__init__(self, config, **kwargs)
-        ZigbeeMixin.__init__(self, controller, **kwargs)
+        Device.__init__(self, **kwargs)
+        NewPollableMixin.__init__(self, **kwargs)
+        ZigbeeMixin.__init__(self, **kwargs)
 
     async def _poll(self):
         new_state = await self._read_status()

--- a/controllers/zigbee/zigbee_controller/sensor/__init__.py
+++ b/controllers/zigbee/zigbee_controller/sensor/__init__.py
@@ -20,8 +20,6 @@ def add_sensors(container):
         'zigbee_energy_monitor_sensor',
         providers.Factory(
             ZigbeeEnergyMonitorSensor,
-            logger=container.common.logger,
-            mqtt_client=container.common.mqtt_client,
             zigbee_controller=container.zigbee_controller
         )
     )

--- a/controllers/zigbee/zigbee_controller/sensor/aqara/__init__.py
+++ b/controllers/zigbee/zigbee_controller/sensor/aqara/__init__.py
@@ -12,6 +12,6 @@ def add_aqara_sensors(container):
             f'aqara_{sensor_type}_sensor',
             providers.Factory(
                 AqaraDoorWindowSensor,
-                controller=container.zigbee_controller
+                zigbee_controller=container.zigbee_controller
             )
         )

--- a/controllers/zigbee/zigbee_controller/sensor/aqara/__init__.py
+++ b/controllers/zigbee/zigbee_controller/sensor/aqara/__init__.py
@@ -12,8 +12,6 @@ def add_aqara_sensors(container):
             f'aqara_{sensor_type}_sensor',
             providers.Factory(
                 AqaraDoorWindowSensor,
-                logger=container.common.logger,
-                controller=container.zigbee_controller,
-                mqtt_client=container.common.mqtt_client
+                controller=container.zigbee_controller
             )
         )

--- a/controllers/zigbee/zigbee_controller/sensor/aqara/door_window_sensor.py
+++ b/controllers/zigbee/zigbee_controller/sensor/aqara/door_window_sensor.py
@@ -1,7 +1,5 @@
 from typing import Any, Dict, List
 
-from powerpi_common.logger import Logger
-from powerpi_common.mqtt import MQTTClient
 from powerpi_common.sensor import Sensor
 from powerpi_common.sensor.mixin.battery import BatteryMixin
 from zigpy.zcl.clusters.general import Basic
@@ -9,9 +7,13 @@ from zigpy.zcl.clusters.general import OnOff as OnOffCluster
 from zigpy.zcl.foundation import Attribute, TypeValue
 
 from zigbee_controller.sensor.metrics import Metric, MetricValue
-from zigbee_controller.zigbee import (ClusterAttributeListener,
-                                      ClusterGeneralCommandListener, OnOff,
-                                      OpenClose, ZigbeeController, ZigbeeMixin)
+from zigbee_controller.zigbee import (
+    ClusterAttributeListener,
+    ClusterGeneralCommandListener,
+    OnOff,
+    OpenClose,
+    ZigbeeMixin
+)
 
 
 class AqaraDoorWindowSensor(Sensor, ZigbeeMixin, BatteryMixin):
@@ -41,19 +43,14 @@ class AqaraDoorWindowSensor(Sensor, ZigbeeMixin, BatteryMixin):
     # pylint: disable=too-many-arguments
     def __init__(
         self,
-        logger: Logger,
-        controller: ZigbeeController,
-        mqtt_client: MQTTClient,
-        metrics: Dict[Metric, MetricValue],
+        metrics: dict[Metric, MetricValue],
         **kwargs
     ):
-        Sensor.__init__(self, mqtt_client, **kwargs)
-        ZigbeeMixin.__init__(self, controller, **kwargs)
+        Sensor.__init__(self, **kwargs)
+        ZigbeeMixin.__init__(self, **kwargs)
         BatteryMixin.__init__(self)
 
         self.__metrics = metrics
-
-        self._logger = logger
 
     @property
     def sensor_type(self):

--- a/controllers/zigbee/zigbee_controller/sensor/ikea/__init__.py
+++ b/controllers/zigbee/zigbee_controller/sensor/ikea/__init__.py
@@ -11,6 +11,6 @@ def add_ikea_sensors(container):
         'ikea_styrbar_sensor',
         providers.Factory(
             IKEAStyrbarSensor,
-            controller=container.zigbee_controller
+            zigbee_controller=container.zigbee_controller
         )
     )

--- a/controllers/zigbee/zigbee_controller/sensor/ikea/__init__.py
+++ b/controllers/zigbee/zigbee_controller/sensor/ikea/__init__.py
@@ -11,8 +11,6 @@ def add_ikea_sensors(container):
         'ikea_styrbar_sensor',
         providers.Factory(
             IKEAStyrbarSensor,
-            logger=container.common.logger,
-            controller=container.zigbee_controller,
-            mqtt_client=container.common.mqtt_client
+            controller=container.zigbee_controller
         )
     )

--- a/controllers/zigbee/zigbee_controller/sensor/ikea/stybar.py
+++ b/controllers/zigbee/zigbee_controller/sensor/ikea/stybar.py
@@ -1,5 +1,3 @@
-from powerpi_common.logger import Logger
-from powerpi_common.mqtt import MQTTClient
 from powerpi_common.sensor import Sensor
 from zigpy.device import Device as ZigPyDevice
 from zigpy.profiles.zha import DeviceType, PROFILE_ID
@@ -18,8 +16,13 @@ from zigpy.zcl.clusters.lightlink import LightLink as LightLinkCluster
 from zigpy.zdo.types import NodeDescriptor, LogicalType, FrequencyBand, MACCapabilityFlags
 
 from zigbee_controller.zigbee.device import ZigbeeMixin
-from zigbee_controller.zigbee.mixins import ButtonMapKey, Button, PressType, ZigbeeSleepyMixin, ZigbeeRemoteMixin
-from zigbee_controller.zigbee import ZigbeeController
+from zigbee_controller.zigbee.mixins import (
+    ButtonMapKey,
+    Button,
+    PressType,
+    ZigbeeSleepyMixin,
+    ZigbeeRemoteMixin
+)
 
 
 class IKEAStyrbarSensor(Sensor, ZigbeeMixin, ZigbeeSleepyMixin, ZigbeeRemoteMixin):
@@ -65,19 +68,11 @@ class IKEAStyrbarSensor(Sensor, ZigbeeMixin, ZigbeeSleepyMixin, ZigbeeRemoteMixi
             (Button.UP, PressType.RELEASE)
     }
 
-    def __init__(
-        self,
-        logger: Logger,
-        controller: ZigbeeController,
-        mqtt_client: MQTTClient,
-        **kwargs
-    ):
-        Sensor.__init__(self, mqtt_client, **kwargs)
-        ZigbeeMixin.__init__(self, controller, **kwargs)
+    def __init__(self, **kwargs):
+        Sensor.__init__(self, **kwargs)
+        ZigbeeMixin.__init__(self, **kwargs)
         ZigbeeSleepyMixin.__init__(self)
         ZigbeeRemoteMixin.__init__(self)
-
-        self._logger = logger
 
     def _configure_device(self, device: ZigPyDevice):
         device.node_desc = NodeDescriptor(

--- a/controllers/zigbee/zigbee_controller/sensor/osram/__init__.py
+++ b/controllers/zigbee/zigbee_controller/sensor/osram/__init__.py
@@ -11,8 +11,6 @@ def add_osram_sensors(container):
         'osram_switch_mini_sensor',
         providers.Factory(
             OsramSwitchMiniSensor,
-            logger=container.common.logger,
-            controller=container.zigbee_controller,
-            mqtt_client=container.common.mqtt_client
+            controller=container.zigbee_controller
         )
     )

--- a/controllers/zigbee/zigbee_controller/sensor/osram/__init__.py
+++ b/controllers/zigbee/zigbee_controller/sensor/osram/__init__.py
@@ -11,6 +11,6 @@ def add_osram_sensors(container):
         'osram_switch_mini_sensor',
         providers.Factory(
             OsramSwitchMiniSensor,
-            controller=container.zigbee_controller
+            zigbee_controller=container.zigbee_controller
         )
     )

--- a/controllers/zigbee/zigbee_controller/sensor/osram/switch_mini.py
+++ b/controllers/zigbee/zigbee_controller/sensor/osram/switch_mini.py
@@ -2,8 +2,6 @@ from asyncio import ensure_future
 from enum import IntEnum, StrEnum, unique
 from typing import Any, List
 
-from powerpi_common.logger import Logger
-from powerpi_common.mqtt import MQTTClient
 from powerpi_common.sensor import Sensor
 from powerpi_common.sensor.mixin import BatteryMixin
 from zigpy.zcl.clusters.general import LevelControl as LevelControlCluster
@@ -12,8 +10,11 @@ from zigpy.zcl.clusters.general import \
     PowerConfiguration as PowerConfigurationCluster
 from zigpy.zcl.clusters.lighting import Color as ColorCluster
 
-from zigbee_controller.zigbee import (ClusterAttributeListener,
-                                      ClusterCommandListener, ZigbeeController, ZigbeeMixin)
+from zigbee_controller.zigbee import (
+    ClusterAttributeListener,
+    ClusterCommandListener,
+    ZigbeeMixin
+)
 
 
 @unique
@@ -73,19 +74,10 @@ class OsramSwitchMiniSensor(Sensor, ZigbeeMixin, BatteryMixin):
     # the maximum expected voltage in mV
     MAX_VOLTAGE = 3100
 
-    # pylint: disable=too-many-arguments
-    def __init__(
-        self,
-        logger: Logger,
-        controller: ZigbeeController,
-        mqtt_client: MQTTClient,
-        **kwargs
-    ):
-        Sensor.__init__(self, mqtt_client, **kwargs)
-        ZigbeeMixin.__init__(self, controller, **kwargs)
+    def __init__(self, **kwargs):
+        Sensor.__init__(self, **kwargs)
+        ZigbeeMixin.__init__(self, **kwargs)
         BatteryMixin.__init__(self)
-
-        self._logger = logger
 
     def button_press_handler(self, button: Button, press_type: PressType):
         self.log_info(f'Received {press_type} press of {button}')

--- a/controllers/zigbee/zigbee_controller/sensor/sonoff/__init__.py
+++ b/controllers/zigbee/zigbee_controller/sensor/sonoff/__init__.py
@@ -11,8 +11,6 @@ def add_sonoff_sensors(container):
         'sonoff_switch_sensor',
         providers.Factory(
             SonoffSwitchSensor,
-            logger=container.common.logger,
-            zigbee_controller=container.zigbee_controller,
-            mqtt_client=container.common.mqtt_client
+            zigbee_controller=container.zigbee_controller
         )
     )

--- a/controllers/zigbee/zigbee_controller/sensor/sonoff/switch.py
+++ b/controllers/zigbee/zigbee_controller/sensor/sonoff/switch.py
@@ -1,9 +1,7 @@
-from powerpi_common.logger import Logger
-from powerpi_common.mqtt import MQTTClient
 from powerpi_common.sensor import Sensor
 from zigpy.zcl.clusters.general import OnOff as OnOffCluster
 
-from zigbee_controller.zigbee import ZigbeeController, ZigbeeMixin
+from zigbee_controller.zigbee import ZigbeeMixin
 from zigbee_controller.zigbee.mixins import ButtonMapKey, Button, PressType, ZigbeeRemoteMixin
 
 
@@ -18,18 +16,10 @@ class SonoffSwitchSensor(Sensor, ZigbeeMixin, ZigbeeRemoteMixin):
         ButtonMapKey(1, OnOffCluster.cluster_id, 0x02): lambda _: (Button.BUTTON, PressType.SHORT),
     }
 
-    def __init__(
-        self,
-        logger: Logger,
-        zigbee_controller: ZigbeeController,
-        mqtt_client: MQTTClient,
-        **kwargs
-    ):
-        Sensor.__init__(self, mqtt_client, **kwargs)
-        ZigbeeMixin.__init__(self, zigbee_controller, **kwargs)
+    def __init__(self, **kwargs):
+        Sensor.__init__(self, **kwargs)
+        ZigbeeMixin.__init__(self, **kwargs)
         ZigbeeRemoteMixin.__init__(self)
-
-        self._logger = logger
 
     def __str__(self):
         return ZigbeeMixin.__str__(self)

--- a/controllers/zigbee/zigbee_controller/sensor/zigbee_energy_monitor.py
+++ b/controllers/zigbee/zigbee_controller/sensor/zigbee_energy_monitor.py
@@ -32,24 +32,19 @@ RMS_VOLTAGE = MeasurementAttributes(
 
 class ZigbeeEnergyMonitorSensor(Sensor, ZigbeeReportMixin, ZigbeeMixin):
     '''
-    Add support for ZigBee Energy Monitoring sensors, supporting take periodic
+    Add support for ZigBee Energy Monitoring sensors, supporting periodic
     power, current and voltage readings.
     '''
 
     def __init__(
         self,
-        logger: Logger,
-        mqtt_client: MQTTClient,
-        zigbee_controller: ZigbeeController,
         metrics: dict[Metric, MetricValue],
         poll_frequency: int | None = 120,
         **kwargs
     ):
         # pylint: disable=too-many-arguments
-        Sensor.__init__(self, mqtt_client, **kwargs)
-        ZigbeeMixin.__init__(self, zigbee_controller, **kwargs)
-
-        self._logger = logger
+        Sensor.__init__(self, **kwargs)
+        ZigbeeMixin.__init__(self, **kwargs)
 
         self.__poll_frequency = poll_frequency
         self.__metrics = metrics

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -56,5 +56,5 @@ dependencies:
   - name: virtual-controller
     version: 0.2.16
   - name: zigbee-controller
-    version: 0.2.12
+    version: 0.2.13
     condition: global.zigbee

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
     version: 0.1.17
     condition: global.energyMonitor
   - name: event
-    version: 0.0.10
+    version: 0.0.11
     condition: global.event
   - name: mosquitto
     version: 0.3.4

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -39,7 +39,7 @@ dependencies:
     version: 0.3.18
     condition: global.voiceAssistant
   - name: energenie-controller
-    version: 0.1.20
+    version: 0.1.21
     condition: global.energenie
   - name: harmony-controller
     version: 0.1.28

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -29,7 +29,7 @@ dependencies:
     repository: oci://ghcr.io/stakater/charts
     condition: global.reloader
   - name: scheduler
-    version: 0.2.21
+    version: 0.2.22
     condition: global.scheduler
   - name: smarter-device-manager
     version: 0.1.3

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -51,7 +51,7 @@ dependencies:
     version: 0.1.20
     condition: global.network
   - name: snapcast-controller
-    version: 0.0.17
+    version: 0.0.18
     condition: global.snapcast
   - name: virtual-controller
     version: 0.2.16

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -45,7 +45,7 @@ dependencies:
     version: 0.1.27
     condition: global.harmony
   - name: lifx-controller
-    version: 0.1.20
+    version: 0.1.21
     condition: global.lifx
   - name: network-controller
     version: 0.1.21

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -42,7 +42,7 @@ dependencies:
     version: 0.1.20
     condition: global.energenie
   - name: harmony-controller
-    version: 0.1.27
+    version: 0.1.28
     condition: global.harmony
   - name: lifx-controller
     version: 0.1.21

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -54,7 +54,7 @@ dependencies:
     version: 0.0.17
     condition: global.snapcast
   - name: virtual-controller
-    version: 0.2.15
+    version: 0.2.16
   - name: zigbee-controller
     version: 0.2.12
     condition: global.zigbee

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -48,7 +48,7 @@ dependencies:
     version: 0.1.20
     condition: global.lifx
   - name: network-controller
-    version: 0.1.20
+    version: 0.1.21
     condition: global.network
   - name: snapcast-controller
     version: 0.0.18

--- a/kubernetes/charts/energenie-controller/Chart.yaml
+++ b/kubernetes/charts/energenie-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: energenie-controller
 description: A Helm chart for the PowerPi Energenie device controller
 type: application
-version: 0.1.20
-appVersion: 0.3.7-rc.7
+version: 0.1.21
+appVersion: 0.3.7-rc.8

--- a/kubernetes/charts/event/Chart.yaml
+++ b/kubernetes/charts/event/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: event
 description: A Helm chart for the PowerPi event service
 type: application
-version: 0.0.10
-appVersion: 0.0.4-rc.7
+version: 0.0.11
+appVersion: 0.0.4-rc.8

--- a/kubernetes/charts/harmony-controller/Chart.yaml
+++ b/kubernetes/charts/harmony-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: harmony-controller
 description: A Helm chart for the PowerPi Logitech Harmony device controller
 type: application
-version: 0.1.27
-appVersion: 0.4.10-rc.9
+version: 0.1.28
+appVersion: 0.4.10-rc.10

--- a/kubernetes/charts/lifx-controller/Chart.yaml
+++ b/kubernetes/charts/lifx-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: lifx-controller
 description: A Helm chart for the PowerPi LIFX device controller
 type: application
-version: 0.1.20
-appVersion: 0.6.6-rc.7
+version: 0.1.21
+appVersion: 0.6.6-rc.8

--- a/kubernetes/charts/mosquitto/acl.conf
+++ b/kubernetes/charts/mosquitto/acl.conf
@@ -10,11 +10,13 @@ topic readwrite powerpi/config/#
 user controller
 topic readwrite powerpi/device/#
 topic readwrite powerpi/event/#
+topic read powerpi/geofence/#
 
 user network_controller
 topic readwrite powerpi/device/#
 topic readwrite powerpi/event/#
 topic readwrite powerpi/presence/#
+topic read powerpi/geofence/#
 
 user virtual_controller
 topic readwrite powerpi/device/#

--- a/kubernetes/charts/network-controller/Chart.yaml
+++ b/kubernetes/charts/network-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: network-controller
 description: A Helm chart for the PowerPi Network device controller
 type: application
-version: 0.1.20
-appVersion: 0.3.0-rc.4
+version: 0.1.21
+appVersion: 0.3.0-rc.5

--- a/kubernetes/charts/scheduler/Chart.yaml
+++ b/kubernetes/charts/scheduler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: scheduler
 description: A Helm chart for the PowerPi scheduler service
 type: application
-version: 0.2.21
-appVersion: 1.5.2-rc.7
+version: 0.2.22
+appVersion: 1.5.2-rc.8

--- a/kubernetes/charts/snapcast-controller/Chart.yaml
+++ b/kubernetes/charts/snapcast-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: snapcast-controller
 description: A Helm chart for the PowerPi snapcast device controller
 type: application
-version: 0.0.17
-appVersion: 0.0.10-rc.8
+version: 0.0.18
+appVersion: 0.0.10-rc.9

--- a/kubernetes/charts/virtual-controller/Chart.yaml
+++ b/kubernetes/charts/virtual-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: virtual-controller
 description: A Helm chart for the PowerPi virtual device controller
 type: application
-version: 0.2.15
-appVersion: 2.2.2-rc.7
+version: 0.2.16
+appVersion: 2.2.2-rc.8

--- a/kubernetes/charts/zigbee-controller/Chart.yaml
+++ b/kubernetes/charts/zigbee-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: zigbee-controller
 description: A Helm chart for the PowerPi ZigBee device controller
 type: application
-version: 0.2.12
-appVersion: 0.8.0-rc.11
+version: 0.2.13
+appVersion: 0.8.0-rc.12

--- a/services/event/pyproject.toml
+++ b/services/event/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "event"
-version = "0.0.4-rc.7"
+version = "0.0.4-rc.8"
 description = "PowerPi Event Service"
 license = "GPL-3.0-only"
 authors = [

--- a/services/scheduler/pyproject.toml
+++ b/services/scheduler/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scheduler"
-version = "1.5.2-rc.7"
+version = "1.5.2-rc.8"
 description = "PowerPi Scheduler Service"
 license = "GPL-3.0-only"
 authors = [


### PR DESCRIPTION
Resolves #766.
- Add geofence checking to all devices using the `geofence` property.
  - Refactor device and sensor DI to populate common dependencies in a function rather than at each declaration.
  - Refactor device, sensor and mixins to use `kwargs` for inherited properties to simplify each definition.
- Add support for `{"var": "geofence.MyGeofence.state"}` to conditional evaluation.
- Add permission for all controllers to read the geofence topic.
- Fix bug which caused consumers that were added after the subscriptions were made to not subscribe.
- Add `self._logger` in `Sensor` so the `LogMixin` works for them all.